### PR TITLE
Refactor transport/fanout runtime, stabilize STOMP tests

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     implementation(project(":core"))
+    implementation(project(":fanout"))
 
     jmh("org.openjdk.jmh:jmh-core:1.37")
     jmh("org.openjdk.jmh:jmh-generator-annprocess:1.37")

--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/DispatcherBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/DispatcherBenchmark.java
@@ -21,6 +21,7 @@ import org.traffichunter.titan.core.message.dispatcher.TrieDispatcher;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.Priority;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
@@ -60,9 +61,8 @@ public class DispatcherBenchmark {
                 .priority(Priority.DEFAULT)
                 .destination(exactKey)
                 .createdAt(Instant.now())
-                .isRecovery(false)
                 .producerId("benchmark-producer")
-                .body("payload".getBytes())
+                .body(Buffer.alloc("payload"))
                 .build();
     }
 

--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
@@ -1,0 +1,136 @@
+package org.traffichunter.titan.benchmark;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.FanoutGateway;
+import org.traffichunter.titan.fanout.FanoutMode;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class FanoutGatewayBenchmark {
+
+    @Param({"platform", "virtual"})
+    public String mode;
+
+    @Param({"64", "256"})
+    public int batchSize;
+
+    private FanoutGateway gateway;
+    private Destination destination;
+    private Message message;
+    private List<Message> batchMessages;
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        LongAdder exportCount = new LongAdder();
+        destination = Destination.create("/benchmark/fanout");
+        message = Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(destination)
+                .createdAt(Instant.now())
+                .producerId("benchmark-producer")
+                .body(Buffer.alloc("payload"))
+                .build();
+        batchMessages = createBatchMessages(destination, batchSize);
+
+        gateway = FanoutMode.resolveMode(mode).fanoutGateway(new CountingNoopExporter(exportCount));
+        gateway.fanout(destination);
+        gateway.publish(message).get(1, TimeUnit.SECONDS);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Exception {
+        gateway.close();
+    }
+
+    @Benchmark
+    @Threads(1)
+    public void publishSingleThreadOneMessage() throws Exception {
+        gateway.publish(message).get(1, TimeUnit.SECONDS);
+    }
+
+    @Benchmark
+    @Threads(16)
+    public void publishConcurrentOneMessage() throws Exception {
+        gateway.publish(message).get(1, TimeUnit.SECONDS);
+    }
+
+    @Benchmark
+    @Threads(16)
+    public void publishConcurrentBatch() throws Exception {
+        List<Future<Void>> futures = new ArrayList<>(batchMessages.size());
+        for (Message batchMessage : batchMessages) {
+            futures.add(gateway.publish(batchMessage));
+        }
+        for (Future<Void> future : futures) {
+            future.get(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static List<Message> createBatchMessages(Destination destination, int batchSize) {
+        List<Message> messages = new ArrayList<>(batchSize);
+        for (int i = 0; i < batchSize; i++) {
+            messages.add(Message.builder()
+                    .priority(Priority.DEFAULT)
+                    .destination(destination)
+                    .createdAt(Instant.now())
+                    .producerId("benchmark-producer-" + i)
+                    .body(Buffer.alloc("payload-" + i))
+                    .build());
+        }
+        return messages;
+    }
+
+    private static final class CountingNoopExporter implements FanoutExporter {
+        private final LongAdder count;
+
+        private CountingNoopExporter(LongAdder count) {
+            this.count = count;
+        }
+
+        @Override
+        public String name() {
+            return "noop";
+        }
+
+        @Override
+        public CompletableResult export(Destination destination, Buffer payload) {
+            count.increment();
+            return null;
+        }
+
+        @Override
+        public CompletableResult export(Destination destination, Message payload) {
+            count.increment();
+            return null;
+        }
+    }
+}

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
@@ -37,7 +37,7 @@ import org.traffichunter.titan.bootstrap.environment.ConfigurationInitializer;
 public final class TitanBootstrap {
 
     private static final String CALL_CORE_APPLICATION =
-            "org.traffichunter.titan.core.CoreApplication";
+            "org.traffichunter.titan.core.TitanApplication";
 
     private final Banner.Mode bannerMode = Configurations.banner(Property.BANNER_MODE);
     private final Banner banner = new Banner();

--- a/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
+++ b/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
@@ -26,18 +26,23 @@ package org.traffichunter.titan.core;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.bootstrap.TitanBootstrap.ApplicationStarter;
 import org.traffichunter.titan.bootstrap.Settings;
 import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.core.spi.FanoutLauncher;
 import org.traffichunter.titan.core.spi.NetworkServerEngineProvider;
 
 /**
  * Reflection entrypoint loaded by bootstrap.
  */
+@Slf4j
+@NullMarked
 @SuppressWarnings("unused")
-public class CoreApplication implements ApplicationStarter {
+public class TitanApplication implements ApplicationStarter {
 
     private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 
@@ -48,21 +53,39 @@ public class CoreApplication implements ApplicationStarter {
     }
 
     @Override
-    public void start(final @NonNull Settings settings) {
+    public void start(final Settings settings) {
         List<ManagedServer> managedServers = new ArrayList<>();
+        List<FanoutLauncher> fanoutLaunchers = FanoutLauncher.load();
 
         settings.servers().forEach(serverSettings -> {
-            ManagedServer server = NetworkServerEngineProvider.find(serverSettings).create(serverSettings);
+            ManagedServer server = NetworkServerEngineProvider
+                    .find(serverSettings)
+                    .create(serverSettings);
+
+            fanoutLaunchers.stream()
+                    .filter(plugin -> plugin.supports(
+                            serverSettings.protocol(),
+                            serverSettings.transport(),
+                            serverSettings.resolvedProtocolOptions(),
+                            server
+                    ))
+                    .forEach(plugin -> plugin.apply(
+                            serverSettings.protocol(),
+                            serverSettings.transport(),
+                            serverSettings.resolvedProtocolOptions(),
+                            server
+                    ));
             server.start();
             managedServers.add(server);
         });
 
         if(managedServers.isEmpty()) {
-            throw new IllegalStateException("No managed servers found");
+            throw new CoreApplicationException("No managed servers found");
         }
 
         managedServers.forEach(managedServer ->
-                SHUTDOWN_HOOK.addShutdownCallback(managedServer::stop));
+                SHUTDOWN_HOOK.addShutdownCallback(managedServer::stop)
+        );
     }
 
     public static class CoreApplicationException extends RuntimeException {

--- a/core/src/main/java/org/traffichunter/titan/core/message/Message.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/Message.java
@@ -30,6 +30,7 @@ import lombok.Builder;
 import lombok.Getter;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
  * @author yungwang-o
@@ -47,8 +48,6 @@ public final class Message implements Comparable<Message> {
 
     private Instant dispatchedAt;
 
-    private boolean isRecovery;
-
     private final String producerId;
 
     private final long size;
@@ -59,21 +58,15 @@ public final class Message implements Comparable<Message> {
     public Message(final Priority priority,
                    final Destination destination,
                    final Instant createdAt,
-                   final boolean isRecovery,
                    final String producerId,
-                   final byte[] body
+                   final Buffer body
     ) {
         this.priority = Objects.requireNonNull(priority, "priority");
         this.destination = Objects.requireNonNull(destination, "routingKey");
         this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
-        this.isRecovery = isRecovery;
         this.producerId = Objects.requireNonNull(producerId, "producerId");
-        this.body = Objects.requireNonNull(body, "body");
-        this.size = body.length;
-    }
-
-    public void setRecover() {
-        this.isRecovery = true;
+        this.body = Objects.requireNonNull(body, "body").getBytes();
+        this.size = this.body.length;
     }
 
     public void setDispatchAt(final Instant dispatchedAt) {
@@ -96,7 +89,7 @@ public final class Message implements Comparable<Message> {
         if (!(o instanceof Message message)) {
             return false;
         }
-        return isRecovery() == message.isRecovery() && getSize() == message.getSize() && Objects.equals(
+        return getSize() == message.getSize() && Objects.equals(
                 getUniqueId(), message.getUniqueId()) && getPriority() == message.getPriority() && Objects.equals(
                 getDestination(), message.getDestination()) && Objects.equals(getCreatedAt(),
                 message.getCreatedAt()) && Objects.equals(getDispatchedAt(), message.getDispatchedAt())
@@ -112,7 +105,6 @@ public final class Message implements Comparable<Message> {
                 getDestination(),
                 getCreatedAt(),
                 getDispatchedAt(),
-                isRecovery(),
                 getProducerId(), getSize(), Arrays.hashCode(getBody())
         );
     }
@@ -125,7 +117,6 @@ public final class Message implements Comparable<Message> {
                 ", routingKey:" + destination +
                 ", createdAt:" + createdAt +
                 ", dispatchedAt:" + dispatchedAt +
-                ", isRecovery:" + isRecovery +
                 ", producerId:'" + producerId + '\'' +
                 ", size:" + size +
                 ", body:" + Arrays.toString(body) +

--- a/core/src/main/java/org/traffichunter/titan/core/spi/FanoutLauncher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/FanoutLauncher.java
@@ -1,0 +1,40 @@
+package org.traffichunter.titan.core.spi;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Hook for optional module integrations (e.g. fanout) without introducing direct module dependencies.
+ */
+public interface FanoutLauncher {
+
+    static List<FanoutLauncher> load() {
+        return ServiceLoader.load(FanoutLauncher.class)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparingInt(FanoutLauncher::order))
+                .toList();
+    }
+
+    default int order() {
+        return 0;
+    }
+
+    default boolean supports(
+            final String protocol,
+            final String transport,
+            final Map<String, String> protocolOptions,
+            final ManagedServer managedServer
+    ) {
+        return true;
+    }
+
+    void apply(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer
+    );
+}

--- a/core/src/main/java/org/traffichunter/titan/core/spi/NetworkServerEngineProvider.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/NetworkServerEngineProvider.java
@@ -23,7 +23,10 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.spi;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
+import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -73,6 +76,12 @@ public interface NetworkServerEngineProvider {
     String transport();
 
     String protocol();
+
+    @CanIgnoreReturnValue
+    NetworkServerEngineProvider setInboundHandler(ChannelInBoundHandler channelInBoundHandler);
+
+    @CanIgnoreReturnValue
+    NetworkServerEngineProvider setOutboundHandler(ChannelOutBoundHandler channelOutBoundHandler);
 
     ManagedServer create(ServerSettings settings);
 

--- a/core/src/main/java/org/traffichunter/titan/core/spi/TcpServerEngineProvider.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/TcpServerEngineProvider.java
@@ -23,15 +23,34 @@
  */
 package org.traffichunter.titan.core.spi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
+import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.codec.LineFrameChannelDecoder;
 import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 
 public final class TcpServerEngineProvider implements NetworkServerEngineProvider {
+
+    private final List<ChannelInBoundHandler> inboundHandlers = new ArrayList<>();
+    private final List<ChannelOutBoundHandler> outboundHandlers = new ArrayList<>();
+
+    @Override
+    public NetworkServerEngineProvider setInboundHandler(ChannelInBoundHandler channelInBoundHandler) {
+        inboundHandlers.add(channelInBoundHandler);
+        return this;
+    }
+
+    @Override
+    public NetworkServerEngineProvider setOutboundHandler(ChannelOutBoundHandler channelOutBoundHandler) {
+        outboundHandlers.add(channelOutBoundHandler);
+        return this;
+    }
 
     @Override
     public String transport() {
@@ -47,13 +66,17 @@ public final class TcpServerEngineProvider implements NetworkServerEngineProvide
     public ManagedServer create(final ServerSettings settings) {
         EventLoopGroups groups = EventLoopGroups.group(settings.primaryThreads(), settings.secondaryThreads());
         InetServerOption inetOption = buildOption(settings.resolvedTransportOptions());
-        InetServer server = InetServer.builder()
-                .group(groups)
-                .options(inetOption)
-                .channelHandler(channel -> channel.chain()
-                        .add(new LineFrameChannelDecoder())
-                )
-                .build();
+        InetServer server = InetServer.open(groups)
+                .option(inetOption)
+                .onChannel(channel -> {
+                    channel.chain().add(new LineFrameChannelDecoder());
+                    inboundHandlers.forEach(inboundHandler ->
+                            channel.chain().add(inboundHandler)
+                    );
+                    outboundHandlers.forEach(outboundHandler ->
+                            channel.chain().add(outboundHandler)
+                    );
+                });
 
         return new ManagedServer() {
             @Override

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -27,18 +27,22 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.traffichunter.titan.core.channel.*;
-import org.traffichunter.titan.core.concurrent.ChannelPromise;
+import org.traffichunter.titan.core.channel.Channel;
+import org.traffichunter.titan.core.channel.ChannelHandShakeEventListener;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.channel.IOEventLoop;
+import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.option.InetClientOption;
-import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.Noop;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
@@ -47,17 +51,60 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 @Slf4j
 public class InetClient extends AbstractTransport<NetChannel> {
 
-    private InetClient(NetChannel channel, EventLoopGroups groups) {
-        super(channel, groups);
+    private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
+    private final InetClientOption option;
+
+    private volatile Handler<Channel> channelHandler = channel -> {};
+
+    private enum State {
+        INIT,
+        STARTED,
+        CONNECTING,
+        CONNECTED,
+        SHUTDOWN
     }
 
-    public static Builder builder() {
-        return new Builder();
+    private InetClient(NetChannel channel, EventLoopGroups groups, InetClientOption option) {
+        super(channel, groups);
+        this.option = option;
+    }
+
+    public static InetClient open(EventLoopGroups groups) {
+        return open(groups, InetClientOption.DEFAULT_INET_CLIENT_OPTION);
+    }
+
+    public static InetClient open(EventLoopGroups groups, InetClientOption option) {
+        ClientChannelConnector connector = new ClientChannelConnector();
+
+        try {
+            NetChannel channel = NetChannel.open(connector);
+            groups.register(channel);
+            return new InetClient(channel, groups, option);
+        } catch (IOException e) {
+            throw new ClientException("Failed to create client", e);
+        }
+    }
+
+    @CanIgnoreReturnValue
+    public InetClient onChannel(Handler<Channel> channelHandler) {
+        this.channelHandler = channelHandler;
+        return this;
     }
 
     @Override
     public void start() {
-        groups().start();
+        if (!state.compareAndSet(State.INIT, State.STARTED)) {
+            throw new IllegalStateException("Cannot start client from state=" + state.get());
+        }
+
+        try {
+            channelHandler.handle(channel());
+            applyClientOption(option);
+            groups().start();
+        } catch (RuntimeException e) {
+            state.compareAndSet(State.STARTED, State.INIT);
+            throw e;
+        }
     }
 
     public Promise<NetChannel> connect(String host, int port) {
@@ -69,9 +116,9 @@ public class InetClient extends AbstractTransport<NetChannel> {
     }
 
     public Promise<NetChannel> connect(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) {
-        if(channel().isClosed()) {
-            log.error("Already connected or closed, cannot connect");
-            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Already connected or closed, cannot connect"));
+        Promise<NetChannel> validate = validateConnection();
+        if (validate != null) {
+            return validate;
         }
 
         IOEventLoop loop = channel().eventLoop();
@@ -87,11 +134,13 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
         connectRequest.addListener(promise -> {
             if (!promise.isSuccess()) {
+                state.compareAndSet(State.CONNECTING, State.STARTED);
                 connectResult.fail(promise.error());
                 return;
             }
 
             if (channel().isConnected()) {
+                state.set(State.CONNECTED);
                 connectResult.success(channel());
                 return;
             }
@@ -102,11 +151,13 @@ public class InetClient extends AbstractTransport<NetChannel> {
                 }
 
                 if (channel().isClosed()) {
+                    state.compareAndSet(State.CONNECTING, State.STARTED);
                     connectResult.fail(new ClientException("Channel closed before connect completed"));
                     return;
                 }
 
                 if (channel().isConnected()) {
+                    state.set(State.CONNECTED);
                     connectResult.success(channel());
                 }
             }, 1, 10, TimeUnit.MILLISECONDS);
@@ -120,6 +171,9 @@ public class InetClient extends AbstractTransport<NetChannel> {
             connectResult.addListener(done -> {
                 activeCheck.cancel();
                 timeoutCheck.cancel();
+                if (!done.isSuccess()) {
+                    state.compareAndSet(State.CONNECTING, State.STARTED);
+                }
             });
         });
 
@@ -128,7 +182,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
     @Override
     public Promise<Void> send(Buffer buffer) {
-        if(channel().isClosed() || !channel().isConnected()) {
+        if (state.get() != State.CONNECTED || channel().isClosed() || !channel().isConnected()) {
             log.error("Not ready to connect");
             return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Not ready to connect"));
         }
@@ -151,80 +205,76 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
     @Override
     public void shutdown(long timeOut, TimeUnit timeUnit) {
-        if(channel().isClosed()) {
-            log.warn("Failed to close client, already closed or not connected");
+        do {
+            State current = state.get();
+            if (current == State.SHUTDOWN) {
+                log.warn("Client is already shutdown");
+                return;
+            }
+            if (current == State.INIT) {
+                log.warn("Client is not started");
+                return;
+            }
+            if (state.compareAndSet(current, State.SHUTDOWN)) {
+                break;
+            }
+        } while (true);
+
+        if (channel().isClosed()) {
+            log.info("Client channel is already closed");
+            groups().gracefullyShutdown(timeOut, timeUnit);
             return;
         }
 
         log.info("Closing client...");
-
         close(timeOut, timeUnit);
-
         log.info("Closed client");
     }
 
-    @SuppressWarnings("unchecked")
-    public static class Builder {
-
-        private @Nullable EventLoopGroups groups;
-        private @Nullable Handler<Channel> channelHandler;
-        private Consumer<NetChannel> optionApplier = channel -> { };
-
-        @CanIgnoreReturnValue
-        public Builder group(EventLoopGroups groups) {
-            this.groups = groups;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder channelHandler(Handler<Channel> channelHandler) {
-            this.channelHandler = channelHandler;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder option(Consumer<NetChannel> optionApplier) {
-            this.optionApplier = this.optionApplier.andThen(optionApplier);
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        @SuppressWarnings("unchecked")
-        public Builder options(InetClientOption option) {
-            optionApplier = optionApplier.andThen(channel ->
-                    option.socketOptions().forEach((k, v) ->
-                            channel.setOption((SocketOption<Object>) k, v)
-                    )
-            );
-            return this;
-        }
-
-        public InetClient build() {
-            Assert.checkNotNull(groups, "groups cannot be null");
-            Assert.checkNotNull(channelHandler, "channelHandler cannot be null");
-
-            try {
-                NetChannel channel = NetChannel.open(new ClientChannelConnector(channelHandler));
-                optionApplier.accept(channel);
-                groups.register(channel);
-                return new InetClient(channel, groups);
-            } catch (IOException e) {
-                throw new ClientException("Failed to create client", e);
-            }
-        }
+    @Override
+    public boolean isStart() {
+        State current = state.get();
+        return current == State.STARTED || current == State.CONNECTING || current == State.CONNECTED;
     }
 
-    private static class ClientChannelConnector implements ChannelHandShakeEventListener {
+    @Override
+    public boolean isShutdown() {
+        return state.get() == State.SHUTDOWN && super.isShutdown();
+    }
 
-        private final Handler<Channel> channelHandler;
+    @SuppressWarnings("unchecked")
+    private void applyClientOption(InetClientOption option) {
+        option.socketOptions().forEach((k, v) -> {
+            channel().setOption((SocketOption<Object>) k, v);
+        });
+    }
 
-        private ClientChannelConnector(Handler<Channel> channelHandler) {
-            this.channelHandler = channelHandler;
+    private @Nullable Promise<NetChannel> validateConnection() {
+        State current = state.get();
+        if (current == State.INIT) {
+            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Client is not started"));
         }
+        if (current == State.SHUTDOWN) {
+            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Client is shutdown"));
+        }
+        if (current == State.CONNECTING || current == State.CONNECTED || channel().isConnected()) {
+            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Client is already connecting or connected"));
+        }
+        if (!state.compareAndSet(State.STARTED, State.CONNECTING)) {
+            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Cannot connect from state=" + state.get()));
+        }
+        if (channel().isClosed()) {
+            state.compareAndSet(State.CONNECTING, State.STARTED);
+            return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Channel is closed"));
+        }
+        return null;
+    }
+
+    @Noop
+    private static final class ClientChannelConnector implements ChannelHandShakeEventListener {
 
         @Override
         public void accept(Channel channel) {
-            channelHandler.handle(channel);
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -27,14 +27,13 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.*;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
-import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.transport.option.InetClientOption;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
@@ -47,25 +46,80 @@ import org.traffichunter.titan.core.util.channel.ChannelRegistry;
 @Slf4j
 public class InetServer extends AbstractTransport<NetServerChannel>{
 
-    private final Object lock = new Object();
-
-    private volatile boolean listening;
-
     private final ChannelRegistry<NetChannel> channelRegistry;
+    private final ServerChannelAcceptor acceptor;
+    private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
 
-    private InetServer(NetServerChannel channel, EventLoopGroups groups, ChannelRegistry<NetChannel> channelRegistry) {
-        super(channel, groups);
-        this.channelRegistry = channelRegistry;
+    private volatile InetServerOption option = InetServerOption.DEFAULT_INET_SERVER_OPTION;
+
+    private enum State {
+        INIT,
+        STARTED,
+        LISTENING,
+        SHUTDOWN
     }
 
-    public static Builder builder() {
-        return new Builder();
+    private InetServer(
+            NetServerChannel channel,
+            EventLoopGroups groups,
+            ChannelRegistry<NetChannel> channelRegistry,
+            ServerChannelAcceptor acceptor
+    ) {
+        super(channel, groups);
+        this.channelRegistry = channelRegistry;
+        this.acceptor = acceptor;
+    }
+
+    public static InetServer open(EventLoopGroups groups) {
+        ChannelRegistry<NetChannel> channelRegistry = new ChannelRegistry<>();
+        ServerChannelAcceptor acceptor = new ServerChannelAcceptor(
+                groups.secondaryGroup(),
+                channelRegistry
+        );
+
+        NetServerChannel serverChannel;
+        try {
+            serverChannel = NetServerChannel.open(acceptor);
+        } catch (IOException e) {
+            throw new ServerException("Failed to open server channel", e);
+        }
+
+        groups.register(serverChannel);
+        return new InetServer(serverChannel, groups, channelRegistry, acceptor);
+    }
+
+    @CanIgnoreReturnValue
+    public InetServer option(InetServerOption option) {
+        this.option = option;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public InetServer childOption(InetClientOption childOption) {
+        this.acceptor.setChildOption(childOption);
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public InetServer onChannel(Handler<Channel> handler) {
+        this.acceptor.setChildHandler(handler);
+        return this;
     }
 
     @Override
     public void start() {
-        groups().primaryGroup().register(channel());
-        groups().start();
+        if (!state.compareAndSet(State.INIT, State.STARTED)) {
+            throw new IllegalStateException("Cannot start server from state=" + state.get());
+        }
+
+        try {
+            applyServerOptions(option);
+            groups().primaryGroup().register(channel());
+            groups().start();
+        } catch (RuntimeException e) {
+            state.compareAndSet(State.STARTED, State.INIT);
+            throw e;
+        }
     }
 
     public Promise<Void> listen(String host, int port) {
@@ -73,9 +127,12 @@ public class InetServer extends AbstractTransport<NetServerChannel>{
     }
 
     public Promise<Void> listen(InetSocketAddress address) {
-        if (listening || !channel().isOpen()) {
-            log.error("Connector is not open");
-            return ChannelPromise.failedPromise(channel(), new ServerException("Connector is not open"));
+        State current = state.get();
+        if (current != State.STARTED || !channel().isOpen()) {
+            return ChannelPromise.failedPromise(channel(), new ServerException("Server is not ready to listen. state=" + current));
+        }
+        if (!state.compareAndSet(State.STARTED, State.LISTENING)) {
+            return ChannelPromise.failedPromise(channel(), new ServerException("Failed to transition to LISTENING. state=" + state.get()));
         }
 
         ChannelPromise resultPromise = ChannelPromise.newPromise(channel());
@@ -86,6 +143,7 @@ public class InetServer extends AbstractTransport<NetServerChannel>{
     private void listen(InetSocketAddress address, ChannelPromise resultPromise) {
         bind(address).addListener(future -> {
             if (!future.isSuccess()) {
+                state.compareAndSet(State.LISTENING, State.STARTED);
                 resultPromise.fail(future.error());
                 return;
             }
@@ -94,14 +152,9 @@ public class InetServer extends AbstractTransport<NetServerChannel>{
             eventLoop.register(() -> {
                 try {
                     eventLoop.ioSelector().registerAccept(channel());
-                    synchronized (lock) {
-                        listening = true;
-                    }
                     resultPromise.success();
                 } catch (IOException e) {
-                    synchronized (lock) {
-                        listening = false;
-                    }
+                    state.compareAndSet(State.LISTENING, State.STARTED);
                     resultPromise.fail(new ServerException("Failed to register accept event", e));
                 }
             });
@@ -143,16 +196,23 @@ public class InetServer extends AbstractTransport<NetServerChannel>{
 
     @Override
     public void shutdown(long timeOut, TimeUnit timeUnit) {
-        if (!listening) {
-            log.warn("Server is not listening");
-            return;
-        }
-
-        synchronized (lock) {
-            listening = false;
-        }
+        do {
+            State current = state.get();
+            if (current == State.SHUTDOWN) {
+                log.warn("Server is already shutdown");
+                return;
+            }
+            if (current == State.INIT) {
+                log.warn("Server is not started");
+                return;
+            }
+            if (state.compareAndSet(current, State.SHUTDOWN)) {
+                break;
+            }
+        } while (true);
 
         log.info("Closing server...");
+
         try {
             super.close(timeOut, timeUnit);
             log.info("Closed server");
@@ -171,105 +231,49 @@ public class InetServer extends AbstractTransport<NetServerChannel>{
         });
     }
 
-    public static final class Builder {
-
-        private @Nullable EventLoopGroups groups;
-        private @Nullable Handler<Channel> channelHandler;
-        private Consumer<NetServerChannel> serverOptionApplier = channel -> { };
-        private Consumer<NetChannel> childOptionApplier = channel -> { };
-        private final ChannelRegistry<NetChannel> channelRegistry = new ChannelRegistry<>();
-
-        @CanIgnoreReturnValue
-        public Builder group(EventLoopGroups groups) {
-            this.groups = groups;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder channelHandler(Handler<Channel> handler) {
-            this.channelHandler = handler;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder option(Consumer<NetServerChannel> optionApplier) {
-            this.serverOptionApplier = this.serverOptionApplier.andThen(optionApplier);
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder childOption(Consumer<NetChannel> optionApplier) {
-            this.childOptionApplier = this.childOptionApplier.andThen(optionApplier);
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        @SuppressWarnings("unchecked")
-        public Builder options(InetServerOption option) {
-            serverOptionApplier = serverOptionApplier.andThen(channel ->
-                    option.serverSocketOptions().forEach((k, v) ->
-                            channel.setOption((SocketOption<Object>) k, v)
-                    )
-            );
-            childOptionApplier = childOptionApplier.andThen(channel ->
-                    option.childSocketOptions().forEach((k, v) ->
-                            channel.setOption((SocketOption<Object>) k, v)
-                    )
-            );
-            return this;
-        }
-
-        public InetServer build() {
-            Assert.checkNotNull(groups, "eventLoopGroups");
-            Assert.checkNotNull(channelHandler, "childHandler");
-
-            NetServerChannel serverChannel;
-            try {
-                serverChannel = NetServerChannel.open(
-                        new ServerChannelAcceptor(
-                                channelHandler,
-                                childOptionApplier,
-                                groups.secondaryGroup(),
-                                channelRegistry
-                        )
-                );
-            } catch (IOException e) {
-                throw new ServerException("Failed to open server channel", e);
-            }
-
-            serverOptionApplier.accept(serverChannel);
-
-            groups.register(serverChannel);
-            return new InetServer(serverChannel, groups, channelRegistry);
-        }
+    @SuppressWarnings("unchecked")
+    private void applyServerOptions(InetServerOption option) {
+        option.serverSocketOptions().forEach((k, v) ->
+                channel().setOption((SocketOption<Object>) k, v)
+        );
     }
 
     private static final class ServerChannelAcceptor implements ChannelHandShakeEventListener {
 
-        private final Handler<Channel> childHandler;
-        private final Consumer<NetChannel> childOptionApplier;
         private final ChannelEventLoopGroup<ChannelSecondaryIOEventLoop> secondaryGroup;
         private final ChannelRegistry<NetChannel> channelRegistry;
 
+        private volatile InetClientOption childOption = InetClientOption.DEFAULT_INET_CLIENT_OPTION;
+        private volatile Handler<Channel> childHandler = ch -> {};
+
         ServerChannelAcceptor(
-                Handler<Channel> childHandler,
-                Consumer<NetChannel> childOptionApplier,
                 ChannelEventLoopGroup<ChannelSecondaryIOEventLoop> secondaryGroup,
                 ChannelRegistry<NetChannel> channelRegistry
         ) {
-            this.childHandler = childHandler;
-            this.childOptionApplier = childOptionApplier;
             this.secondaryGroup = secondaryGroup;
             this.channelRegistry = channelRegistry;
         }
 
+        void setChildOption(InetClientOption childOption) {
+            this.childOption = childOption;
+        }
+
+        void setChildHandler(Handler<Channel> childHandler) {
+            this.childHandler = childHandler;
+        }
+
+        @SuppressWarnings("unchecked")
         @Override
         public void accept(Channel channel) {
             if (!(channel instanceof NetChannel netChannel)) {
                 throw new IllegalArgumentException("Unsupported channel: " + channel);
             }
 
-            childOptionApplier.accept(netChannel);
+            InetClientOption childOption = this.childOption;
+            Handler<Channel> childHandler = this.childHandler;
+            childOption.socketOptions().forEach((k, v) ->
+                    netChannel.setOption((SocketOption<Object>) k, v)
+            );
 
             ChannelSecondaryIOEventLoop loop = secondaryGroup.next();
             loop.register(() -> {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/option/InetClientOption.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/option/InetClientOption.java
@@ -33,6 +33,8 @@ import java.util.Map;
  */
 public class InetClientOption extends InetOption {
 
+    public static final InetClientOption DEFAULT_INET_CLIENT_OPTION = InetClientOption.builder().build();
+
     private InetClientOption(Map<SocketOption<?>, Object> socketOptions) {
         super(socketOptions);
     }

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
@@ -59,13 +59,11 @@ public class ClientToServerTest {
 
     @BeforeEach
     void setUp() throws InterruptedException {
-        server = InetServer.builder()
-                .group(EventLoopGroups.group(1))
-                .options(InetServerOption.builder().build())
-                .channelHandler(ctx -> ctx.chain()
+        server = InetServer.open(EventLoopGroups.group(1))
+                .option(InetServerOption.builder().build())
+                .onChannel(ctx -> ctx.chain()
                         .add(new LineFrameChannelDecoder())
-                        .add(new TestChannelInboundHandler()))
-                .build();
+                        .add(new TestChannelInboundHandler()));
 
         server.start();
 
@@ -88,11 +86,8 @@ public class ClientToServerTest {
     @Test
     void client_to_server_single_send_test() throws ExecutionException, InterruptedException {
 
-        InetClient client = InetClient.builder()
-                .group(EventLoopGroups.group())
-                .options(InetClientOption.builder().build())
-                .channelHandler(channel -> channel.chain())
-                .build();
+        InetClient client = InetClient.open(EventLoopGroups.group())
+                .onChannel(channel -> channel.chain());
 
         client.start();
         client.connect("localhost", 7777).get();
@@ -116,11 +111,8 @@ public class ClientToServerTest {
 
         ExecutorService es = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2, r -> new Thread(r, "TestThread"));
 
-        InetClient client = InetClient.builder()
-                .group(EventLoopGroups.group())
-                .options(InetClientOption.builder().build())
-                .channelHandler(channel -> channel.chain())
-                .build();
+        InetClient client = InetClient.open(EventLoopGroups.group())
+                .onChannel(channel -> channel.chain());
 
         client.start();
         client.connect("localhost", 7777).get();
@@ -154,7 +146,7 @@ public class ClientToServerTest {
             final Message msg = Message.builder()
                     .destination(Destination.create("/route/test"))
                     .priority(Priority.DEFAULT)
-                    .body(buffer.getBytes())
+                    .body(buffer)
                     .producerId(IdGenerator.uuid())
                     .createdAt(Instant.now())
                     .build();

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
@@ -23,37 +23,44 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.fanout;
 
-import org.traffichunter.titan.core.message.Message;
-import org.traffichunter.titan.core.util.Destination;
+import lombok.Getter;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 
-import java.io.Closeable;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Future;
+import java.util.Map;
 
 /**
  * @author yun
  */
-public interface FanoutGateway extends Closeable {
+@Getter
+public enum FanoutMode {
 
-    static FanoutGateway ofThread(FanoutExporter exporter) {
-        return new ThreadPoolExecutorFanoutGateway(exporter);
+    PLATFORM_EXECUTOR("platform") {
+        @Override
+        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
+            return FanoutGateway.ofThread(fanoutExporter);
+        }
+    },
+    VT_EXECUTOR("virtual") {
+        @Override
+        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
+            return FanoutGateway.ofVirtual(fanoutExporter);
+        }
+    },
+    ;
+
+    private final String name;
+
+    FanoutMode(String name) {
+        this.name = name;
     }
 
-    static FanoutGateway ofVirtual(FanoutExporter exporter) {
-        return new VirtualThreadExecutorFanoutGateway(exporter);
+    public abstract FanoutGateway fanoutGateway(FanoutExporter fanoutExporter);
+
+    public static FanoutMode resolveMode(String modeName) {
+        return switch (modeName) {
+            case "platform" -> FanoutMode.PLATFORM_EXECUTOR;
+            case "virtual" -> FanoutMode.VT_EXECUTOR;
+            default -> throw new IllegalStateException("Unexpected value: " + modeName);
+        };
     }
-
-    List<Future<Void>> fanout(Collection<Destination> destinations);
-
-    Future<Void> fanout(Destination destination);
-
-    List<Future<Void>> publish(Collection<Message> messages);
-
-    Future<Void> publish(Message message);
-
-    boolean isOpen();
-
-    boolean isClosed();
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutStompServerLauncher.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutStompServerLauncher.java
@@ -1,0 +1,47 @@
+package org.traffichunter.titan.fanout;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.traffichunter.titan.core.spi.*;
+import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
+
+@SuppressWarnings("unused")
+public final class FanoutStompServerLauncher implements FanoutLauncher {
+
+    private static final String OPTION_FANOUT_MODE = "fanout-mode";
+
+    @Override
+    public boolean supports(
+            final String protocol,
+            final String transport,
+            final Map<String, String> protocolOptions,
+            final ManagedServer managedServer
+    ) {
+        return managedServer instanceof StompManagedServer
+                && "stomp".equalsIgnoreCase(protocol);
+    }
+
+    @Override
+    public void apply(
+            final String protocol,
+            final String transport,
+            final Map<String, String> protocolOptions,
+            final ManagedServer managedServer
+    ) {
+        StompManagedServer stompManagedServer = (StompManagedServer) managedServer;
+        FanoutMode mode = resolveMode(protocolOptions);
+        FanoutGateway fanoutGateway = mode.fanoutGateway(new StompFanoutExporter(stompManagedServer.server().connection()));
+        StompSendToFanoutHandler stompSendToFanoutHandler = new StompSendToFanoutHandler(fanoutGateway);
+
+        stompManagedServer.server().onStomp(handler ->
+                handler.sendHandler(stompSendToFanoutHandler)
+        );
+    }
+
+    private static FanoutMode resolveMode(final Map<String, String> protocolOptions) {
+        String raw = protocolOptions.getOrDefault(OPTION_FANOUT_MODE, "virtual");
+        String normalized = raw.toLowerCase(Locale.ROOT).trim();
+        return FanoutMode.resolveMode(normalized);
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import java.time.Instant;
+
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.channel.stomp.StompServerCommandHandler;
 import org.traffichunter.titan.core.channel.stomp.StompServerEvent;
@@ -33,7 +34,6 @@ import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.Priority;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.IdGenerator;
 
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 
@@ -63,9 +63,8 @@ public final class StompSendToFanoutHandler implements StompServerCommandHandler
                 .priority(Priority.DEFAULT)
                 .destination(Destination.create(destination))
                 .createdAt(Instant.now())
-                .isRecovery(false)
-                .producerId(IdGenerator.uuid())
-                .body(sf.getBody().getBytes())
+                .producerId(connection.session())
+                .body(sf.getBody())
                 .build();
 
         try {

--- a/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.FanoutLauncher
+++ b/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.FanoutLauncher
@@ -1,0 +1,1 @@
+org.traffichunter.titan.fanout.FanoutStompServerLauncher

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompManagedServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompManagedServer.java
@@ -21,39 +21,48 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package org.traffichunter.titan.fanout;
+package org.traffichunter.titan.core.spi;
 
-import org.traffichunter.titan.core.message.Message;
-import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.channel.stomp.StompServerConnection;
+import org.traffichunter.titan.core.transport.stomp.StompServer;
 
-import java.io.Closeable;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author yun
  */
-public interface FanoutGateway extends Closeable {
+public final class StompManagedServer implements ManagedServer {
 
-    static FanoutGateway ofThread(FanoutExporter exporter) {
-        return new ThreadPoolExecutorFanoutGateway(exporter);
+    private final StompServer server;
+    private final ServerSettings settings;
+
+    public StompManagedServer(StompServer server, ServerSettings settings) {
+        this.server = server;
+        this.settings = settings;
     }
 
-    static FanoutGateway ofVirtual(FanoutExporter exporter) {
-        return new VirtualThreadExecutorFanoutGateway(exporter);
+    @Override
+    public String name() {
+        return settings.serverName();
     }
 
-    List<Future<Void>> fanout(Collection<Destination> destinations);
+    @Override
+    public void start() {
+        try {
+            server.start();
+            server.listen(settings.host(), settings.port()).get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to start STOMP server " + name(), e);
+        }
+    }
 
-    Future<Void> fanout(Destination destination);
+    public StompServer server() {
+        return server;
+    }
 
-    List<Future<Void>> publish(Collection<Message> messages);
-
-    Future<Void> publish(Message message);
-
-    boolean isOpen();
-
-    boolean isClosed();
+    @Override
+    public void stop() {
+        server.shutdown();
+    }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
@@ -23,17 +23,57 @@
  */
 package org.traffichunter.titan.core.spi;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
+import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 import org.traffichunter.titan.core.transport.stomp.StompServer;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
 
 public final class StompServerEngineProvider implements NetworkServerEngineProvider {
+
+    private final List<ChannelInBoundHandler> inboundHandlers = new ArrayList<>();
+    private final List<ChannelOutBoundHandler> outboundHandlers = new ArrayList<>();
+
+    @Override
+    @CanIgnoreReturnValue
+    public NetworkServerEngineProvider setInboundHandler(ChannelInBoundHandler channelInBoundHandler) {
+        inboundHandlers.add(channelInBoundHandler);
+        return this;
+    }
+
+    @Override
+    @CanIgnoreReturnValue
+    public NetworkServerEngineProvider setOutboundHandler(ChannelOutBoundHandler channelOutBoundHandler) {
+        outboundHandlers.add(channelOutBoundHandler);
+        return this;
+    }
+
+    @Override
+    public ManagedServer create(final ServerSettings settings) {
+        EventLoopGroups groups = EventLoopGroups.group(settings.primaryThreads(), settings.secondaryThreads());
+        InetServerOption inetOption = buildInetOption(settings.resolvedTransportOptions());
+        StompServerOption stompServerOption = buildOption(settings.resolvedProtocolOptions(), inetOption);
+
+        StompServer server = StompServer.open(groups, stompServerOption)
+                .onChannel(channel -> {
+                    inboundHandlers.forEach(inboundHandler ->
+                            channel.chain().add(inboundHandler)
+                    );
+                    outboundHandlers.forEach(outboundHandler ->
+                            channel.chain().add(outboundHandler)
+                    );
+                });
+
+        return new StompManagedServer(server, settings);
+    }
 
     @Override
     public String transport() {
@@ -43,39 +83,6 @@ public final class StompServerEngineProvider implements NetworkServerEngineProvi
     @Override
     public String protocol() {
         return "stomp";
-    }
-
-    @Override
-    public ManagedServer create(final ServerSettings settings) {
-        EventLoopGroups groups = EventLoopGroups.group(settings.primaryThreads(), settings.secondaryThreads());
-        InetServerOption inetOption = buildInetOption(settings.resolvedTransportOptions());
-        StompServer server = StompServer.builder()
-                .group(groups)
-                .option(buildOption(settings.resolvedProtocolOptions(), inetOption))
-                .build();
-
-        return new ManagedServer() {
-
-            @Override
-            public String name() {
-                return settings.serverName();
-            }
-
-            @Override
-            public void start() {
-                try {
-                    server.start();
-                    server.listen(settings.host(), settings.port()).get(30, TimeUnit.SECONDS);
-                } catch (Exception e) {
-                    throw new IllegalStateException("Failed to start STOMP server " + name(), e);
-                }
-            }
-
-            @Override
-            public void stop() {
-                server.shutdown();
-            }
-        };
     }
 
     private static StompServerOption buildOption(final Map<String, String> options, final InetServerOption inetOption) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompClient.java
@@ -25,13 +25,14 @@ package org.traffichunter.titan.core.transport.stomp;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.SocketOption;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
@@ -41,13 +42,11 @@ import org.traffichunter.titan.core.codec.stomp.*;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.InetClient;
-import org.traffichunter.titan.core.transport.option.InetClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
-import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Handler;
 
-import static org.traffichunter.titan.core.codec.stomp.StompFrame.*;
-import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
+import static org.traffichunter.titan.core.codec.stomp.StompFrame.HeartBeat;
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 
 /**
  * @author yun
@@ -57,30 +56,44 @@ public final class StompClient {
 
     private final InetClient inetClient;
     private final StompClientOption option;
-    private final Handler<StompClientHandler> clientHandlerConfigurer;
+
+    private Handler<StompClientHandler> stompClientHandler = handler -> {};
     private @Nullable StompClientConnection connection;
 
-    private StompClient(
-            EventLoopGroups groups,
-            StompClientOption option,
-            Consumer<NetChannel> optionApplier,
-            Handler<StompClientHandler> clientHandlerConfigurer
-    ) {
-
-        this.inetClient = InetClient.builder()
-                .group(groups)
-                .option(optionApplier)
-                .build();
-
+    private StompClient(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
         this.option = option;
-        this.clientHandlerConfigurer = clientHandlerConfigurer;
+
+        if (inetClient == null) {
+            inetClient = InetClient.open(groups, option.inetClientOption());
+        }
+        this.inetClient = inetClient;
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public static StompClient open(EventLoopGroups groups, StompClientOption option) {
+        return open(groups, null, option);
+    }
+
+    public static StompClient open(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
+        return new StompClient(groups, inetClient, option);
+    }
+
+    @CanIgnoreReturnValue
+    public StompClient onChannel(Handler<Channel> channelHandler) {
+        inetClient.onChannel(channelHandler);
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public StompClient onStomp(Handler<StompClientHandler> stompClientHandler) {
+        this.stompClientHandler = stompClientHandler;
+        return this;
     }
 
     public void start() {
+        if(inetClient.isStart()) {
+            throw new StompException("Client already started");
+        }
+
         inetClient.start();
     }
 
@@ -139,40 +152,36 @@ public final class StompClient {
     }
 
     public void handler(Consumer<StompClientConnection> connection) {
-        StompClientConnection clientConnection = connection();
-
-        connection.accept(clientConnection);
+        connection.accept(connection());
     }
 
     private StompClientConnection createConnection(NetChannel channel) {
-        StompClientConnection connection = StompClientConnection.wrap(channel, option, clientHandlerConfigurer);
+        StompClientConnection connection = StompClientConnection.wrap(channel, option);
+        stompClientHandler.handle(connection.handler());
         channel.chain().add(new StompChannelDecoder(option.maxFrameLength(), connection, connection.handler()));
         this.connection = connection;
         return connection;
     }
 
     private StompFrame generateConnectFrame(String host) {
-        StompHeaders headers = create();
-        String accepted = option.stompVersion().getVersion();
-        headers.put(Elements.ACCEPT_VERSION, accepted);
+        StompHeaders headers = StompHeaders.create();
+        headers.put(Elements.ACCEPT_VERSION, option.stompVersion().getVersion());
 
-        if(!option.bypassHostHeader()) {
+        if (!option.bypassHostHeader()) {
             headers.put(Elements.HOST, host);
         }
-        if(option.virtualHost() != null) {
+        if (option.virtualHost() != null) {
             headers.put(Elements.HOST, option.virtualHost());
         }
-        if(option.login() != null) {
+        if (option.login() != null) {
             headers.put(Elements.LOGIN, option.login());
         }
-        if(option.passcode() != null) {
+        if (option.passcode() != null) {
             headers.put(Elements.PASSCODE, option.passcode());
         }
 
         headers.put(Elements.HEART_BEAT, HeartBeat.create(option.heartbeatX(), option.heartbeatY()).value());
-
         StompCommand command = option.useStompFrame() ? StompCommand.STOMP : StompCommand.CONNECT;
-
         return StompFrame.create(headers, command);
     }
 
@@ -184,8 +193,7 @@ public final class StompClient {
     ) {
         Promise<StompClientConnection> result = Promise.newPromise(conn.channel().eventLoop());
         ScheduledPromise<Object> timeoutTask = conn.channel().eventLoop().schedule(() -> {
-            if (result.tryFail(new StompNetChannelException(
-                    "Timed out waiting for CONNECTED from " + remoteAddress + " in " + timeOut + " " + timeUnit))) {
+            if (result.tryFail(new StompNetChannelException("Timed out waiting for CONNECTED from " + remoteAddress + " in " + timeOut + " " + timeUnit))) {
                 conn.close();
             }
         }, timeOut, timeUnit);
@@ -206,54 +214,5 @@ public final class StompClient {
         });
 
         return result;
-    }
-
-    public static final class Builder {
-
-        private @Nullable EventLoopGroups groups;
-        private StompClientOption option = StompClientOption.DEFAULT_STOMP_CLIENT_OPTION;
-        private Consumer<NetChannel> optionApplier = channel -> { };
-        private Handler<StompClientHandler> stompClientHandler = handler -> { };
-
-        @CanIgnoreReturnValue
-        public Builder group(EventLoopGroups groups) {
-            this.groups = groups;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder option(StompClientOption option) {
-            this.option = option;
-            if (option.inetClientOption() != null) {
-                option(option.inetClientOption());
-            }
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        @SuppressWarnings("unchecked")
-        public Builder option(InetClientOption option) {
-            this.optionApplier = this.optionApplier.andThen(channel ->
-                    option.socketOptions().forEach((k, v) ->
-                            channel.setOption((SocketOption<Object>) k, v)
-                    ));
-            return this;
-        }
-
-        public Builder handler(Handler<StompClientHandler> stompClientHandler) {
-            this.stompClientHandler = stompClientHandler;
-            return this;
-        }
-
-        public StompClient build() {
-            Assert.checkNotNull(groups, "groups cannot be null");
-
-            return new StompClient(
-                    groups,
-                    option,
-                    optionApplier,
-                    stompClientHandler
-            );
-        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -27,19 +27,16 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.NetChannel;
-import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
-import org.traffichunter.titan.core.channel.stomp.StompServerConnection;
-import org.traffichunter.titan.core.channel.stomp.StompServerHandler;
-import org.traffichunter.titan.core.channel.stomp.StompServerHandlerImpl;
+import org.traffichunter.titan.core.channel.stomp.*;
 import org.traffichunter.titan.core.codec.stomp.StompChannelDecoder;
 import org.traffichunter.titan.core.codec.stomp.StompException;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.concurrent.Promise;
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.transport.InetServer;
-import org.traffichunter.titan.core.transport.option.InetServerOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
 import org.traffichunter.titan.core.util.Assert;
@@ -51,52 +48,76 @@ import org.traffichunter.titan.core.util.Handler;
 public final class StompServer {
 
     private final InetServer inetServer;
-    private final StompServerOption option;
     private final StompServerConnection serverConnection;
+    private final StompServerOption option;
 
-    private StompServer(
-            EventLoopGroups groups,
-            StompServerOption option,
-            InetServerOption inetServerOption,
-            StompClientOption childOption,
-            Handler<StompServerHandler> stompServerHandlerConfigurer
-    ) {
+    private StompClientOption childOption = StompClientOption.DEFAULT_STOMP_CLIENT_OPTION;
+    private Handler<StompServerHandler> stompServerHandler = handler -> {};
+    private Handler<Channel> channelHandler = channel -> {};
+
+    private StompServer(EventLoopGroups groups, @Nullable InetServer inetServer, StompServerOption option) {
         this.option = option;
+        this.serverConnection = StompServerConnection.create(option);
+        if(inetServer == null) {
+            inetServer = initializeInetServer(groups);
+        }
+        this.inetServer = inetServer;
+    }
 
-        StompServerConnection stompServerConnection = StompServerConnection.create(option);
-        StompClientOption acceptedConnectionOption = serverChildSessionOption(option, childOption);
-        StompServerHandler stompServerHandler = new StompServerHandlerImpl(stompServerConnection);
-        stompServerHandlerConfigurer.handle(stompServerHandler);
+    public static StompServer open(EventLoopGroups groups, StompServerOption option) {
+        return open(groups, null, option);
+    }
 
-        InetServer stompInetServer = InetServer.builder()
-                .group(groups)
-                .options(inetServerOption)
-                .channelHandler(channel -> {
+    public static StompServer open(EventLoopGroups groups, @Nullable InetServer inetServer, StompServerOption option) {
+        return new StompServer(groups, inetServer, option);
+    }
+
+    @CanIgnoreReturnValue
+    public StompServer childOption(StompClientOption option) {
+        this.childOption = Assert.checkNotNull(option, "option");
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public StompServer onChannel(Handler<Channel> channelHandler) {
+        this.channelHandler = channelHandler;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public StompServer onStomp(Handler<StompServerHandler> stompServerHandler) {
+        this.stompServerHandler = stompServerHandler;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public StompServer start() {
+        StompClientOption stompClientOption = serverChildSessionOption(option, childOption);
+        StompServerHandler stompServerHandler = new StompServerHandlerImpl(serverConnection);
+        this.stompServerHandler.handle(stompServerHandler);
+
+        inetServer.option(option.inetServerOption())
+                .childOption(childOption.inetClientOption())
+                .onChannel(channel -> {
                     if (!(channel instanceof NetChannel netChannel)) {
                         throw new IllegalArgumentException("Unsupported channel: " + channel);
                     }
 
                     StompClientConnection stompConnection =
-                            StompClientConnection.wrap(netChannel, acceptedConnectionOption);
-                    stompServerConnection.register(stompConnection);
+                            StompClientConnection.wrap(netChannel, stompClientOption);
+                    serverConnection.register(stompConnection);
 
                     netChannel.chain()
                             .add(new StompChannelDecoder(option.maxBodyLength(), stompConnection, stompServerHandler));
-                })
-                .build();
 
-        stompServerConnection.bind(stompInetServer.channel());
+                    channelHandler.handle(netChannel);
+                });
 
-        this.serverConnection = stompServerConnection;
-        this.inetServer = stompInetServer;
-    }
+        serverConnection.bind(inetServer.channel());
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public void start() {
         inetServer.start();
+
+        return this;
     }
 
     public Promise<Void> listen(String host, int port) {
@@ -104,7 +125,7 @@ public final class StompServer {
     }
 
     public Promise<Void> listen(InetSocketAddress address) {
-        ChannelPromise channelPromise = ChannelPromise.newPromise(serverConnection.channel());
+        ChannelPromise channelPromise = ChannelPromise.newPromise(connection().channel());
         listen(address, channelPromise);
         return channelPromise;
     }
@@ -126,6 +147,7 @@ public final class StompServer {
     }
 
     public void shutdown(long timeout, TimeUnit unit) {
+        Assert.checkState(inetServer.isStart(), "inetServer is not started");
         inetServer.shutdown(timeout, unit);
     }
 
@@ -134,6 +156,8 @@ public final class StompServer {
     }
 
     private void listen(InetSocketAddress address, ChannelPromise resultPromise) {
+        Assert.checkState(inetServer.isStart(), "inetServer is not started");
+
         inetServer.listen(address)
                 .addListener(listenFuture -> {
                     if (listenFuture.isSuccess()) {
@@ -144,6 +168,10 @@ public final class StompServer {
                 });
     }
 
+    private InetServer initializeInetServer(EventLoopGroups groups) {
+        return InetServer.open(groups);
+    }
+
     private static StompClientOption serverChildSessionOption(StompServerOption option, StompClientOption childOption) {
         return StompClientOption.builder()
                 .version(option.stompVersion())
@@ -152,59 +180,5 @@ public final class StompServer {
                 .heartbeatY(option.heartbeatY())
                 .maxFrameLength(option.maxBodyLength())
                 .build();
-    }
-
-    public static final class Builder {
-
-        private @Nullable EventLoopGroups groups;
-        private @Nullable StompServerOption option;
-        private InetServerOption inetServerOption = InetServerOption.DEFAULT_INET_SERVER_OPTION;
-        private StompClientOption childOption = StompClientOption.DEFAULT_STOMP_CLIENT_OPTION;
-        private Handler<StompServerHandler> stompServerHandler = handler -> {};
-
-        @CanIgnoreReturnValue
-        public Builder group(EventLoopGroups groups) {
-            this.groups = groups;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder option(StompServerOption option) {
-            this.option = option;
-            if (option.inetServerOption() != null) {
-                this.inetServerOption = option.inetServerOption();
-            }
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder option(InetServerOption option) {
-            this.inetServerOption = option;
-            return this;
-        }
-
-        @CanIgnoreReturnValue
-        public Builder childOption(StompClientOption option) {
-            this.childOption = option;
-            return this;
-        }
-
-        public Builder handler(Handler<StompServerHandler> serverHandlerHandler) {
-            this.stompServerHandler = serverHandlerHandler;
-            return this;
-        }
-
-        public StompServer build() {
-            Assert.checkNotNull(groups, "groups cannot be null");
-            Assert.checkNotNull(option, "option cannot be null");
-
-            return new StompServer(
-                    groups,
-                    option,
-                    inetServerOption,
-                    childOption,
-                    stompServerHandler
-            );
-        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompClientOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompClientOption.java
@@ -102,7 +102,7 @@ public record StompClientOption(
                 virtualHost,
                 maxFrameLength == null ? DEFAULT_MAX_FRAME_LENGTH : maxFrameLength,
                 StompVersion.STOMP_1_2,
-                inetClientOption
+                inetClientOption == null ? InetClientOption.DEFAULT_INET_CLIENT_OPTION : inetClientOption
         );
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
@@ -104,7 +104,7 @@ public record StompServerOption(
                 transactionChunkSize == null ? DEFAULT_TRANSACTION_CHUNK_SIZE : transactionChunkSize,
                 maxSubscriptionsByClient == null ? DEFAULT_MAX_SUBSCRIPTIONS_BY_CLIENT : maxSubscriptionsByClient,
                 StompVersion.STOMP_1_2,
-                inetServerOption
+                inetServerOption == null ? InetServerOption.DEFAULT_INET_SERVER_OPTION : inetServerOption
         );
     }
 }

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -5,12 +5,15 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.StompHandler;
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
+import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -174,7 +177,14 @@ class StompChannelDecoderTest {
     private static class TestStompChannelDecoder extends StompChannelDecoder {
 
         public TestStompChannelDecoder(int maxLength, StompHandler handler) {
-            super(maxLength, StompClientConnection.wrap(new InMemoryNetChannel(), StompClientOption.builder().build()), handler);
+            super(maxLength, StompClientConnection.wrap(channelWithEventLoop(), StompClientOption.builder().build()), handler);
+        }
+
+        private static InMemoryNetChannel channelWithEventLoop() {
+            InMemoryNetChannel channel = new InMemoryNetChannel();
+            IOEventLoop eventLoop = Mockito.mock(IOEventLoop.class);
+            channel.register(eventLoop, ChannelPromise.newPromise(eventLoop, channel));
+            return channel;
         }
     }
 

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
@@ -48,6 +48,7 @@ import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -71,9 +72,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_client_can_connect_to_server_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -89,9 +88,7 @@ class StompIntegrationTest {
 
     @RepeatedTest(5)
     void stomp_reconnect_cycle_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -113,9 +110,7 @@ class StompIntegrationTest {
 
     @RepeatedTest(10)
     void stomp_ping_pong_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -130,11 +125,8 @@ class StompIntegrationTest {
     @Test
     void stomp_send_with_text_body_test(StompTestServer testServer, Dispatcher dispatcher) throws Exception {
         Destination key = Destination.create("/queue/test");
-        DispatcherQueue queue = DispatcherQueue.create(key);
-        dispatcher.produce(key, queue);
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        DispatcherQueue queue = dispatcher.getOrPut(key);
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -149,7 +141,7 @@ class StompIntegrationTest {
             assertThat(result.getBody().toString()).isEqualTo("Hello STOMP!");
         } finally {
             client.shutdown();
-            dispatcher.subscribe(key);
+            dispatcher.remove(key);
         }
     }
 
@@ -158,34 +150,30 @@ class StompIntegrationTest {
     @Test
     void stomp_subscribe_and_receive_message_test(StompTestServer testServer, Dispatcher dispatcher) throws Exception {
         Destination key = Destination.create("/topic/test");
-        DispatcherQueue queue = DispatcherQueue.create(key);
-        dispatcher.produce(key, queue);
+        DispatcherQueue queue = dispatcher.getOrPut(key);
 
         AtomicBoolean messageReceived = new AtomicBoolean(false);
         AtomicReference<StompFrame> receivedFrame = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
-        StompClient subscriber = StompClient.builder().group(clientGroups()).build();
-        StompClient publisher = StompClient.builder().group(clientGroups()).build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
-            subscriber.start();
-            publisher.start();
+            client.start();
 
-            subscriber.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
-            publisher.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
+            client.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
 
             // Subscribe with message handler
-            subscriber.connection().subscribe("/topic/test", frame -> {
+            client.connection().subscribe("/topic/test", frame -> {
                 messageReceived.set(true);
                 receivedFrame.set(frame);
                 latch.countDown();
             }).get(3, TimeUnit.SECONDS);
 
-            assertThat(subscriber.connection().subscriptions()).hasSize(1);
+            assertThat(client.connection().subscriptions()).hasSize(1);
 
             // Publish message
-            publisher.connection().send("/topic/test", Buffer.alloc("Test message")).get(3, TimeUnit.SECONDS);
+            client.connection().send("/topic/test", Buffer.alloc("Test message")).get(3, TimeUnit.SECONDS);
 
             // Wait for message
             boolean received = latch.await(5, TimeUnit.SECONDS);
@@ -196,21 +184,17 @@ class StompIntegrationTest {
                 assertThat(receivedFrame.get().getCommand()).isEqualTo(StompCommand.MESSAGE);
             }
         } finally {
-            subscriber.shutdown();
-            publisher.shutdown();
-            dispatcher.subscribe(key);
+            client.shutdown();
+            dispatcher.remove(key);
         }
     }
 
     @Test
     void stomp_unsubscribe_test(StompTestServer testServer, Dispatcher dispatcher) throws Exception {
         Destination key = Destination.create("/topic/unsub");
-        DispatcherQueue queue = DispatcherQueue.create(key);
-        dispatcher.produce(key, queue);
+        DispatcherQueue queue = dispatcher.getOrPut(key);
 
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -231,7 +215,7 @@ class StompIntegrationTest {
             assertThat(client.connection().subscriptions()).hasSize(0);
         } finally {
             client.shutdown();
-            dispatcher.subscribe(key);
+            dispatcher.remove(key);
         }
     }
 
@@ -240,13 +224,11 @@ class StompIntegrationTest {
         Destination key1 = Destination.create("/topic/ack1");
         Destination key2 = Destination.create("/topic/ack2");
         Destination key3 = Destination.create("/topic/ack3");
-        dispatcher.produce(key1, DispatcherQueue.create(key1));
-        dispatcher.produce(key2, DispatcherQueue.create(key2));
-        dispatcher.produce(key3, DispatcherQueue.create(key3));
+        dispatcher.getOrPut(key1);
+        dispatcher.getOrPut(key2);
+        dispatcher.getOrPut(key3);
 
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -270,9 +252,9 @@ class StompIntegrationTest {
             assertThat(client.connection().subscriptions()).hasSize(3);
         } finally {
             client.shutdown();
-            dispatcher.subscribe(key1);
-            dispatcher.subscribe(key2);
-            dispatcher.subscribe(key3);
+            dispatcher.remove(key1);
+            dispatcher.remove(key2);
+            dispatcher.remove(key3);
         }
     }
 
@@ -280,9 +262,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_ack_command_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -295,9 +275,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_nack_command_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -310,9 +288,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_ack_within_transaction_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -331,9 +307,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_transaction_begin_commit_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -349,9 +323,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_transaction_begin_abort_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -368,16 +340,13 @@ class StompIntegrationTest {
     @Test
     void stomp_transaction_with_send_test(StompTestServer testServer, Dispatcher dispatcher) throws Exception {
         Destination key = Destination.create("/queue/tx-test");
-        DispatcherQueue queue = DispatcherQueue.create(key);
-        dispatcher.produce(key, queue);
+        DispatcherQueue queue = dispatcher.getOrPut(key);
 
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .channelHandler(channel ->
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION)
+                .onChannel(channel ->
                         channel.chain()
                             .add(new TestChannelInboundHandler(queue))
-                )
-                .build();
+                );
 
         try {
             client.start();
@@ -397,15 +366,13 @@ class StompIntegrationTest {
             assertThat(queue.size()).isGreaterThan(0);
         } finally {
             client.shutdown();
-            dispatcher.subscribe(key);
+            dispatcher.remove(key);
         }
     }
 
     @RepeatedTest(3)
     void stomp_multiple_transactions_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -429,9 +396,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_disconnect_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -451,9 +416,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_subscribe_to_nonexistent_destination_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -470,9 +433,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_commit_without_begin_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.builder()
-                .group(clientGroups())
-                .build();
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -501,9 +462,8 @@ class StompIntegrationTest {
                     .priority(Priority.DEFAULT)
                     .destination(queue.route())
                     .createdAt(Instant.now())
-                    .isRecovery(false)
                     .producerId(UUID.randomUUID().toString())
-                    .body(buffer.getBytes())
+                    .body(buffer)
                     .build();
 
             queue.enqueue(message);

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompServerExtension.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompServerExtension.java
@@ -25,7 +25,9 @@ package org.traffichunter.titan.core.transport.stomp;
 
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -34,13 +36,22 @@ import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
 
-public final class StompServerExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+public final class StompServerExtension implements
+        BeforeAllCallback,
+        AfterAllCallback,
+        BeforeEachCallback,
+        AfterEachCallback,
+        ParameterResolver {
 
     private static final ExtensionContext.Namespace NS = ExtensionContext.Namespace.create(StompServerExtension.class);
     private static final String KEY = "stomp-test-server";
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
         EnableStompServer config = context.getRequiredTestClass().getAnnotation(EnableStompServer.class);
         if (config == null) {
             throw new IllegalStateException("@EnableStompServer is required");
@@ -51,11 +62,7 @@ public final class StompServerExtension implements BeforeAllCallback, AfterAllCa
                 .maxBodyLength(config.maxFrameLength())
                 .build();
 
-        StompServer server = StompServer.builder()
-                .group(groups)
-                .option(serverOption)
-                .build();
-
+        StompServer server = StompServer.open(groups, serverOption);
         server.start();
         server.listen(config.host(), config.port()).get(3, TimeUnit.SECONDS);
 
@@ -68,6 +75,10 @@ public final class StompServerExtension implements BeforeAllCallback, AfterAllCa
 
     @Override
     public void afterAll(ExtensionContext context) {
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
         StompTestServer testServer = context.getStore(NS).remove(KEY, StompTestServer.class);
         if (testServer != null) {
             testServer.server().shutdown();


### PR DESCRIPTION
## Overview.

<!---- Resolves: #(Isuue Number) [FEAT] ... -->

## Background
We had a few issues across STOMP/transport:
- missing default option guarantees,
- unclear lifecycle/state handling,
- flaky integration tests,
and we also needed a fanout runtime extension point (SPI) plus a benchmark comparing platform vs virtual threads.

## What changed

### 1) STOMP stability and API cleanup
- Guaranteed default `inet*Option` values in:
  - `StompServerOption`
  - `StompClientOption`
- Refactored `StompClient` to match `StompServer` style:
  - removed `clientHandlerConfigurer`
  - use `onChannel` / `onStomp` configuration flow
- Changed `StompServerExtension` to per-test lifecycle (`beforeEach`/`afterEach`) to reduce flakiness

### 2) Transport lifecycle hardening
- Added explicit state machine to `InetClient`:
  - `INIT`, `STARTED`, `CONNECTING`, `CONNECTED`, `SHUTDOWN`
- Added state transition checks to `start/connect/send/shutdown`
- Simplified `onChannel` handler assignment path (`this.channelHandler = handler`)

### 3) Core/Fanout runtime integration
- Renamed bootstrap entrypoint from `CoreApplication` to `TitanApplication`
- Added `FanoutLauncher` SPI hook and loading path
- Added STOMP fanout integration components:
  - `FanoutStompServerLauncher`
  - `StompManagedServer`
- Extended `NetworkServerEngineProvider` with inbound/outbound handler injection
- Updated TCP/STOMP providers to use the new configuration flow

## Pull Request Convention.

- [x] New feature. (feat)
- [ ] Fix bug. (fix)
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names) (style)
- [x] Refactor code (refactor)
- [ ] Add and edit comments (style)
- [ ] Edit docs (docs)
- [ ] Add and refactor tests (test)
- [ ] Edit the build part or package manager (chore)
- [ ] Rename file or directory (rename)
- [ ] Remove file or directory (remove)

## Opinion.