### PR TITLE
stomp: harden tx handling and connection cleanup lifecycle

### DIFF
--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
@@ -401,7 +401,7 @@ public class StompClientConnectionImpl implements StompClientConnection {
 
     private void send(StompFrame frame, Completable<StompFrame> receiptPromise) {
         Buffer body = frame.getBody();
-        if (body != null && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
+        if (!frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
             frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length()));
         }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerConnection.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerConnection.java
@@ -51,21 +51,19 @@ public interface StompServerConnection extends StompConnection {
         return new StompServerConnectionImpl(serverChannel, option);
     }
 
-    static StompServerConnection create(StompServerOption option) {
-        return new StompServerConnectionImpl(option);
-    }
-
     default Promise<Void> write(StompFrame frame) {
         return write(frame.toBuffer());
     }
 
     Promise<Void> write(Buffer buffer);
 
-    void bind(NetServerChannel serverChannel);
-
     void register(StompClientConnection connection);
 
     void unregister(String sessionId);
+
+    void cleanUp(StompClientConnection connection);
+
+    void cleanupInactiveConnections();
 
     @Nullable StompClientConnection findConnection(String sessionId);
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerConnectionImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerConnectionImpl.java
@@ -25,12 +25,15 @@ package org.traffichunter.titan.core.channel.stomp;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.traffichunter.titan.core.channel.*;
+import org.traffichunter.titan.core.codec.stomp.Transactions;
 import org.traffichunter.titan.core.codec.stomp.StompServerSubscription;
 import org.traffichunter.titan.core.codec.stomp.StompSubscriptions;
 import org.traffichunter.titan.core.concurrent.Promise;
@@ -43,11 +46,20 @@ import org.jspecify.annotations.Nullable;
  */
 public class StompServerConnectionImpl implements StompServerConnection {
 
-    private @Nullable NetServerChannel serverChannel;
+    private final NetServerChannel serverChannel;
     private final StompServerOption option;
     private final Map<String, StompClientConnection> connections = new ConcurrentHashMap<>();
     private final AtomicInteger roundRobinSequence = new AtomicInteger();
     private final StompSubscriptions<StompServerSubscription> subscriptions = new StompSubscriptions<>();
+
+    private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
+
+    enum State {
+        INIT,
+        RUNNING,
+        CLOSING,
+        CLOSED
+    }
 
     StompServerConnectionImpl(
             ChannelHandShakeEventListener channelHandShakeEventListener,
@@ -56,28 +68,26 @@ public class StompServerConnectionImpl implements StompServerConnection {
         try {
             this.serverChannel = NetServerChannel.open(channelHandShakeEventListener);
             this.option = option;
+            state.set(State.RUNNING);
         } catch (IOException e) {
             throw new StompNetServeChannelException("Not open channel", e);
         }
     }
 
-    StompServerConnectionImpl(StompServerOption option) {
-        this.option = option;
-    }
-
     StompServerConnectionImpl(NetServerChannel serverChannel, StompServerOption option) {
         this.serverChannel = serverChannel;
         this.option = option;
+        state.set(State.RUNNING);
     }
 
     @Override
     public Channel channel() {
-        return requireServerChannel();
+        return serverChannel;
     }
 
     @Override
     public String session() {
-        return requireServerChannel().session();
+        return serverChannel.session();
     }
 
     @Override
@@ -85,7 +95,7 @@ public class StompServerConnectionImpl implements StompServerConnection {
         StompClientConnection connection = nextConnection();
         if (connection == null) {
             return Promise.failedPromise(
-                    requireServerChannel().eventLoop(),
+                    serverChannel.eventLoop(),
                     new StompNetServeChannelException("No active STOMP client connections")
             );
         }
@@ -96,12 +106,60 @@ public class StompServerConnectionImpl implements StompServerConnection {
 
     @Override
     public void register(StompClientConnection connection) {
+
+        State current = state.get();
+        if (current != State.RUNNING) {
+            connection.close();
+            return;
+        }
+
         connections.put(connection.session(), connection);
+
+        State afterRegister = state.get();
+        if (afterRegister == State.CLOSING || afterRegister == State.CLOSED) {
+            cleanUp(connection);
+            connection.close();
+        }
     }
 
     @Override
     public void unregister(String sessionId) {
-        connections.remove(sessionId);
+        StompClientConnection connection = connections.get(sessionId);
+        if (connection != null) {
+            cleanUp(connection);
+        }
+    }
+
+    @Override
+    public void cleanUp(StompClientConnection connection) {
+        if (state.get() == State.CLOSED) {
+            return;
+        }
+
+        connections.remove(connection.session());
+
+        List<String> subscriptionIds = subscriptions.values().stream()
+                .filter(subscription -> connection.equals(subscription.getConnection()))
+                .map(StompServerSubscription::id)
+                .toList();
+        subscriptionIds.forEach(subscriptions::unregister);
+
+        Transactions.getInstance().removeTransactions(connection);
+    }
+
+    @Override
+    public void cleanupInactiveConnections() {
+        State current = state.get();
+        if (current != State.RUNNING && current != State.CLOSING) {
+            return;
+        }
+
+        connections.values().forEach(connection -> {
+            Channel channel = connection.channel();
+            if (channel.isClosed() || !channel.isActive()) {
+                cleanUp(connection);
+            }
+        });
     }
 
     @Override
@@ -131,12 +189,12 @@ public class StompServerConnectionImpl implements StompServerConnection {
 
     @Override
     public Instant setLastActivatedAt() {
-        return requireServerChannel().setLastActivatedAt();
+        return serverChannel.setLastActivatedAt();
     }
 
     @Override
     public Instant lastActivatedAt() {
-        return requireServerChannel().lastActivatedAt();
+        return serverChannel.lastActivatedAt();
     }
 
     @Override
@@ -146,14 +204,20 @@ public class StompServerConnectionImpl implements StompServerConnection {
 
     @Override
     public void close() {
-        connections.values().forEach(StompClientConnection::close);
-        connections.clear();
-        requireServerChannel().close();
-    }
+        if (!state.compareAndSet(State.RUNNING, State.CLOSING)
+                && !state.compareAndSet(State.INIT, State.CLOSING)) {
+            return;
+        }
 
-    @Override
-    public void bind(NetServerChannel serverChannel) {
-        this.serverChannel = serverChannel;
+        try {
+            Collection<StompClientConnection> activeConnections = connections.values();
+            activeConnections.forEach(this::cleanUp);
+            activeConnections.forEach(StompClientConnection::close);
+            connections.clear();
+            serverChannel.close();
+        } finally {
+            state.set(State.CLOSED);
+        }
     }
 
     @Override
@@ -179,23 +243,10 @@ public class StompServerConnectionImpl implements StompServerConnection {
 
     private boolean isActive(StompClientConnection connection) {
         Channel channel = connection.channel();
-        if (channel.isClosed() || !channel.isActive()) {
-            unregister(connection.session());
-            return false;
-        }
-
-        return true;
+        return !(channel.isClosed() || !channel.isActive());
     }
 
     private NetChannel asNetChannel(StompClientConnection connection) {
         return connection.channel();
-    }
-
-    private NetServerChannel requireServerChannel() {
-        NetServerChannel channel = serverChannel;
-        if (channel == null) {
-            throw new StompNetServeChannelException("Server channel is not bound");
-        }
-        return channel;
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
@@ -33,7 +33,6 @@ import org.traffichunter.titan.core.util.secure.auth.authentication.UsernamePass
 
 import java.util.Optional;
 
-import static org.traffichunter.titan.core.codec.stomp.StompFrame.*;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.create;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.formatString;
@@ -239,6 +238,7 @@ public final class StompServerHandlerImpl implements StompServerHandler {
             @Override
             public void handle(StompServerEvent event, StompServerHandlerContext context) {
                 context.receipt(event.frame(), event.connection());
+                context.serverConnection().cleanUp(event.connection());
                 event.connection().close();
             }
         }
@@ -441,19 +441,11 @@ public final class StompServerHandlerImpl implements StompServerHandler {
                         );
                         sc.send(errorFrame("Unknown transaction", formatString("Unknown transaction id = {}", txId)));
                         sc.close();
+                        return;
                     }
-                    return;
-                }
 
-                if(!Transactions.getInstance().registerTransaction(sc, id)) {
-                    log.warn(
-                            "Failed to ACK due to transaction registration failure. session={}, id={}",
-                            sc.session(),
-                            id
-                    );
-                    Transactions.getInstance().removeTransactions(sc);
-                    sc.send(errorFrame("Failed transaction", formatString("Failed transaction add id = {}", id)));
-                    sc.close();
+                    transaction.addFrame(sf);
+                    context.receipt(sf, sc);
                     return;
                 }
 
@@ -489,19 +481,11 @@ public final class StompServerHandlerImpl implements StompServerHandler {
                         );
                         sc.send(errorFrame("Unknown transaction.", formatString("Unknown transaction id = {}", txId)));
                         sc.close();
+                        return;
                     }
-                    return;
-                }
 
-                if(!Transactions.getInstance().registerTransaction(sc, id)) {
-                    log.warn(
-                            "Failed to NACK due to transaction registration failure. session={}, id={}",
-                            sc.session(),
-                            id
-                    );
-                    Transactions.getInstance().removeTransactions(sc);
-                    sc.send(errorFrame("Failed to transaction.", formatString("Failed to transaction add id = {}", id)));
-                    sc.close();
+                    transaction.addFrame(sf);
+                    context.receipt(sf, sc);
                     return;
                 }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transaction.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transaction.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 
 /**
+ * Transaction is thread safe.
+ *
  * @author yungwang-o
  */
 @Getter

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transactions.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transactions.java
@@ -59,11 +59,12 @@ public final class Transactions {
     }
 
     public synchronized boolean removeTransaction(final StompClientConnection sc, final String txId) {
-        if(getTransaction(sc, txId) == null) {
+        Transaction tx = getTransaction(sc, txId);
+        if (tx == null) {
             return false;
         }
 
-        return transactions.remove(Transaction.create(sc, txId));
+        return transactions.remove(tx);
     }
 
     @CanIgnoreReturnValue
@@ -73,6 +74,10 @@ public final class Transactions {
         }
 
         return transactions.removeIf(transaction -> transaction.getStompClientConnection().equals(sc));
+    }
+
+    public synchronized void clear() {
+        transactions.clear();
     }
 
     public synchronized int size() {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -37,6 +37,7 @@ import org.traffichunter.titan.core.codec.stomp.StompChannelDecoder;
 import org.traffichunter.titan.core.codec.stomp.StompException;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
@@ -56,14 +57,15 @@ public final class StompServer {
     private StompClientOption childOption = StompClientOption.DEFAULT_STOMP_CLIENT_OPTION;
     private Handler<StompServerHandler> stompServerHandler = handler -> {};
     private Handler<Channel> channelHandler = channel -> {};
+    private @Nullable ScheduledPromise<?> inactiveConnectionCleanupTask;
 
     private StompServer(EventLoopGroups groups, @Nullable InetServer inetServer, StompServerOption option) {
         this.option = option;
-        this.serverConnection = StompServerConnection.create(option);
         if(inetServer == null) {
-            inetServer = initializeInetServer(groups);
+            inetServer = InetServer.open(groups);
         }
         this.inetServer = inetServer;
+        this.serverConnection = StompServerConnection.wrap(inetServer.channel(), option);
     }
 
     public static StompServer open(EventLoopGroups groups, StompServerOption option) {
@@ -94,6 +96,10 @@ public final class StompServer {
 
     @CanIgnoreReturnValue
     public StompServer start() {
+        if(isShutdown()) {
+            throw new StompException("Server has been shut down");
+        }
+
         StompClientOption stompClientOption = serverChildSessionOption(option, childOption);
         StompServerHandler stompServerHandler = new StompServerHandlerImpl(serverConnection);
         this.stompServerHandler.handle(stompServerHandler);
@@ -115,9 +121,13 @@ public final class StompServer {
                     channelHandler.handle(netChannel);
                 });
 
-        serverConnection.bind(inetServer.channel());
-
         inetServer.start();
+        inactiveConnectionCleanupTask = serverConnection.channel().eventLoop().scheduleAtFixedRate(
+                serverConnection::cleanupInactiveConnections,
+                1,
+                1,
+                TimeUnit.SECONDS
+        );
         log.info(
                 "Started STOMP server engine. session={}, version={}, secured={}, sendErrorOnNoSubscriptions={}",
                 serverConnection.session(),
@@ -157,6 +167,11 @@ public final class StompServer {
 
     public void shutdown(long timeout, TimeUnit unit) {
         Assert.checkState(inetServer.isStart(), "inetServer is not started");
+        ScheduledPromise<?> task = inactiveConnectionCleanupTask;
+        if (task != null) {
+            task.cancel();
+            inactiveConnectionCleanupTask = null;
+        }
         inetServer.shutdown(timeout, unit);
     }
 
@@ -176,10 +191,6 @@ public final class StompServer {
                         resultPromise.fail(new StompException("Failed to listen on address " + address, listenFuture.error()));
                     }
                 });
-    }
-
-    private InetServer initializeInetServer(EventLoopGroups groups) {
-        return InetServer.open(groups);
     }
 
     private static StompClientOption serverChildSessionOption(StompServerOption option, StompClientOption childOption) {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
@@ -40,10 +40,13 @@ import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.codec.stomp.Transaction;
+import org.traffichunter.titan.core.codec.stomp.Transactions;
 import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
 import org.traffichunter.titan.core.message.Message;
@@ -294,11 +297,58 @@ class StompIntegrationTest {
             client.start();
             client.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
 
+            final StompClientConnection serverConnection = awaitSingleServerConnection(testServer);
             String txId = "tx-" + UUID.randomUUID();
             client.connection().begin(txId).get(3, TimeUnit.SECONDS);
             client.connection().ack("msg-3", txId).get(3, TimeUnit.SECONDS);
+
+            await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+                Transaction transaction = Transactions.getInstance().getTransaction(serverConnection, txId);
+                assertThat(transaction).isNotNull();
+                assertThat(transaction.getFrames()).hasSize(1);
+                assertThat(transaction.getFrames().getFirst().getCommand()).isEqualTo(StompCommand.ACK);
+                assertThat(transaction.getFrames().getFirst().getHeader(Elements.ID)).isEqualTo("msg-3");
+            });
+
             client.connection().commit(txId).get(3, TimeUnit.SECONDS);
+
+            await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+                    assertThat(Transactions.getInstance().getTransaction(serverConnection, txId)).isNull());
         } finally {
+            testServer.server().connection().connections()
+                    .forEach(connection -> Transactions.getInstance().removeTransactions(connection));
+            client.shutdown();
+        }
+    }
+
+    @Test
+    void stomp_nack_within_transaction_test(StompTestServer testServer) throws Exception {
+        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+
+        try {
+            client.start();
+            client.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
+
+            final StompClientConnection serverConnection = awaitSingleServerConnection(testServer);
+            String txId = "tx-" + UUID.randomUUID();
+            client.connection().begin(txId).get(3, TimeUnit.SECONDS);
+            client.connection().nack("msg-4", txId).get(3, TimeUnit.SECONDS);
+
+            await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+                Transaction transaction = Transactions.getInstance().getTransaction(serverConnection, txId);
+                assertThat(transaction).isNotNull();
+                assertThat(transaction.getFrames()).hasSize(1);
+                assertThat(transaction.getFrames().getFirst().getCommand()).isEqualTo(StompCommand.NACK);
+                assertThat(transaction.getFrames().getFirst().getHeader(Elements.ID)).isEqualTo("msg-4");
+            });
+
+            client.connection().abort(txId).get(3, TimeUnit.SECONDS);
+
+            await().atMost(3, TimeUnit.SECONDS).untilAsserted(() ->
+                    assertThat(Transactions.getInstance().getTransaction(serverConnection, txId)).isNull());
+        } finally {
+            testServer.server().connection().connections()
+                    .forEach(connection -> Transactions.getInstance().removeTransactions(connection));
             client.shutdown();
         }
     }
@@ -445,6 +495,15 @@ class StompIntegrationTest {
                 client.shutdown();
             }
         }
+    }
+
+    private static StompClientConnection awaitSingleServerConnection(StompTestServer testServer) {
+        AtomicReference<StompClientConnection> holder = new AtomicReference<>();
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(testServer.server().connection().connections()).isNotEmpty();
+            holder.set(testServer.server().connection().connections().getFirst());
+        });
+        return holder.get();
     }
 
     @NullMarked


### PR DESCRIPTION
## Overview.

This PR hardens STOMP transaction and connection lifecycle handling by fixing ACK/NACK transactional behavior and adding tests that verify transaction frame buffering and cleanup after COMMIT/ABORT.
It also introduces state-based server connection shutdown and unified per-connection cleanup (connections/subscriptions/transactions) to prevent stale state on DISCONNECT, socket close, and heartbeat-timeout paths.

<!---- Resolves: #(Isuue Number) [FEAT] ... -->

## Pull Request Convention.

- [ ] New feature. (feat)
- [x] Fix bug. (fix)
- [x] Changes that do not affect the code (correct typos, change tab size, change variable names) (style)
- [x] Refactor code (refactor)
- [ ] Add and edit comments (style)
- [ ] Edit docs (docs)
- [ ] Add and refactor tests (test)
- [ ] Edit the build part or package manager (chore)
- [ ] Rename file or directory (rename)
- [ ] Remove file or directory (remove)

## Opinion.