### PR TITLE
Introduce Spring STOMP client module with listener infrastructure

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,6 +14,7 @@
             <option value="$PROJECT_DIR$/core" />
             <option value="$PROJECT_DIR$/fanout" />
             <option value="$PROJECT_DIR$/monitor" />
+            <option value="$PROJECT_DIR$/titan-spring-client" />
             <option value="$PROJECT_DIR$/titan-stomp" />
           </set>
         </option>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,3 +7,4 @@ include("titan-stomp")
 
 include("benchmark")
 include("fanout")
+include("titan-spring-client")

--- a/titan-spring-client/build.gradle.kts
+++ b/titan-spring-client/build.gradle.kts
@@ -1,10 +1,12 @@
 dependencies {
     implementation(project(":titan-stomp"))
     implementation(project(":core"))
+
     implementation("org.springframework.boot:spring-boot-autoconfigure:3.3.5")
     implementation("org.springframework:spring-context:6.1.14")
     implementation("org.springframework:spring-beans:6.1.14")
     implementation("org.springframework:spring-messaging:6.1.14")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
 
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.3.5")
 }

--- a/titan-spring-client/build.gradle.kts
+++ b/titan-spring-client/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    implementation(project(":titan-stomp"))
+    implementation(project(":core"))
+    implementation("org.springframework.boot:spring-boot-autoconfigure:3.3.5")
+    implementation("org.springframework:spring-context:6.1.14")
+    implementation("org.springframework:spring-beans:6.1.14")
+    implementation("org.springframework:spring-messaging:6.1.14")
+
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.3.5")
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/EnableTitan.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/EnableTitan.java
@@ -1,0 +1,40 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author yun
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TitanListenerConfiguration.class)
+public @interface EnableTitan {
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -1,0 +1,105 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
+import org.traffichunter.titan.core.transport.stomp.StompClient;
+
+public final class TitanClientManager implements SmartLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(TitanClientManager.class);
+
+    private final StompClient stompClient;
+    private final TitanProperties properties;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public TitanClientManager(StompClient stompClient, TitanProperties properties) {
+        this.stompClient = stompClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            if (!stompClient.isStart()) {
+                stompClient.start();
+            }
+            if (properties.isAutoConnect()) {
+                connect();
+            }
+        } catch (Exception e) {
+            running.set(false);
+            throw new IllegalStateException("Failed to start Titan STOMP client manager", e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        try {
+            stompClient.shutdown(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("Failed to shutdown STOMP client cleanly", e);
+        }
+    }
+
+    @Override
+    public void stop(Runnable callback) {
+        stop();
+        callback.run();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    @Override
+    public boolean isAutoStartup() {
+        return properties.isAutoStart();
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE;
+    }
+
+    public StompClientConnection connect() throws Exception {
+        return stompClient
+                .connect(properties.getHost(), properties.getPort(), properties.getConnectTimeoutMillis(), TimeUnit.MILLISECONDS)
+                .get(properties.getConnectTimeoutMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public StompClientConnection connection() throws Exception {
+        if (isConnected()) {
+            return stompClient.connection();
+        }
+        return connect();
+    }
+
+    public @Nullable StompClientConnection currentConnection() {
+        try {
+            return stompClient.connection();
+        } catch (IllegalStateException e) {
+            return null;
+        }
+    }
+
+    public boolean isConnected() {
+        try {
+            return stompClient.connection().isConnected();
+        } catch (IllegalStateException e) {
+            return false;
+        }
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListener.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListener.java
@@ -1,0 +1,45 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author yun
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TitanListener {
+
+    String destination();
+
+    String id() default "";
+
+    int concurrency() default 1;
+
+    String clientRef() default "titanStompClientManager";
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfiguration.java
@@ -1,0 +1,72 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.converter.*;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.traffichunter.titan.springframework.stomp.beans.TitanListenerAnnotationBeanPostProcessor;
+import org.traffichunter.titan.springframework.stomp.messaging.converter.StompFrameMessageConverter;
+import org.traffichunter.titan.springframework.stomp.messaging.resolver.TitanPayloadHandlerMethodArgumentResolver;
+import org.traffichunter.titan.springframework.stomp.messaging.resolver.TitanStompHandlerMethodArgumentResolver;
+
+import java.util.List;
+
+/**
+ * @author yun
+ */
+@Configuration
+public class TitanListenerConfiguration {
+
+    @Bean
+    TitanListenerEndpointRegistry titanListenerEndpointRegistry() {
+        return new TitanListenerEndpointRegistry();
+    }
+
+    @Bean
+    TitanListenerAnnotationBeanPostProcessor titanListenerAnnotationBeanPostProcessor(TitanListenerEndpointRegistry registry) {
+        return new TitanListenerAnnotationBeanPostProcessor(registry);
+    }
+
+    @Bean
+    SmartMessageConverter titanMessageConverter() {
+        List<MessageConverter> converters = List.of(
+                new StompFrameMessageConverter(),
+                new ByteArrayMessageConverter(),
+                new StringMessageConverter(),
+                new MappingJackson2MessageConverter()
+        );
+
+        return new CompositeMessageConverter(converters);
+    }
+
+    @Bean
+    HandlerMethodArgumentResolverComposite titanResolverComposite(SmartMessageConverter converter) {
+        HandlerMethodArgumentResolverComposite c = new HandlerMethodArgumentResolverComposite();
+        c.addResolver(new TitanStompHandlerMethodArgumentResolver(converter));
+        c.addResolver(new TitanPayloadHandlerMethodArgumentResolver(converter));
+        return c;
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerEndpoint.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerEndpoint.java
@@ -1,0 +1,12 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import java.lang.reflect.Method;
+
+public record TitanListenerEndpoint(
+    String id,
+    String destination,
+    Object bean,
+    Method method,
+    String clientRef,
+    int concurrency
+) {}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerEndpointRegistry.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListenerEndpointRegistry.java
@@ -1,0 +1,31 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class TitanListenerEndpointRegistry implements SmartLifecycle {
+
+    private final List<TitanMessageListenerContainer> containers = new ArrayList<>();
+
+    public void register(TitanListenerEndpoint endpoint, BeanFactory beanFactory) {
+        TitanClientManager manager = beanFactory.getBean(endpoint.clientRef(), TitanClientManager.class);
+        HandlerMethodArgumentResolverComposite resolvers = beanFactory.getBean(HandlerMethodArgumentResolverComposite.class);
+        containers.add(new TitanMessageListenerContainer(endpoint, manager, resolvers));
+    }
+
+    public void start() {
+        containers.forEach(TitanMessageListenerContainer::start);
+    }
+
+    public void stop() {
+        containers.forEach(TitanMessageListenerContainer::stop);
+    }
+
+    public boolean isRunning() {
+        return containers.stream().allMatch(TitanMessageListenerContainer::isRunning);
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListeners.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanListeners.java
@@ -1,0 +1,39 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author yun
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TitanListeners {
+
+    TitanListener[] value();
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanMessageListenerContainer.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanMessageListenerContainer.java
@@ -1,0 +1,80 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class TitanMessageListenerContainer {
+
+    private final TitanListenerEndpoint endpoint;
+    private final TitanClientManager manager;
+    private final HandlerMethodArgumentResolverComposite argumentResolvers;
+
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    public TitanMessageListenerContainer(
+            TitanListenerEndpoint endpoint,
+            TitanClientManager manager,
+            HandlerMethodArgumentResolverComposite argumentResolvers
+    ) {
+        this.endpoint = endpoint;
+        this.manager = manager;
+        this.argumentResolvers = argumentResolvers;
+    }
+
+    public void start() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            StompClientConnection conn = manager.connection();
+            conn.subscribe(endpoint.destination(), frame -> {
+                try {
+                    invoke(frame); // payload binding
+                } catch (Exception e) {
+                    // TODO: error handler, nack/retry policy
+                }
+            });
+        } catch (Exception e) {
+            running.set(false);
+            throw new IllegalStateException("Failed to start listener " + endpoint.id(), e);
+        }
+    }
+
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+
+        try {
+            StompClientConnection conn = manager.currentConnection();
+            if(conn == null) {
+                return;
+            }
+
+            if (conn.isConnected()) {
+                conn.unsubscribe(endpoint.destination());
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to stop listener " + endpoint.id(), e);
+        }
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    private void invoke(StompFrame frame) throws Exception {
+        Message<byte[]> springMessage = TitanSpringMessageAdapter.from(frame);
+
+        InvocableHandlerMethod invocable = new InvocableHandlerMethod(endpoint.bean(), endpoint.method());
+        invocable.setMessageMethodArgumentResolvers(this.argumentResolvers);
+        invocable.invoke(springMessage);
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -1,0 +1,181 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.titan")
+public class TitanProperties {
+
+    private boolean enabled = true;
+
+    private boolean autoStart = true;
+
+    private boolean autoConnect = true;
+
+    private int primaryThreads = 1;
+
+    private int secondaryThreads = Runtime.getRuntime().availableProcessors();
+
+    private String host = "127.0.0.1";
+
+    private int port = 61613;
+
+    private String login = "guest";
+
+    private String passcode = "guest";
+
+    private String virtualHost = "guest";
+
+    private long connectTimeoutMillis = 30000L;
+
+    private long heartbeatX = 1000L;
+
+    private long heartbeatY = 1000L;
+
+    private int maxFrameLength = 65536;
+
+    private boolean autoComputeContentLength = true;
+
+    private boolean useStompFrame = false;
+
+    private boolean bypassHostHeader = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isAutoStart() {
+        return autoStart;
+    }
+
+    public void setAutoStart(boolean autoStart) {
+        this.autoStart = autoStart;
+    }
+
+    public boolean isAutoConnect() {
+        return autoConnect;
+    }
+
+    public void setAutoConnect(boolean autoConnect) {
+        this.autoConnect = autoConnect;
+    }
+
+    public int getPrimaryThreads() {
+        return primaryThreads;
+    }
+
+    public void setPrimaryThreads(int primaryThreads) {
+        this.primaryThreads = primaryThreads;
+    }
+
+    public int getSecondaryThreads() {
+        return secondaryThreads;
+    }
+
+    public void setSecondaryThreads(int secondaryThreads) {
+        if (secondaryThreads <= 0) {
+            this.secondaryThreads = Runtime.getRuntime().availableProcessors();
+            return;
+        }
+        this.secondaryThreads = secondaryThreads;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    public String getPasscode() {
+        return passcode;
+    }
+
+    public void setPasscode(String passcode) {
+        this.passcode = passcode;
+    }
+
+    public String getVirtualHost() {
+        return virtualHost;
+    }
+
+    public void setVirtualHost(String virtualHost) {
+        this.virtualHost = virtualHost;
+    }
+
+    public long getConnectTimeoutMillis() {
+        return connectTimeoutMillis;
+    }
+
+    public void setConnectTimeoutMillis(long connectTimeoutMillis) {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+    }
+
+    public long getHeartbeatX() {
+        return heartbeatX;
+    }
+
+    public void setHeartbeatX(long heartbeatX) {
+        this.heartbeatX = heartbeatX;
+    }
+
+    public long getHeartbeatY() {
+        return heartbeatY;
+    }
+
+    public void setHeartbeatY(long heartbeatY) {
+        this.heartbeatY = heartbeatY;
+    }
+
+    public int getMaxFrameLength() {
+        return maxFrameLength;
+    }
+
+    public void setMaxFrameLength(int maxFrameLength) {
+        this.maxFrameLength = maxFrameLength;
+    }
+
+    public boolean isAutoComputeContentLength() {
+        return autoComputeContentLength;
+    }
+
+    public void setAutoComputeContentLength(boolean autoComputeContentLength) {
+        this.autoComputeContentLength = autoComputeContentLength;
+    }
+
+    public boolean isUseStompFrame() {
+        return useStompFrame;
+    }
+
+    public void setUseStompFrame(boolean useStompFrame) {
+        this.useStompFrame = useStompFrame;
+    }
+
+    public boolean isBypassHostHeader() {
+        return bypassHostHeader;
+    }
+
+    public void setBypassHostHeader(boolean bypassHostHeader) {
+        this.bypassHostHeader = bypassHostHeader;
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanTemplate.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanTemplate.java
@@ -1,0 +1,39 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+public final class TitanTemplate {
+
+    private final TitanClientManager clientManager;
+
+    public TitanTemplate(TitanClientManager clientManager) {
+        this.clientManager = clientManager;
+    }
+
+    public StompFrame send(String destination, String payload) throws Exception {
+        return send(destination, payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public StompFrame send(String destination, byte[] payload) throws Exception {
+        StompClientConnection connection = resolveConnection();
+        return connection.send(destination, Buffer.alloc(payload)).get(30, TimeUnit.SECONDS);
+    }
+
+    public StompFrame subscribe(String destination) throws Exception {
+        StompClientConnection connection = resolveConnection();
+        return connection.subscribe(destination).get(30, TimeUnit.SECONDS);
+    }
+
+    public StompFrame disconnect() throws Exception {
+        StompClientConnection connection = resolveConnection();
+        return connection.disconnect().get(30, TimeUnit.SECONDS);
+    }
+
+    private StompClientConnection resolveConnection() throws Exception {
+        return clientManager.connection();
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -1,0 +1,69 @@
+package org.traffichunter.titan.springframework.stomp.autoconfigure;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.transport.stomp.StompClient;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.springframework.stomp.TitanClientManager;
+import org.traffichunter.titan.springframework.stomp.TitanProperties;
+import org.traffichunter.titan.springframework.stomp.TitanTemplate;
+
+@AutoConfiguration
+@ConditionalOnClass({StompClient.class, EventLoopGroups.class})
+@EnableConfigurationProperties(TitanProperties.class)
+@ConditionalOnProperty(prefix = "titan.stomp.client", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class TitanStompClientAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "titanStompClientEventLoopGroups")
+    public EventLoopGroups titanStompClientEventLoopGroups(TitanProperties properties) {
+        return EventLoopGroups.group(properties.getPrimaryThreads(), properties.getSecondaryThreads());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public StompClientOption titanStompClientOption(TitanProperties properties) {
+        return StompClientOption.builder()
+                .host(properties.getHost())
+                .port(properties.getPort())
+                .login(properties.getLogin())
+                .passcode(properties.getPasscode())
+                .virtualHost(properties.getVirtualHost())
+                .heartbeatX(properties.getHeartbeatX())
+                .heartbeatY(properties.getHeartbeatY())
+                .maxFrameLength(properties.getMaxFrameLength())
+                .autoComputeContentLength(properties.isAutoComputeContentLength())
+                .useStompFrame(properties.isUseStompFrame())
+                .bypassHostHeader(properties.isBypassHostHeader())
+                .build();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public StompClient titanStompClient(
+            EventLoopGroups titanStompClientEventLoopGroups,
+            StompClientOption titanStompClientOption
+    ) {
+        return StompClient.open(titanStompClientEventLoopGroups, titanStompClientOption);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TitanClientManager titanStompClientManager(
+            StompClient titanStompClient,
+            TitanProperties properties
+    ) {
+        return new TitanClientManager(titanStompClient, properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public TitanTemplate titanStompTemplate(TitanClientManager titanClientManager) {
+        return new TitanTemplate(titanClientManager);
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/package-info.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.springframework.stomp.autoconfigure;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/beans/TitanListenerAnnotationBeanPostProcessor.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/beans/TitanListenerAnnotationBeanPostProcessor.java
@@ -1,0 +1,91 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp.beans;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.util.Assert;
+import org.traffichunter.titan.springframework.stomp.TitanListener;
+import org.traffichunter.titan.springframework.stomp.TitanListenerEndpoint;
+import org.traffichunter.titan.springframework.stomp.TitanListenerEndpointRegistry;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author yun
+ */
+public class TitanListenerAnnotationBeanPostProcessor implements BeanPostProcessor, BeanFactoryAware, SmartInitializingSingleton {
+
+    private final List<TitanListenerEndpoint> endpoints = new ArrayList<>();
+    private final TitanListenerEndpointRegistry registry;
+
+    private @Nullable BeanFactory beanFactory;
+
+    public TitanListenerAnnotationBeanPostProcessor(TitanListenerEndpointRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public @Nullable Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        for(Method method : bean.getClass().getMethods()) {
+            TitanListener titanListener = AnnotatedElementUtils.findMergedAnnotation(method, TitanListener.class);
+            if(titanListener == null) {
+                continue;
+            }
+
+            String id = titanListener.id().isBlank() ? beanName + "#" + method.getName() : titanListener.id();
+            TitanListenerEndpoint endpoint = new TitanListenerEndpoint(
+                    id,
+                    titanListener.destination(),
+                    bean,
+                    method,
+                    titanListener.clientRef(),
+                    titanListener.concurrency()
+            );
+
+            endpoints.add(endpoint);
+        }
+
+        return bean;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        Assert.notNull(beanFactory, "beanFactory must not be null");
+
+        endpoints.forEach(endpoint -> registry.register(endpoint, beanFactory));
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/beans/package-info.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/beans/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.springframework.stomp.beans;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
@@ -1,0 +1,47 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp.messaging;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+
+/**
+ * @author yun
+ */
+public final class TitanSpringMessageAdapter {
+
+    public static final String HDR_STOMP_FRAME = "titan.stomp.frame";
+
+    public static Message<byte[]> from(StompFrame frame) {
+        MessageBuilder<byte[]> builder = MessageBuilder.withPayload(frame.getBody().getBytes());
+
+        frame.getHeaders()
+                .entrySet()
+                .forEach(entry -> builder.setHeader(entry.getKey().getName(), entry.getValue()));
+
+        builder.setHeader(HDR_STOMP_FRAME, frame);
+        return builder.build();
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
@@ -23,6 +23,7 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.springframework.stomp.messaging;
 
+import org.jspecify.annotations.NullMarked;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
@@ -30,6 +31,7 @@ import org.traffichunter.titan.core.codec.stomp.StompFrame;
 /**
  * @author yun
  */
+@NullMarked
 public final class TitanSpringMessageAdapter {
 
     public static final String HDR_STOMP_FRAME = "titan.stomp.frame";

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/StompFrameMessageConverter.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/StompFrameMessageConverter.java
@@ -1,0 +1,55 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp.messaging.converter;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.AbstractMessageConverter;
+import org.springframework.util.MimeTypeUtils;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
+
+/**
+ * @author yun
+ */
+public final class StompFrameMessageConverter extends AbstractMessageConverter {
+
+    public StompFrameMessageConverter() {
+        super(MimeTypeUtils.ALL);
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return StompFrame.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    protected @Nullable Object convertFromInternal(Message<?> message, Class<?> targetClass, @Nullable Object conversionHint) {
+        if (!StompFrame.class.isAssignableFrom(targetClass)) {
+            return null;
+        }
+
+        return message.getHeaders().get(TitanSpringMessageAdapter.HDR_STOMP_FRAME, StompFrame.class);
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/package-info.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.springframework.stomp.messaging.converter;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanPayloadHandlerMethodArgumentResolver.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanPayloadHandlerMethodArgumentResolver.java
@@ -1,0 +1,68 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp.messaging.resolver;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.SmartMessageConverter;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+
+/**
+ * @author yun
+ */
+public class TitanPayloadHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final SmartMessageConverter messageConverter;
+
+    public TitanPayloadHandlerMethodArgumentResolver(SmartMessageConverter messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> type = parameter.getParameterType();
+
+        return !Message.class.isAssignableFrom(type) && !StompFrame.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
+        Class<?> targetType = parameter.getParameterType();
+
+        Object payload = message.getPayload();
+        if(targetType.isInstance(payload)) {
+            return payload;
+        }
+
+        Object convertedMessage = messageConverter.fromMessage(message, targetType);
+        if(convertedMessage == null) {
+            throw new MessageConversionException("Cannot convert payload to " + targetType.getName());
+        }
+
+        return convertedMessage;
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanStompHandlerMethodArgumentResolver.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanStompHandlerMethodArgumentResolver.java
@@ -1,0 +1,67 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.springframework.stomp.messaging.resolver;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.SmartMessageConverter;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+
+/**
+ * @author yun
+ */
+public class TitanStompHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final SmartMessageConverter messageConverter;
+
+    public TitanStompHandlerMethodArgumentResolver(SmartMessageConverter messageConverter) {
+        this.messageConverter = messageConverter;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        Class<?> type = parameter.getParameterType();
+
+        return Message.class.isAssignableFrom(type) || StompFrame.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
+        Class<?> targetType = parameter.getParameterType();
+
+        if (Message.class.isAssignableFrom(targetType)) {
+            return message;
+        }
+
+        Object convertedMessage = messageConverter.fromMessage(message, targetType);
+        if (convertedMessage == null) {
+            throw new MessageConversionException("Cannot convert payload to " + targetType.getName());
+        }
+
+        return convertedMessage;
+    }
+}

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/package-info.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.springframework.stomp.messaging.resolver;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/package-info.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.springframework.stomp;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-spring-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/titan-spring-client/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.traffichunter.titan.springframework.stomp.autoconfigure.TitanStompClientAutoConfiguration

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfigurationTest.java
@@ -1,0 +1,63 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.SmartMessageConverter;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.springframework.messaging.support.MessageBuilder;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
+
+class TitanListenerConfigurationTest {
+
+    @Test
+    void resolver_composite_resolves_stomp_frame_and_payload() throws Exception {
+        TitanListenerConfiguration configuration = new TitanListenerConfiguration();
+        SmartMessageConverter converter = configuration.titanMessageConverter();
+        HandlerMethodArgumentResolverComposite composite = configuration.titanResolverComposite(converter);
+
+        StompFrame frame = StompFrame.create(
+                StompHeaders.create(),
+                StompCommand.MESSAGE,
+                "hello".getBytes(StandardCharsets.UTF_8)
+        );
+        Message<byte[]> stompMessage = TitanSpringMessageAdapter.from(frame);
+
+        Object resolvedFrame = composite.resolveArgument(parameter("onFrame", StompFrame.class), stompMessage);
+        Object resolvedPayload = composite.resolveArgument(parameter("onPayload", String.class), stompMessage);
+
+        assertSame(frame, resolvedFrame);
+        assertEquals("hello", resolvedPayload);
+    }
+
+    @Test
+    void resolver_composite_resolves_message_parameter() throws Exception {
+        TitanListenerConfiguration configuration = new TitanListenerConfiguration();
+        HandlerMethodArgumentResolverComposite composite =
+                configuration.titanResolverComposite(configuration.titanMessageConverter());
+        Message<byte[]> message = MessageBuilder.withPayload("hello".getBytes(StandardCharsets.UTF_8)).build();
+
+        Object resolvedMessage = composite.resolveArgument(parameter("onMessage", Message.class), message);
+
+        assertSame(message, resolvedMessage);
+    }
+
+    private static MethodParameter parameter(String name, Class<?> type) throws NoSuchMethodException {
+        Method method = FixtureHandler.class.getDeclaredMethod(name, type);
+        return new MethodParameter(method, 0);
+    }
+
+    static final class FixtureHandler {
+        void onFrame(StompFrame frame) {}
+        void onPayload(String payload) {}
+        void onMessage(Message<byte[]> message) {}
+    }
+}

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
@@ -1,0 +1,45 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class TitanPropertiesTest {
+
+    @Test
+    void defaults_are_initialized() {
+        TitanProperties properties = new TitanProperties();
+
+        assertTrue(properties.isEnabled());
+        assertTrue(properties.isAutoStart());
+        assertTrue(properties.isAutoConnect());
+        assertEquals("127.0.0.1", properties.getHost());
+        assertEquals(61613, properties.getPort());
+        assertEquals(30000L, properties.getConnectTimeoutMillis());
+        assertTrue(properties.isAutoComputeContentLength());
+        assertFalse(properties.isUseStompFrame());
+        assertFalse(properties.isBypassHostHeader());
+    }
+
+    @Test
+    void set_secondary_threads_fallback_to_available_processors_when_non_positive() {
+        TitanProperties properties = new TitanProperties();
+
+        properties.setSecondaryThreads(0);
+        assertEquals(Runtime.getRuntime().availableProcessors(), properties.getSecondaryThreads());
+
+        properties.setSecondaryThreads(-1);
+        assertEquals(Runtime.getRuntime().availableProcessors(), properties.getSecondaryThreads());
+    }
+
+    @Test
+    void set_secondary_threads_uses_explicit_value_when_positive() {
+        TitanProperties properties = new TitanProperties();
+
+        properties.setSecondaryThreads(4);
+
+        assertEquals(4, properties.getSecondaryThreads());
+    }
+}

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanArgumentResolverTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanArgumentResolverTest.java
@@ -1,0 +1,113 @@
+package org.traffichunter.titan.springframework.stomp.messaging.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.ByteArrayMessageConverter;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.converter.SmartMessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.support.MessageBuilder;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
+import org.traffichunter.titan.springframework.stomp.messaging.converter.StompFrameMessageConverter;
+
+class TitanArgumentResolverTest {
+
+    private static final SmartMessageConverter CONVERTER = new CompositeMessageConverter(List.of(
+            new StompFrameMessageConverter(),
+            new ByteArrayMessageConverter(),
+            new StringMessageConverter(),
+            new MappingJackson2MessageConverter()
+    ));
+
+    @Test
+    void stomp_resolver_supports_message_and_stomp_frame() throws Exception {
+        TitanStompHandlerMethodArgumentResolver resolver = new TitanStompHandlerMethodArgumentResolver(CONVERTER);
+
+        assertTrue(resolver.supportsParameter(parameter("onMessage", Message.class)));
+        assertTrue(resolver.supportsParameter(parameter("onFrame", StompFrame.class)));
+        assertFalse(resolver.supportsParameter(parameter("onPayload", String.class)));
+    }
+
+    @Test
+    void stomp_resolver_returns_message_for_message_parameter() throws Exception {
+        TitanStompHandlerMethodArgumentResolver resolver = new TitanStompHandlerMethodArgumentResolver(CONVERTER);
+        Message<byte[]> message = MessageBuilder.withPayload("hello".getBytes(StandardCharsets.UTF_8)).build();
+
+        Object resolved = resolver.resolveArgument(parameter("onMessage", Message.class), message);
+
+        assertSame(message, resolved);
+    }
+
+    @Test
+    void stomp_resolver_converts_to_stomp_frame_parameter() throws Exception {
+        TitanStompHandlerMethodArgumentResolver resolver = new TitanStompHandlerMethodArgumentResolver(CONVERTER);
+        StompFrame frame = createFrame("hello");
+        Message<byte[]> message = TitanSpringMessageAdapter.from(frame);
+
+        Object resolved = resolver.resolveArgument(parameter("onFrame", StompFrame.class), message);
+
+        assertSame(frame, resolved);
+    }
+
+    @Test
+    void payload_resolver_supports_non_message_non_stomp_types_only() throws Exception {
+        TitanPayloadHandlerMethodArgumentResolver resolver = new TitanPayloadHandlerMethodArgumentResolver(CONVERTER);
+
+        assertTrue(resolver.supportsParameter(parameter("onPayload", String.class)));
+        assertFalse(resolver.supportsParameter(parameter("onMessage", Message.class)));
+        assertFalse(resolver.supportsParameter(parameter("onFrame", StompFrame.class)));
+    }
+
+    @Test
+    void payload_resolver_converts_byte_payload_to_string() throws Exception {
+        TitanPayloadHandlerMethodArgumentResolver resolver = new TitanPayloadHandlerMethodArgumentResolver(CONVERTER);
+        Message<byte[]> message = MessageBuilder.withPayload("hello".getBytes(StandardCharsets.UTF_8)).build();
+
+        Object resolved = resolver.resolveArgument(parameter("onPayload", String.class), message);
+
+        assertEquals("hello", resolved);
+    }
+
+    @Test
+    void payload_resolver_throws_when_conversion_fails() throws Exception {
+        TitanPayloadHandlerMethodArgumentResolver resolver = new TitanPayloadHandlerMethodArgumentResolver(CONVERTER);
+        Message<byte[]> message = MessageBuilder.withPayload("hello".getBytes(StandardCharsets.UTF_8)).build();
+
+        assertThrows(
+                MessageConversionException.class,
+                () -> resolver.resolveArgument(parameter("onNumber", Integer.class), message)
+        );
+    }
+
+    private static MethodParameter parameter(String name, Class<?> type) throws NoSuchMethodException {
+        Method method = FixtureHandler.class.getDeclaredMethod(name, type);
+        return new MethodParameter(method, 0);
+    }
+
+    private static StompFrame createFrame(String body) {
+        return StompFrame.create(StompHeaders.create(), StompCommand.MESSAGE, body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static final class FixtureHandler {
+        void onMessage(Message<byte[]> message) {}
+        void onFrame(StompFrame frame) {}
+        void onPayload(String payload) {}
+        void onNumber(Integer number) {}
+    }
+}


### PR DESCRIPTION
## Overview.

<!---- Resolves: #(Isuue Number) [FEAT] ... -->

This PR adds a new titan-spring-client module so Titan STOMP can be used naturally in Spring applications.
It includes auto-configuration, properties-based client setup, and a lightweight template for basic operations.
It also introduces an annotation-driven listener model (@TitanListener) with Spring-style message conversion and method argument resolution, so handlers can consume payloads, Message<?>, or StompFrame directly.
Finally, test coverage was added for properties defaults/fallback behavior and resolver wiring/conversion paths to validate the core integration flow.

## Pull Request Convention.

- [x] New feature. (feat)
- [ ] Fix bug. (fix)
- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names) (style)
- [ ] Refactor code (refactor)
- [ ] Add and edit comments (style)
- [ ] Edit docs (docs)
- [ ] Add and refactor tests (test)
- [ ] Edit the build part or package manager (chore)
- [ ] Rename file or directory (rename)
- [ ] Remove file or directory (remove)

## Opinion.