### PR TITLE
Add Vert.x STOMP transport support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,13 @@
-## Overview.
+## Motivation:
 
-<!---- Resolves: #(Isuue Number) [FEAT] ... -->
+Explain here the context, and why you're making that change. What is the problem you're trying to solve.
 
-## Pull Request Convention.
+## Modification:
 
-- [ ] New feature. (feat)
-- [ ] Fix bug. (fix)
-- [ ] Changes that do not affect the code (correct typos, change tab size, change variable names) (style)
-- [ ] Refactor code (refactor)
-- [ ] Add and edit comments (style)
-- [ ] Edit docs (docs)
-- [ ] Add and refactor tests (test)
-- [ ] Edit the build part or package manager (chore)
-- [ ] Rename file or directory (rename)
-- [ ] Remove file or directory (remove)
+Describe the modifications you've done.
 
-## Opinion.
+## Result:
+
+Fixes #.
+
+If there is no issue then describe the changes introduced by this PR.

--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
@@ -6,6 +6,9 @@ import java.util.List;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -24,7 +27,7 @@ import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.Priority;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 import org.traffichunter.titan.fanout.FanoutGateway;
 import org.traffichunter.titan.fanout.FanoutMode;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
@@ -109,6 +112,7 @@ public class FanoutGatewayBenchmark {
         return messages;
     }
 
+    @NullMarked
     private static final class CountingNoopExporter implements FanoutExporter {
         private final LongAdder count;
 
@@ -122,13 +126,13 @@ public class FanoutGatewayBenchmark {
         }
 
         @Override
-        public CompletableResult export(Destination destination, Buffer payload) {
+        public @Nullable AggregationResult export(Destination destination, Buffer payload) {
             count.increment();
             return null;
         }
 
         @Override
-        public CompletableResult export(Destination destination, Message payload) {
+        public @Nullable AggregationResult export(Destination destination, Message payload) {
             count.increment();
             return null;
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,6 +10,11 @@ dependencies {
     implementation(project.libs.jetty.servlet)
     implementation(project.libs.jetty.http)
 
+    // netty
+    implementation(project.libs.netty.transport)
+    implementation(project.libs.netty.codec)
+    implementation(project.libs.netty.handler)
+
     // jackson
     implementation(project.libs.jackson.databind)
 

--- a/fanout/build.gradle.kts
+++ b/fanout/build.gradle.kts
@@ -1,4 +1,6 @@
 dependencies {
     implementation(project(":core"))
     implementation(project(":titan-stomp"))
+
+    implementation(project.libs.vertx.stomp)
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/AggregationResult.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/AggregationResult.java
@@ -24,8 +24,6 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.Destination;
 
 /**
@@ -33,73 +31,63 @@ import org.traffichunter.titan.core.util.Destination;
  *
  * <p>Fanout delivery can target zero, one, or many consumers. This object keeps
  * the destination set, the number of attempted writes, and the success/failure
- * counters in one place. Its promise is completed when all attempted writes have
- * reported a result. An export with no targets completes immediately.</p>
+ * counters in one place.</p>
  */
-public final class CompletableResult {
+public final class AggregationResult {
 
     private final Collection<Destination> destinations;
     private final int totalAttempted;
-    private final Promise<CompletableResult> promise;
-    private final AtomicInteger done;
-    private final AtomicInteger succeeded;
-    private final AtomicInteger failed;
+    private int done;
+    private int succeeded;
+    private int failed;
 
-    private CompletableResult(
+    private AggregationResult(
             Collection<Destination> destinations,
             int totalAttempted,
-            Promise<CompletableResult> promise,
             int done,
             int succeeded,
             int failed
     ) {
         this.destinations = destinations;
         this.totalAttempted = totalAttempted;
-        this.promise = promise;
-        this.done = new AtomicInteger(done);
-        this.succeeded = new AtomicInteger(succeeded);
-        this.failed = new AtomicInteger(failed);
+        this.done = done;
+        this.succeeded = succeeded;
+        this.failed = failed;
     }
 
-    public static CompletableResult create(
-            Collection<Destination> destinations,
-            int attempted,
-            Promise<CompletableResult> promise
-    ) {
-        CompletableResult result = new CompletableResult(destinations, attempted, promise, 0, 0, 0);
-        if (attempted == 0) {
-            promise.trySuccess(result);
-        }
-        return result;
+    public static AggregationResult create(Collection<Destination> destinations, int attempted) {
+        return new AggregationResult(
+                destinations,
+                attempted,
+                0,
+                0,
+                0
+        );
     }
 
-    public static CompletableResult completed(
+    public static AggregationResult completed(
             Collection<Destination> destinations,
             int attempted,
             int succeeded,
-            int failed,
-            Promise<CompletableResult> promise
+            int failed
     ) {
-        CompletableResult result = new CompletableResult(
+        return new AggregationResult(
                 destinations,
                 attempted,
-                promise,
                 attempted,
                 succeeded,
                 failed
         );
-        promise.trySuccess(result);
-        return result;
     }
 
-    public void markSuccess() {
-        succeeded.incrementAndGet();
-        completeIfDone();
+    public void success() {
+        succeeded++;
+        incrementDone();
     }
 
-    public void markFailure() {
-        failed.incrementAndGet();
-        completeIfDone();
+    public void fail() {
+        failed++;
+        incrementDone();
     }
 
     public Collection<Destination> destinations() {
@@ -111,28 +99,26 @@ public final class CompletableResult {
     }
 
     public int done() {
-        return done.get();
+        return done;
     }
 
     public int succeeded() {
-        return succeeded.get();
+        return succeeded;
     }
 
     public int failed() {
-        return failed.get();
+        return failed;
     }
 
     public boolean isSuccess() {
-        return done() == totalAttempted && failed() == 0;
+        return isDone() && failed() == 0;
     }
 
-    public Promise<CompletableResult> promise() {
-        return promise;
+    public boolean isDone() {
+        return done() >= totalAttempted;
     }
 
-    private void completeIfDone() {
-        if (done.incrementAndGet() == totalAttempted) {
-            promise.trySuccess(this);
-        }
+    private void incrementDone() {
+        done++;
     }
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/ManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/ManagedServerFanoutAdapter.java
@@ -1,0 +1,66 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+
+/**
+ * Adapter SPI for installing fanout behavior into a concrete managed server.
+ */
+public interface ManagedServerFanoutAdapter {
+
+    static List<ManagedServerFanoutAdapter> load() {
+        return ServiceLoader.load(ManagedServerFanoutAdapter.class, ManagedServerFanoutAdapter.class.getClassLoader())
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparingInt(ManagedServerFanoutAdapter::order))
+                .toList();
+    }
+
+    default int order() {
+        return 0;
+    }
+
+    boolean supports(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer
+    );
+
+    void apply(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer,
+            Function<FanoutExporter, FanoutGateway> gatewayFactory
+    );
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
@@ -4,8 +4,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.spi.*;
-import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
 
 /**
  * SPI launcher that installs fanout behavior into a managed STOMP server.
@@ -13,7 +13,7 @@ import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
  * <p>The bootstrap/core SPI discovers this class as a {@link FanoutLauncher}.
  * When the managed server is STOMP, the launcher creates a fanout gateway,
  * connects it to the server-side STOMP connection registry through
- * {@link StompFanoutExporter}, and registers {@link StompSendToFanoutHandler}
+ * {@link StompServerFanoutLauncher}, and registers {@link StompSendToFanoutHandler}
  * as the SEND command ingress.</p>
  *
  * <pre>{@code
@@ -23,7 +23,7 @@ import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
  * Managed STOMP server
  *      |
  *      v
- * FanoutStompServerLauncher.apply(...)
+ * StompServerFanoutLauncher.apply(...)
  *      |
  *      v
  * SEND handler -> FanoutGateway -> StompFanoutExporter
@@ -31,7 +31,7 @@ import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
  */
 @Slf4j
 @SuppressWarnings("unused")
-public final class FanoutStompServerLauncher implements FanoutLauncher {
+public final class StompServerFanoutLauncher implements FanoutLauncher {
 
     private static final String OPTION_FANOUT_MODE = "fanout-mode";
 
@@ -42,8 +42,7 @@ public final class FanoutStompServerLauncher implements FanoutLauncher {
             final Map<String, String> protocolOptions,
             final ManagedServer managedServer
     ) {
-        return managedServer instanceof StompManagedServer
-                && "stomp".equalsIgnoreCase(protocol);
+        return "stomp".equalsIgnoreCase(protocol) && findAdapter(protocol, transport, protocolOptions, managedServer) != null;
     }
 
     @Override
@@ -53,16 +52,29 @@ public final class FanoutStompServerLauncher implements FanoutLauncher {
             final Map<String, String> protocolOptions,
             final ManagedServer managedServer
     ) {
-        StompManagedServer stompManagedServer = (StompManagedServer) managedServer;
         FanoutMode mode = resolveMode(protocolOptions);
-        FanoutGateway fanoutGateway = mode.fanoutGateway(new StompFanoutExporter(stompManagedServer.server().connection()));
-        StompSendToFanoutHandler stompSendToFanoutHandler = new StompSendToFanoutHandler(fanoutGateway);
+        ManagedServerFanoutAdapter adapter = findAdapter(protocol, transport, protocolOptions, managedServer);
+        if (adapter == null) {
+            throw new IllegalStateException("No fanout adapter for protocol=" + protocol + ", transport=" + transport);
+        }
 
-        stompManagedServer.server().onStomp(handler ->
-                handler.sendHandler(stompSendToFanoutHandler)
-        );
+        adapter.apply(protocol, transport, protocolOptions, managedServer, mode::fanoutGateway);
+        log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), managedServer.name());
+    }
 
-        log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), stompManagedServer.name());
+    private static @Nullable ManagedServerFanoutAdapter findAdapter(
+            final String protocol,
+            final String transport,
+            final Map<String, String> protocolOptions,
+            final ManagedServer managedServer
+    ) {
+        for (ManagedServerFanoutAdapter adapter : ManagedServerFanoutAdapter.load()) {
+            if (adapter.supports(protocol, transport, protocolOptions, managedServer)) {
+                return adapter;
+            }
+        }
+
+        return null;
     }
 
     private static FanoutMode resolveMode(final Map<String, String> protocolOptions) {

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
@@ -1,0 +1,71 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.core.spi.StompManagedServer;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Fanout adapter for Titan's own STOMP managed server.
+ */
+@Slf4j
+public final class TitanStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    @Override
+    public boolean supports(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer
+    ) {
+        return managedServer instanceof StompManagedServer
+                && "stomp".equalsIgnoreCase(protocol);
+    }
+
+    @Override
+    public void apply(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer,
+            Function<FanoutExporter, FanoutGateway> gatewayFactory
+    ) {
+        StompManagedServer stompManagedServer = (StompManagedServer) managedServer;
+        FanoutGateway fanoutGateway = gatewayFactory.apply(
+                new StompFanoutExporter(stompManagedServer.server().connection())
+        );
+
+        stompManagedServer.server().onStomp(handler ->
+                handler.sendHandler(new StompSendToFanoutHandler(fanoutGateway))
+        );
+
+        log.info("Fanout adapter installed for server={}", managedServer.name());
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
@@ -1,0 +1,71 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.core.spi.vertx.VertxStompManagedServer;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+import org.traffichunter.titan.fanout.exporter.VertxStompFanoutExporter;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Fanout adapter for Vert.x's native STOMP managed server.
+ */
+@Slf4j
+public final class VertxStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    @Override
+    public boolean supports(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer
+    ) {
+        return managedServer instanceof VertxStompManagedServer
+                && "stomp".equalsIgnoreCase(protocol)
+                && "vertx".equalsIgnoreCase(transport);
+    }
+
+    @Override
+    public void apply(
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer,
+            Function<FanoutExporter, FanoutGateway> gatewayFactory
+    ) {
+        VertxStompManagedServer vertxStompManagedServer = (VertxStompManagedServer) managedServer;
+        FanoutGateway fanoutGateway = gatewayFactory.apply(
+                new VertxStompFanoutExporter(vertxStompManagedServer.server())
+        );
+
+        vertxStompManagedServer.server().stompHandler()
+                .sendHandler(new VertxStompSendToFanoutHandler(fanoutGateway));
+
+        log.info("Fanout adapter installed for server={}", managedServer.name());
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
@@ -1,0 +1,95 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.stomp.Frame;
+import io.vertx.ext.stomp.Frames;
+import io.vertx.ext.stomp.ServerFrame;
+import io.vertx.ext.stomp.utils.Headers;
+import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.time.Instant;
+
+/**
+ * Vert.x STOMP ingress adapter that publishes SEND frames through Titan fanout.
+ */
+@Slf4j
+public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame> {
+
+    private final FanoutGateway fanoutGateway;
+
+    public VertxStompSendToFanoutHandler(FanoutGateway fanoutGateway) {
+        this.fanoutGateway = fanoutGateway;
+    }
+
+    @Override
+    public void handle(ServerFrame serverFrame) {
+        Frame frame = serverFrame.frame();
+        String destination = frame.getDestination();
+        if (destination == null || destination.isBlank()) {
+            log.warn("Rejected Vert.x fanout publish due to missing destination. session={}", serverFrame.connection().session());
+            serverFrame.connection().write(Frames.createErrorFrame(
+                    "Wrong send.",
+                    Headers.create(frame.getHeaders()),
+                    "Wrong send destination id, Id is required."
+            ));
+            serverFrame.connection().close();
+            return;
+        }
+
+        io.vertx.core.buffer.Buffer body = frame.getBody();
+        Message message = Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(Destination.create(destination))
+                .createdAt(Instant.now())
+                .producerId(serverFrame.connection().session())
+                .body(Buffer.alloc(body == null ? new byte[]{} : body.getBytes()))
+                .build();
+
+        try {
+            fanoutGateway.publish(message);
+        } catch (Exception e) {
+            log.error(
+                    "Failed to publish Vert.x fanout message. session={}, destination={}",
+                    serverFrame.connection().session(),
+                    destination,
+                    e
+            );
+            serverFrame.connection().write(Frames.createErrorFrame(
+                    "Failed to publish.",
+                    Headers.create(frame.getHeaders()),
+                    "Failed to publish inbound SEND frame."
+            ));
+            serverFrame.connection().close();
+            return;
+        }
+
+        Frames.handleReceipt(frame, serverFrame.connection());
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/FanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/FanoutExporter.java
@@ -28,14 +28,14 @@ import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.util.inet.Frame;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 
 /**
  * Protocol boundary for writing a fanout payload to subscribed clients.
  *
  * <p>The gateway calls exporters after a message has been routed to a
  * destination queue. Implementations should find the currently eligible
- * consumers for the destination and return a {@link CompletableResult} that
+ * consumers for the destination and return a {@link AggregationResult} that
  * reports how many writes were attempted and completed.</p>
  */
 public interface FanoutExporter {
@@ -43,15 +43,15 @@ public interface FanoutExporter {
     String name();
 
     @CanIgnoreReturnValue
-    default CompletableResult export(Destination destination, Frame<?, ?> payload) {
+    default AggregationResult export(Destination destination, Frame<?, ?> payload) {
         return export(destination, payload.toBuffer());
     }
 
     @CanIgnoreReturnValue
-    default CompletableResult export(Destination destination, Message payload) {
+    default AggregationResult export(Destination destination, Message payload) {
         return export(destination, Buffer.alloc(payload.getBody()));
     }
 
     @CanIgnoreReturnValue
-    CompletableResult export(Destination destination, Buffer payload);
+    AggregationResult export(Destination destination, Buffer payload);
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/StompFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/StompFanoutExporter.java
@@ -32,7 +32,7 @@ import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 
 import java.util.List;
 
@@ -63,15 +63,13 @@ public class StompFanoutExporter implements FanoutExporter {
     }
 
     @Override
-    public CompletableResult export(Destination destination, Buffer message) {
+    public AggregationResult export(Destination destination, Buffer message) {
         List<StompServerSubscription> subscriptions =
                 serverConnection.subscriptions().findByDestination(destination);
 
-        Promise<CompletableResult> resultPromise = Promise.newPromise(serverConnection.channel().eventLoop());
-        CompletableResult result = CompletableResult.create(
+        AggregationResult result = AggregationResult.create(
                 List.of(destination),
-                subscriptions.size(),
-                resultPromise
+                subscriptions.size()
         );
 
         subscriptions.forEach(subscription -> {
@@ -83,9 +81,9 @@ public class StompFanoutExporter implements FanoutExporter {
             Promise<StompFrame> sendPromise = subscription.getConnection().send(frame);
             sendPromise.addListener(sendFuture -> {
                 if (sendFuture.isSuccess()) {
-                    result.markSuccess();
+                    result.success();
                 } else {
-                    result.markFailure();
+                    result.fail();
                 }
             });
         });

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/TcpFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/TcpFanoutExporter.java
@@ -24,12 +24,11 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout.exporter;
 
 import org.traffichunter.titan.core.channel.NetChannel;
-import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 
 import java.util.List;
 
@@ -56,7 +55,7 @@ public class TcpFanoutExporter implements FanoutExporter {
     }
 
     @Override
-    public CompletableResult export(Destination destination, Buffer payload) {
+    public AggregationResult export(Destination destination, Buffer payload) {
         Assert.checkState(inetServer.isStart(), "Cannot send an unstarted inet server");
 
         int attempted = 0;
@@ -78,13 +77,11 @@ public class TcpFanoutExporter implements FanoutExporter {
             }
         }
 
-        Promise<CompletableResult> resultPromise = Promise.newPromise(inetServer.channel().eventLoop());
-        return CompletableResult.completed(
+        return AggregationResult.completed(
                 List.of(destination),
                 attempted,
                 succeeded,
-                failed,
-                resultPromise
+                failed
         );
     }
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
@@ -23,22 +23,15 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.fanout.exporter;
 
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 import io.vertx.ext.stomp.Command;
 import io.vertx.ext.stomp.Frame;
 import io.vertx.ext.stomp.StompServer;
-import org.traffichunter.titan.core.channel.EventLoop;
-import org.traffichunter.titan.core.concurrent.Promise;
-import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author yun
@@ -46,11 +39,9 @@ import java.util.concurrent.TimeUnit;
 public final class VertxStompFanoutExporter implements FanoutExporter {
 
     private final StompServer server;
-    private final EventLoop eventLoop;
 
     public VertxStompFanoutExporter(StompServer server) {
         this.server = Assert.checkNotNull(server, "server");
-        this.eventLoop = new VertxEventLoop(server.vertx().getOrCreateContext());
     }
 
     @Override
@@ -59,14 +50,13 @@ public final class VertxStompFanoutExporter implements FanoutExporter {
     }
 
     @Override
-    public CompletableResult export(Destination destination, Buffer payload) {
+    public AggregationResult export(Destination destination, Buffer payload) {
         Assert.checkState(server.isListening(), "Vert.x STOMP server is not listening");
 
         io.vertx.ext.stomp.Destination stompDestination = server.stompHandler()
                 .getDestination(destination.path());
         if (stompDestination == null) {
-            Promise<CompletableResult> resultPromise = Promise.newPromise(eventLoop);
-            return CompletableResult.completed(List.of(destination), 0, 0, 0, resultPromise);
+            return AggregationResult.completed(List.of(destination), 0, 0, 0);
         }
 
         int attempted = stompDestination.numberOfSubscriptions();
@@ -85,103 +75,11 @@ public final class VertxStompFanoutExporter implements FanoutExporter {
             failed = attempted;
         }
 
-        Promise<CompletableResult> resultPromise = Promise.newPromise(eventLoop);
-        return CompletableResult.completed(
+        return AggregationResult.completed(
                 List.of(destination),
                 attempted,
                 succeeded,
-                failed,
-                resultPromise
+                failed
         );
-    }
-
-    private static final class VertxEventLoop implements EventLoop {
-
-        private final Context context;
-
-        private VertxEventLoop(Context context) {
-            this.context = context;
-        }
-
-        @Override
-        public void start() {
-        }
-
-        @Override
-        public void register(Runnable task) {
-            context.runOnContext(ignored -> task.run());
-        }
-
-        @Override
-        public <V> Promise<V> submit(Runnable task) {
-            Promise<V> promise = Promise.newPromise(this, task);
-            register(promise);
-            return promise;
-        }
-
-        @Override
-        public <V> Promise<V> submit(Callable<V> task) {
-            Promise<V> promise = Promise.newPromise(this, task);
-            register(promise);
-            return promise;
-        }
-
-        @Override
-        public <V> ScheduledPromise<V> schedule(Runnable task, long delay, TimeUnit unit) {
-            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
-        }
-
-        @Override
-        public <V> ScheduledPromise<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
-            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
-        }
-
-        @Override
-        public <V> ScheduledPromise<V> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
-            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
-        }
-
-        @Override
-        public <V> ScheduledPromise<V> scheduleWithFixedDelay(Runnable task, long initialDelay, long period, TimeUnit unit) {
-            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
-        }
-
-        @Override
-        public boolean inEventLoop(Thread thread) {
-            return Context.isOnEventLoopThread() && Vertx.currentContext() == context;
-        }
-
-        @Override
-        public void gracefullyShutdown(long timeout, TimeUnit unit) {
-        }
-
-        @Override
-        public void close() {
-        }
-
-        @Override
-        public boolean isNotStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isStarted() {
-            return true;
-        }
-
-        @Override
-        public boolean isShuttingDown() {
-            return false;
-        }
-
-        @Override
-        public boolean isShutdown() {
-            return false;
-        }
-
-        @Override
-        public boolean isTerminated() {
-            return false;
-        }
     }
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
@@ -1,0 +1,187 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout.exporter;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.ext.stomp.Command;
+import io.vertx.ext.stomp.Frame;
+import io.vertx.ext.stomp.StompServer;
+import org.traffichunter.titan.core.channel.EventLoop;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.concurrent.ScheduledPromise;
+import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.fanout.CompletableResult;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author yun
+ */
+public final class VertxStompFanoutExporter implements FanoutExporter {
+
+    private final StompServer server;
+    private final EventLoop eventLoop;
+
+    public VertxStompFanoutExporter(StompServer server) {
+        this.server = Assert.checkNotNull(server, "server");
+        this.eventLoop = new VertxEventLoop(server.vertx().getOrCreateContext());
+    }
+
+    @Override
+    public String name() {
+        return "vertx-stomp";
+    }
+
+    @Override
+    public CompletableResult export(Destination destination, Buffer payload) {
+        Assert.checkState(server.isListening(), "Vert.x STOMP server is not listening");
+
+        io.vertx.ext.stomp.Destination stompDestination = server.stompHandler()
+                .getDestination(destination.path());
+        if (stompDestination == null) {
+            Promise<CompletableResult> resultPromise = Promise.newPromise(eventLoop);
+            return CompletableResult.completed(List.of(destination), 0, 0, 0, resultPromise);
+        }
+
+        int attempted = stompDestination.numberOfSubscriptions();
+        int succeeded = 0;
+        int failed = 0;
+
+        try {
+            Frame frame = new Frame()
+                    .setCommand(Command.SEND)
+                    .setDestination(destination.path())
+                    .setBody(io.vertx.core.buffer.Buffer.buffer(payload.getBytes()));
+            frame.addHeader(Frame.CONTENT_LENGTH, Integer.toString(payload.length()));
+            stompDestination.dispatch(null, frame);
+            succeeded = attempted;
+        } catch (Exception e) {
+            failed = attempted;
+        }
+
+        Promise<CompletableResult> resultPromise = Promise.newPromise(eventLoop);
+        return CompletableResult.completed(
+                List.of(destination),
+                attempted,
+                succeeded,
+                failed,
+                resultPromise
+        );
+    }
+
+    private static final class VertxEventLoop implements EventLoop {
+
+        private final Context context;
+
+        private VertxEventLoop(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void register(Runnable task) {
+            context.runOnContext(ignored -> task.run());
+        }
+
+        @Override
+        public <V> Promise<V> submit(Runnable task) {
+            Promise<V> promise = Promise.newPromise(this, task);
+            register(promise);
+            return promise;
+        }
+
+        @Override
+        public <V> Promise<V> submit(Callable<V> task) {
+            Promise<V> promise = Promise.newPromise(this, task);
+            register(promise);
+            return promise;
+        }
+
+        @Override
+        public <V> ScheduledPromise<V> schedule(Runnable task, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
+        }
+
+        @Override
+        public <V> ScheduledPromise<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
+        }
+
+        @Override
+        public <V> ScheduledPromise<V> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
+        }
+
+        @Override
+        public <V> ScheduledPromise<V> scheduleWithFixedDelay(Runnable task, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException("Vert.x fanout result event loop does not support scheduling");
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return Context.isOnEventLoopThread() && Vertx.currentContext() == context;
+        }
+
+        @Override
+        public void gracefullyShutdown(long timeout, TimeUnit unit) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public boolean isNotStarted() {
+            return false;
+        }
+
+        @Override
+        public boolean isStarted() {
+            return true;
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return false;
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return false;
+        }
+    }
+}

--- a/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.FanoutLauncher
+++ b/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.FanoutLauncher
@@ -1,1 +1,1 @@
-org.traffichunter.titan.fanout.FanoutStompServerLauncher
+org.traffichunter.titan.fanout.StompServerFanoutLauncher

--- a/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.fanout.ManagedServerFanoutAdapter
+++ b/fanout/src/main/resources/META-INF/services/org.traffichunter.titan.fanout.ManagedServerFanoutAdapter
@@ -1,0 +1,2 @@
+org.traffichunter.titan.fanout.TitanStompManagedServerFanoutAdapter
+org.traffichunter.titan.fanout.VertxStompManagedServerFanoutAdapter

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -49,7 +48,7 @@ import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.util.channel.ChannelRegistry;
-import org.traffichunter.titan.fanout.CompletableResult;
+import org.traffichunter.titan.fanout.AggregationResult;
 
 @ExtendWith(MockitoExtension.class)
 class FanoutExporterTest {
@@ -64,22 +63,18 @@ class FanoutExporterTest {
     private InetServer inetServer;
 
     @Test
-    void completableResult_completes_when_done_reaches_attempted() throws Exception {
-        IOEventLoop loop = immediateEventLoop();
-        Promise<CompletableResult> promise = Promise.newPromise(loop);
-        CompletableResult result = CompletableResult.create(
+    void aggregationResult_completes_when_done_reaches_attempted() {
+        AggregationResult result = AggregationResult.create(
                 List.of(Destination.create("/topic/test")),
-                2,
-                promise
+                2
         );
 
-        result.markSuccess();
-        assertThat(result.promise().isDone()).isFalse();
+        result.success();
+        assertThat(result.isDone()).isFalse();
 
-        result.markFailure();
-        result.promise().await(1, TimeUnit.SECONDS);
+        result.fail();
 
-        assertThat(result.promise().isDone()).isTrue();
+        assertThat(result.isDone()).isTrue();
         assertThat(result.done()).isEqualTo(2);
         assertThat(result.succeeded()).isEqualTo(1);
         assertThat(result.failed()).isEqualTo(1);
@@ -89,9 +84,6 @@ class FanoutExporterTest {
     @Test
     void stompFanoutExporter_aggregates_success_and_failure() throws Exception {
         IOEventLoop loop = immediateEventLoop();
-
-        when(serverConnection.channel()).thenReturn(serverChannel);
-        when(serverChannel.eventLoop()).thenReturn(loop);
 
         StompServerSubscriptions subscriptions = new StompServerSubscriptions();
         when(serverConnection.subscriptions()).thenReturn(subscriptions);
@@ -124,8 +116,7 @@ class FanoutExporterTest {
                 .build());
 
         StompFanoutExporter exporter = new StompFanoutExporter(serverConnection);
-        CompletableResult result = exporter.export(destination, Buffer.alloc("hello".getBytes()));
-        result.promise().await(1, TimeUnit.SECONDS);
+        AggregationResult result = exporter.export(destination, Buffer.alloc("hello".getBytes()));
 
         assertThat(result.totalAttempted()).isEqualTo(2);
         assertThat(result.done()).isEqualTo(2);
@@ -135,12 +126,7 @@ class FanoutExporterTest {
 
     @Test
     void tcpFanoutExporter_returns_completed_result_counts() {
-        IOEventLoop loop = immediateEventLoop();
-
         when(inetServer.isStart()).thenReturn(true);
-
-        when(inetServer.channel()).thenReturn(serverChannel);
-        when(serverChannel.eventLoop()).thenReturn(loop);
 
         ChannelRegistry<NetChannel> registry = new ChannelRegistry<>();
         NetChannel channelOk = mock(NetChannel.class);
@@ -159,9 +145,9 @@ class FanoutExporterTest {
         when(inetServer.childChannel()).thenReturn(registry.getChannels());
 
         TcpFanoutExporter exporter = new TcpFanoutExporter(inetServer);
-        CompletableResult result = exporter.export(Destination.create("/topic/a"), Buffer.alloc("p".getBytes()));
+        AggregationResult result = exporter.export(Destination.create("/topic/a"), Buffer.alloc("p".getBytes()));
 
-        assertThat(result.promise().isDone()).isTrue();
+        assertThat(result.isDone()).isTrue();
         assertThat(result.totalAttempted()).isEqualTo(2);
         assertThat(result.succeeded()).isEqualTo(1);
         assertThat(result.failed()).isEqualTo(1);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ lombok = "1.18.46"
 slf4j = "2.0.17"
 google-guava = "33.6.0-jre"
 netty = "4.2.12.Final"
+vertx = "5.0.12"
 assertj = "3.27.7"
 mokito = "5.23.0"
 jetty = "12.1.9"
@@ -22,6 +23,7 @@ netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty" }
 netty-transport = { module = "io.netty:netty-transport", version.ref = "netty" }
 netty-codec = { module = "io.netty:netty-codec", version.ref = "netty" }
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
+vertx-stomp = { module = "io.vertx:vertx-stomp", version.ref = "vertx" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 jetty-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 lombok = "1.18.46"
 slf4j = "2.0.17"
 google-guava = "33.6.0-jre"
-netty-buffer = "4.2.12.Final"
+netty = "4.2.12.Final"
 assertj = "3.27.7"
 mokito = "5.23.0"
 jetty = "12.1.9"
@@ -18,7 +18,10 @@ lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 mokito = { module = "org.mockito:mockito-core", version.ref = "mokito" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 google-guava = { module = "com.google.guava:guava", version.ref = "google-guava" }
-netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty-buffer" }
+netty-buffer = { module = "io.netty:netty-buffer", version.ref = "netty" }
+netty-transport = { module = "io.netty:netty-transport", version.ref = "netty" }
+netty-codec = { module = "io.netty:netty-codec", version.ref = "netty" }
+netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty" }
 jetty-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty"}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ logback = "1.5.27"
 awaitility = "4.3.0"
 snakeyaml = "2.3"
 jetbrains-annotations = "26.1.0"
+spring = "6.1.14"
+spring-boot = "3.3.5"
 
 [libraries]
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
@@ -34,3 +36,8 @@ logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml"}
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+spring-context = { module = "org.springframework:spring-context", version.ref = "spring"}
+spring-beans = { module = "org.springframework:spring-beans", version.ref = "spring" }
+spring-messaging = { module = "org.springframework:spring-messaging", version.ref = "spring" }
+spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot"}
+spring-boot-configure-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot"}

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/TitanSmokeTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/TitanSmokeTest.java
@@ -30,15 +30,13 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.traffichunter.titan.smoke.springframework.smoke.junit.TitanBootstrapper;
+import org.springframework.test.annotation.DirtiesContext;
 
-/**
- * @author yun
- */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @TitanBootstrapper
-@SpringBootTest
+@SpringBootTest(properties = "spring.titan.client=titan")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public @interface LocalSmokeTest {
+public @interface TitanSmokeTest {
 }

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/VertxSmokeTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/VertxSmokeTest.java
@@ -23,20 +23,20 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.smoke.springframework.smoke.junit;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
-/**
- * @author yun
- */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@ExtendWith(TitanBootstrapExtension.class)
-public @interface TitanBootstrapper {
-
-    String environmentPath() default "./titan-env.yml";
+@TitanBootstrapper
+@SpringBootTest(properties = "spring.titan.client=vertx")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public @interface VertxSmokeTest {
 }

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/package-info.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.smoke.springframework.smoke.junit;
+
+import org.jspecify.annotations.NullMarked;

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/AbstractTitanSmokeLocalTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/AbstractTitanSmokeLocalTest.java
@@ -1,0 +1,158 @@
+package org.traffichunter.titan.smoke.springframework.smoke.local;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.springframework.stomp.TitanClientManager;
+import org.traffichunter.titan.springframework.stomp.TitanTemplate;
+
+public abstract class AbstractTitanSmokeLocalTest {
+
+    private static final String PAYLOAD = "smoke-message";
+
+    @Autowired
+    private TitanTemplate titanTemplate;
+
+    @Autowired
+    private TitanClientManager clientManager;
+
+    @Autowired
+    private StompClient stompClient;
+
+    @Autowired
+    private SmokeListener smokeListener;
+
+    protected abstract Class<? extends StompClient> clientType();
+
+    protected abstract Class<? extends StompClientOperations> operationsType();
+
+    @Test
+    void configured_client_matches_smoke_client() throws Exception {
+        assertThat(stompClient).isInstanceOf(clientType());
+        assertThat(clientManager.operations()).isInstanceOf(operationsType());
+    }
+
+    @Test
+    void sync_subscribe_and_send_smoke() throws Exception {
+        String destination = destination("sync");
+        subscribeEventually(destination);
+        sendEventually(destination, PAYLOAD);
+    }
+
+    @Test
+    void sync_send_bytes_smoke() throws Exception {
+        String destination = destination("bytes");
+        byte[] payload = PAYLOAD.getBytes();
+
+        subscribeEventually(destination);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.send(destination, payload)).isNotNull());
+    }
+
+    @Test
+    void repeated_send_smoke() throws Exception {
+        String destination = destination("repeat");
+        subscribeEventually(destination);
+
+        sendEventually(destination, PAYLOAD + "-1");
+        sendEventually(destination, PAYLOAD + "-2");
+    }
+
+    @Test
+    void subscribe_multiple_destinations_smoke() throws Exception {
+        String destinationA = destination("multi-a");
+        String destinationB = destination("multi-b");
+
+        subscribeEventually(destinationA);
+        subscribeEventually(destinationB);
+
+        sendEventually(destinationA, PAYLOAD + "-a");
+        sendEventually(destinationB, PAYLOAD + "-b");
+    }
+
+    @Test
+    void unsubscribe_and_resubscribe_smoke() throws Exception {
+        String destination = destination("unsubscribe");
+
+        subscribeEventually(destination);
+        unsubscribeEventually(destination);
+        subscribeEventually(destination);
+        sendEventually(destination, PAYLOAD + "-after-unsubscribe");
+    }
+
+    @Test
+    void byte_buffer_send_smoke() throws Exception {
+        String destination = destination("byte-buffer");
+        subscribeEventually(destination);
+
+        ByteBuffer wrapped = ByteBuffer.wrap((PAYLOAD + "-wrapped").getBytes(StandardCharsets.UTF_8));
+        ByteBuffer direct = ByteBuffer.allocateDirect((PAYLOAD + "-direct").getBytes(StandardCharsets.UTF_8).length);
+        direct.put((PAYLOAD + "-direct").getBytes(StandardCharsets.UTF_8));
+        direct.flip();
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.send(destination, wrapped)).isNotNull());
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.send(destination, direct)).isNotNull());
+    }
+
+    @Test
+    void titan_listener_receives_message_smoke() {
+        String payload = PAYLOAD + "-listener";
+
+        smokeListener.clear();
+        sendEventually(SmokeListener.DESTINATION, payload);
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(smokeListener.received()).contains(payload));
+    }
+
+    @Test
+    void invalid_destination_should_fail_fast() {
+        assertThatThrownBy(() -> titanTemplate.subscribe("/queue/smoke local/invalid"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid routing key");
+    }
+
+    private static String destination(String suffix) {
+        return "/queue/smoke-local/" + suffix;
+    }
+
+    private void subscribeEventually(String destination) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.subscribe(destination)).isNotNull());
+    }
+
+    private void sendEventually(String destination, String payload) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.send(destination, payload)).isNotNull());
+    }
+
+    private void unsubscribeEventually(String destination) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .ignoreExceptions()
+                .untilAsserted(() -> assertThat(titanTemplate.unsubscribe(destination)).isNotNull());
+    }
+}

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/SmokeConfiguration.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/SmokeConfiguration.java
@@ -1,0 +1,13 @@
+package org.traffichunter.titan.smoke.springframework.smoke.local;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+class SmokeConfiguration {
+
+    @Bean
+    SmokeListener smokeListener() {
+        return new SmokeListener();
+    }
+}

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/SmokeListener.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/SmokeListener.java
@@ -1,0 +1,28 @@
+package org.traffichunter.titan.smoke.springframework.smoke.local;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.springframework.boot.test.context.TestComponent;
+import org.traffichunter.titan.springframework.stomp.annotation.TitanListener;
+
+@TestComponent
+final class SmokeListener {
+
+    static final String DESTINATION = "/queue/smoke-local/listener";
+
+    private final BlockingQueue<String> received = new LinkedBlockingQueue<>();
+
+    @TitanListener(destination = DESTINATION)
+    public void onMessage(String payload) {
+        received.add(payload);
+    }
+
+    void clear() {
+        received.clear();
+    }
+
+    BlockingQueue<String> received() {
+        return received;
+    }
+}

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/TitanSmokeLocalTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/TitanSmokeLocalTest.java
@@ -23,130 +23,27 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.smoke.springframework.smoke.local;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.traffichunter.titan.smoke.springframework.smoke.junit.LocalSmokeTest;
-import org.traffichunter.titan.springframework.stomp.TitanTemplate;
+import org.springframework.context.annotation.Import;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.client.TitanStompClientOperations;
+import org.traffichunter.titan.smoke.springframework.smoke.junit.TitanSmokeTest;
 
 /**
  * @author yun
  */
-@LocalSmokeTest
-public class TitanSmokeLocalTest {
+@TitanSmokeTest
+@Import(SmokeConfiguration.class)
+class TitanSmokeLocalTest extends AbstractTitanSmokeLocalTest {
 
-    private static final String PAYLOAD = "smoke-message";
-
-    @Autowired
-    private TitanTemplate titanTemplate;
-
-    @Test
-    void sync_subscribe_and_send_smoke() throws Exception {
-        String destination = destination("sync");
-        subscribeEventually(destination);
-        sendEventually(destination, PAYLOAD);
+    @Override
+    protected Class<? extends StompClient> clientType() {
+        return TitanStompClient.class;
     }
 
-    @Test
-    void sync_send_bytes_smoke() throws Exception {
-        String destination = destination("bytes");
-        byte[] payload = PAYLOAD.getBytes();
-
-        subscribeEventually(destination);
-
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.send(destination, payload)).isNotNull());
-    }
-
-    @Test
-    void repeated_send_smoke() throws Exception {
-        String destination = destination("repeat");
-        subscribeEventually(destination);
-
-        sendEventually(destination, PAYLOAD + "-1");
-        sendEventually(destination, PAYLOAD + "-2");
-    }
-
-    @Test
-    void subscribe_multiple_destinations_smoke() throws Exception {
-        String destinationA = destination("multi-a");
-        String destinationB = destination("multi-b");
-
-        subscribeEventually(destinationA);
-        subscribeEventually(destinationB);
-
-        sendEventually(destinationA, PAYLOAD + "-a");
-        sendEventually(destinationB, PAYLOAD + "-b");
-    }
-
-    @Test
-    void unsubscribe_and_resubscribe_smoke() throws Exception {
-        String destination = destination("unsubscribe");
-
-        subscribeEventually(destination);
-        unsubscribeEventually(destination);
-        subscribeEventually(destination);
-        sendEventually(destination, PAYLOAD + "-after-unsubscribe");
-    }
-
-    @Test
-    void byte_buffer_send_smoke() throws Exception {
-        String destination = destination("byte-buffer");
-        subscribeEventually(destination);
-
-        ByteBuffer wrapped = ByteBuffer.wrap((PAYLOAD + "-wrapped").getBytes(StandardCharsets.UTF_8));
-        ByteBuffer direct = ByteBuffer.allocateDirect((PAYLOAD + "-direct").getBytes(StandardCharsets.UTF_8).length);
-        direct.put((PAYLOAD + "-direct").getBytes(StandardCharsets.UTF_8));
-        direct.flip();
-
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.send(destination, wrapped)).isNotNull());
-
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.send(destination, direct)).isNotNull());
-    }
-
-    @Test
-    void invalid_destination_should_fail_fast() {
-        assertThatThrownBy(() -> titanTemplate.subscribe("/queue/smoke local/invalid"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Invalid routing key");
-    }
-
-    private static String destination(String suffix) {
-        return "/queue/smoke-local/" + suffix;
-    }
-
-    private void subscribeEventually(String destination) {
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.subscribe(destination)).isNotNull());
-    }
-
-    private void sendEventually(String destination, String payload) {
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.send(destination, payload)).isNotNull());
-    }
-
-    private void unsubscribeEventually(String destination) {
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(10))
-                .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.unsubscribe(destination)).isNotNull());
+    @Override
+    protected Class<? extends StompClientOperations> operationsType() {
+        return TitanStompClientOperations.class;
     }
 }

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/VertxSmokeLocalTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/VertxSmokeLocalTest.java
@@ -1,0 +1,23 @@
+package org.traffichunter.titan.smoke.springframework.smoke.local;
+
+import org.springframework.context.annotation.Import;
+import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.client.VertxStompClientOperations;
+import org.traffichunter.titan.smoke.springframework.smoke.junit.VertxSmokeTest;
+
+@VertxSmokeTest
+@Import(SmokeConfiguration.class)
+class VertxSmokeLocalTest extends AbstractTitanSmokeLocalTest {
+
+    @Override
+    protected Class<? extends StompClient> clientType() {
+        return VertxStompClient.class;
+    }
+
+    @Override
+    protected Class<? extends StompClientOperations> operationsType() {
+        return VertxStompClientOperations.class;
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
-import org.traffichunter.titan.core.transport.stomp.StompClient;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.StompServer;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
@@ -69,9 +69,9 @@ class TitanFanoutSmokeTest {
         EventLoopGroups producerGroups = EventLoopGroups.group(1, 2);
         EventLoopGroups firstConsumerGroups = EventLoopGroups.group(1, 2);
         EventLoopGroups secondConsumerGroups = EventLoopGroups.group(1, 2);
-        StompClient producer = null;
-        StompClient firstConsumer = null;
-        StompClient secondConsumer = null;
+        TitanStompClient producer = null;
+        TitanStompClient firstConsumer = null;
+        TitanStompClient secondConsumer = null;
 
         try {
             server.start();
@@ -128,8 +128,8 @@ class TitanFanoutSmokeTest {
                 .build();
     }
 
-    private static StompClient newStompClient(EventLoopGroups groups, int port) {
-        return StompClient.open(groups, StompClientOption.builder()
+    private static TitanStompClient newStompClient(EventLoopGroups groups, int port) {
+        return TitanStompClient.open(groups, StompClientOption.builder()
                 .host(HOST)
                 .port(port)
                 .heartbeatX(0L)
@@ -137,7 +137,7 @@ class TitanFanoutSmokeTest {
                 .build());
     }
 
-    private static StompClientConnection connect(StompClient client, int port) throws Exception {
+    private static StompClientConnection connect(TitanStompClient client, int port) throws Exception {
         return client.connect(HOST, port, TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
                 .get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     }
@@ -149,7 +149,7 @@ class TitanFanoutSmokeTest {
         return ((InetSocketAddress) localAddress).getPort();
     }
 
-    private static void shutdown(StompClient client) {
+    private static void shutdown(TitanStompClient client) {
         if (client != null && client.isStart()) {
             client.shutdown(10, TimeUnit.SECONDS);
         }

--- a/titan-spring-client/build.gradle.kts
+++ b/titan-spring-client/build.gradle.kts
@@ -6,11 +6,11 @@ dependencies {
     api(project(":titan-stomp"))
     implementation(project(":core"))
 
-    implementation("org.springframework.boot:spring-boot-autoconfigure:3.3.5")
-    implementation("org.springframework:spring-context:6.1.14")
-    implementation("org.springframework:spring-beans:6.1.14")
-    implementation("org.springframework:spring-messaging:6.1.14")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
+    implementation(project.libs.spring.boot.autoconfigure)
+    implementation(project.libs.spring.context)
+    implementation(project.libs.spring.beans)
+    implementation(project.libs.spring.messaging)
+    implementation(project.libs.jackson.databind)
 
-    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.3.5")
+    annotationProcessor(project.libs.spring.boot.configure.processor)
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
-import org.traffichunter.titan.core.transport.stomp.StompClient;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 
 /**
  * Spring lifecycle adapter for a Titan STOMP client.
@@ -20,11 +20,11 @@ public final class TitanClientManager implements SmartLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(TitanClientManager.class);
 
-    private final StompClient stompClient;
+    private final TitanStompClient stompClient;
     private final TitanProperties properties;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
-    public TitanClientManager(StompClient stompClient, TitanProperties properties) {
+    public TitanClientManager(TitanStompClient stompClient, TitanProperties properties) {
         this.stompClient = stompClient;
         this.properties = properties;
     }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -19,6 +19,7 @@ import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations
 public final class TitanClientManager implements SmartLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(TitanClientManager.class);
+    public static final int PHASE = Integer.MAX_VALUE - 100;
 
     private final StompClient stompClient;
     private final TitanProperties properties;
@@ -78,7 +79,7 @@ public final class TitanClientManager implements SmartLifecycle {
 
     @Override
     public int getPhase() {
-        return Integer.MAX_VALUE;
+        return PHASE;
     }
 
     public StompClientOperations connect() throws Exception {

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -6,13 +6,13 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
-import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
-import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 
 /**
  * Spring lifecycle adapter for a Titan STOMP client.
  * Starts and stops the underlying client with the application context.
- * Resolves or creates the active STOMP connection for template and listener use.
+ * Resolves or creates active STOMP operations for template and listener use.
  *
  * @author yun
  */
@@ -20,11 +20,11 @@ public final class TitanClientManager implements SmartLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(TitanClientManager.class);
 
-    private final TitanStompClient stompClient;
+    private final StompClient stompClient;
     private final TitanProperties properties;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
-    public TitanClientManager(TitanStompClient stompClient, TitanProperties properties) {
+    public TitanClientManager(StompClient stompClient, TitanProperties properties) {
         this.stompClient = stompClient;
         this.properties = properties;
     }
@@ -81,15 +81,15 @@ public final class TitanClientManager implements SmartLifecycle {
         return Integer.MAX_VALUE;
     }
 
-    public StompClientConnection connect() throws Exception {
+    public StompClientOperations connect() throws Exception {
         return stompClient
-                .connect(properties.getHost(), properties.getPort(), properties.getConnectTimeoutMillis(), TimeUnit.MILLISECONDS)
+                .connect()
                 .get(properties.getConnectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 
-    public StompClientConnection connection() throws Exception {
+    public StompClientOperations operations() throws Exception {
         if (isConnected()) {
-            return stompClient.connection();
+            return stompClient.operations();
         }
         return connect();
     }
@@ -98,9 +98,9 @@ public final class TitanClientManager implements SmartLifecycle {
         return properties.getConnectTimeoutMillis();
     }
 
-    public @Nullable StompClientConnection currentConnection() {
+    public @Nullable StompClientOperations currentOperations() {
         try {
-            return stompClient.connection();
+            return stompClient.operations();
         } catch (IllegalStateException e) {
             return null;
         }
@@ -108,7 +108,7 @@ public final class TitanClientManager implements SmartLifecycle {
 
     public boolean isConnected() {
         try {
-            return stompClient.connection().isConnected();
+            return stompClient.operations().isConnected();
         } catch (IllegalStateException e) {
             return false;
         }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -18,6 +18,8 @@ public class TitanProperties {
 
     private boolean autoConnect = true;
 
+    private String client = "titan";
+
     private int primaryThreads = 1;
 
     private int secondaryThreads = Runtime.getRuntime().availableProcessors();
@@ -184,5 +186,13 @@ public class TitanProperties {
 
     public void setBypassHostHeader(boolean bypassHostHeader) {
         this.bypassHostHeader = bypassHostHeader;
+    }
+
+    public String getClient() {
+        return client;
+    }
+
+    public void setClient(String client) {
+        this.client = client;
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanTemplate.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanTemplate.java
@@ -4,16 +4,15 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
-import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements.ID;
 
 /**
  * Convenience operations for sending and managing STOMP subscriptions.
  * Uses {@link TitanClientManager} to resolve the active connection.
- * Provides synchronous methods and an async view backed by Titan promises.
+ * Provides synchronous methods and an async view backed by the configured STOMP client.
  *
  * @author yun
  */
@@ -29,45 +28,43 @@ public final class TitanTemplate {
         return new AsyncTitanTemplate(clientManager);
     }
 
-    public StompFrame send(String destination, String payload) throws Exception {
+    public StompFrames send(String destination, String payload) throws Exception {
         return send(destination, payload.getBytes(StandardCharsets.UTF_8));
     }
 
-    public StompFrame send(String destination, ByteBuffer byteBuffer) throws Exception {
+    public StompFrames send(String destination, ByteBuffer byteBuffer) throws Exception {
         ByteBuffer copied = byteBuffer.slice();
         byte[] payload = new byte[copied.remaining()];
         copied.get(payload);
         return send(destination, payload);
     }
 
-    public StompFrame send(String destination, byte[] payload) throws Exception {
-        StompClientConnection connection = resolveConnection();
-        return connection.send(destination, Buffer.alloc(payload))
+    public StompFrames send(String destination, byte[] payload) throws Exception {
+        StompClientOperations operations = resolveOperations();
+        return operations.send(destination, Buffer.alloc(payload))
                 .get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 
-    public StompFrame subscribe(String destination) throws Exception {
-        StompClientConnection connection = resolveConnection();
-        return connection.subscribe(destination)
+    public String subscribe(String destination) throws Exception {
+        StompClientOperations operations = resolveOperations();
+        return operations.subscribe(destination, frame -> { })
                 .get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 
-    public StompFrame unsubscribe(String destination) throws Exception {
-        StompClientConnection connection = resolveConnection();
-        StompHeaders headers = StompHeaders.create();
-        headers.put(ID, destination);
-        return connection.unsubscribe(destination, headers)
+    public StompFrames unsubscribe(String destination) throws Exception {
+        StompClientOperations operations = resolveOperations();
+        return operations.unsubscribe(destination, java.util.Map.of(ID, destination))
                 .get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 
-    public StompFrame disconnect() throws Exception {
-        StompClientConnection connection = resolveConnection();
-        return connection.disconnect()
+    public StompFrames disconnect() throws Exception {
+        StompClientOperations operations = resolveOperations();
+        return operations.disconnect()
                 .get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 
-    private StompClientConnection resolveConnection() throws Exception {
-        return clientManager.connection();
+    private StompClientOperations resolveOperations() throws Exception {
+        return clientManager.operations();
     }
 
     /**
@@ -83,41 +80,39 @@ public final class TitanTemplate {
             this.clientManager = clientManager;
         }
 
-        public Future<StompFrame> send(String destination, String payload) throws Exception {
+        public Future<StompFrames> send(String destination, String payload) throws Exception {
             return send(destination, payload.getBytes(StandardCharsets.UTF_8));
         }
 
-        public Future<StompFrame> send(String destination, ByteBuffer byteBuffer) throws Exception {
+        public Future<StompFrames> send(String destination, ByteBuffer byteBuffer) throws Exception {
             ByteBuffer copied = byteBuffer.slice();
             byte[] payload = new byte[copied.remaining()];
             copied.get(payload);
             return send(destination, payload);
         }
 
-        public Future<StompFrame> send(String destination, byte[] payload) throws Exception {
-            StompClientConnection connection = resolveConnection();
-            return connection.send(destination, Buffer.alloc(payload)).future();
+        public Future<StompFrames> send(String destination, byte[] payload) throws Exception {
+            StompClientOperations operations = resolveOperations();
+            return operations.send(destination, Buffer.alloc(payload));
         }
 
-        public Future<StompFrame> subscribe(String destination) throws Exception {
-            StompClientConnection connection = resolveConnection();
-            return connection.subscribe(destination).future();
+        public Future<String> subscribe(String destination) throws Exception {
+            StompClientOperations operations = resolveOperations();
+            return operations.subscribe(destination, frame -> { });
         }
 
-        public Future<StompFrame> unsubscribe(String destination) throws Exception {
-            StompClientConnection connection = resolveConnection();
-            StompHeaders headers = StompHeaders.create();
-            headers.put(ID, destination);
-            return connection.unsubscribe(destination, headers).future();
+        public Future<StompFrames> unsubscribe(String destination) throws Exception {
+            StompClientOperations operations = resolveOperations();
+            return operations.unsubscribe(destination, java.util.Map.of(ID, destination));
         }
 
-        public Future<StompFrame> disconnect() throws Exception {
-            StompClientConnection connection = resolveConnection();
-            return connection.disconnect().future();
+        public Future<StompFrames> disconnect() throws Exception {
+            StompClientOperations operations = resolveOperations();
+            return operations.disconnect();
         }
 
-        private StompClientConnection resolveConnection() throws Exception {
-            return clientManager.connection();
+        private StompClientOperations resolveOperations() throws Exception {
+            return clientManager.operations();
         }
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/annotation/TitanListener.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/annotation/TitanListener.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
  * Marks a method as a Titan STOMP message listener.
  * The annotated method is registered against a destination.
  * Listener endpoints are created during Spring bean initialization.
- * Typical listener methods receive a payload, Spring {@code Message}, or {@code StompFrame}.
+ * Typical listener methods receive a payload, Spring {@code Message}, or {@code StompFrames}.
  *
  * <pre> {@code
  * @TitanListener(destination = "/topic/alerts")

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.traffichunter.titan.springframework.stomp.autoconfigure;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -7,11 +8,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.codec.stomp.StompVersion;
 import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientProvider;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
 import org.traffichunter.titan.springframework.stomp.TitanTemplate;
+
+import java.util.List;
 
 /**
  * Autoconfiguration for Titan's Spring STOMP client integration.
@@ -21,13 +28,14 @@ import org.traffichunter.titan.springframework.stomp.TitanTemplate;
  * @author yun
  */
 @AutoConfiguration
-@ConditionalOnClass({TitanStompClient.class, EventLoopGroups.class})
+@ConditionalOnClass({StompClient.class, EventLoopGroups.class})
 @EnableConfigurationProperties(TitanProperties.class)
-@ConditionalOnProperty(prefix = "titan.stomp.client", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "spring.titan", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class TitanStompClientAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(name = "titanStompClientEventLoopGroups")
+    @ConditionalOnProperty(prefix = "spring.titan", name = "client", havingValue = "titan", matchIfMissing = true)
     public EventLoopGroups titanStompClientEventLoopGroups(TitanProperties properties) {
         return EventLoopGroups.group(properties.getPrimaryThreads(), properties.getSecondaryThreads());
     }
@@ -51,18 +59,79 @@ public class TitanStompClientAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "titanStompClientProvider")
+    public StompClientProvider titanStompClientProvider(ObjectProvider<EventLoopGroups> titanStompClientEventLoopGroups) {
+        return new StompClientProvider() {
+            @Override
+            public String name() {
+                return "titan";
+            }
+
+            @Override
+            public String version() {
+                return StompVersion.STOMP_1_2.getVersion();
+            }
+
+            @Override
+            public boolean supports(String transport, String version) {
+                return name().equalsIgnoreCase(transport) && version().equals(version);
+            }
+
+            @Override
+            public StompClient create(StompClientOption option) {
+                return TitanStompClient.open(titanStompClientEventLoopGroups.getObject(), option);
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnClass(VertxStompClient.class)
+    @ConditionalOnMissingBean(name = "vertxStompClientProvider")
+    public StompClientProvider vertxStompClientProvider() {
+        return new StompClientProvider() {
+            @Override
+            public String name() {
+                return "vertx";
+            }
+
+            @Override
+            public String version() {
+                return StompVersion.STOMP_1_2.getVersion();
+            }
+
+            @Override
+            public boolean supports(String transport, String version) {
+                return name().equalsIgnoreCase(transport) && version().equals(version);
+            }
+
+            @Override
+            public StompClient create(StompClientOption option) {
+                return VertxStompClient.open(option);
+            }
+        };
+    }
+
+    @Bean
     @ConditionalOnMissingBean
-    public TitanStompClient titanStompClient(
-            EventLoopGroups titanStompClientEventLoopGroups,
-            StompClientOption titanStompClientOption
+    public StompClient titanStompClient(
+            List<StompClientProvider> stompClientProviders,
+            StompClientOption titanStompClientOption,
+            TitanProperties properties
     ) {
-        return TitanStompClient.open(titanStompClientEventLoopGroups, titanStompClientOption);
+        return stompClientProviders.stream()
+                .filter(provider -> provider.supports(properties.getClient(), titanStompClientOption.stompVersion().getVersion()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No STOMP client provider found for client: "
+                        + properties.getClient()
+                        + ", version: "
+                        + titanStompClientOption.stompVersion().getVersion()))
+                .create(titanStompClientOption);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public TitanClientManager titanStompClientManager(
-            TitanStompClient titanStompClient,
+            StompClient titanStompClient,
             TitanProperties properties
     ) {
         return new TitanClientManager(titanStompClient, properties);

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
-import org.traffichunter.titan.core.transport.stomp.StompClient;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
@@ -21,7 +21,7 @@ import org.traffichunter.titan.springframework.stomp.TitanTemplate;
  * @author yun
  */
 @AutoConfiguration
-@ConditionalOnClass({StompClient.class, EventLoopGroups.class})
+@ConditionalOnClass({TitanStompClient.class, EventLoopGroups.class})
 @EnableConfigurationProperties(TitanProperties.class)
 @ConditionalOnProperty(prefix = "titan.stomp.client", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class TitanStompClientAutoConfiguration {
@@ -52,17 +52,17 @@ public class TitanStompClientAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public StompClient titanStompClient(
+    public TitanStompClient titanStompClient(
             EventLoopGroups titanStompClientEventLoopGroups,
             StompClientOption titanStompClientOption
     ) {
-        return StompClient.open(titanStompClientEventLoopGroups, titanStompClientOption);
+        return TitanStompClient.open(titanStompClientEventLoopGroups, titanStompClientOption);
     }
 
     @Bean
     @ConditionalOnMissingBean
     public TitanClientManager titanStompClientManager(
-            StompClient titanStompClient,
+            TitanStompClient titanStompClient,
             TitanProperties properties
     ) {
         return new TitanClientManager(titanStompClient, properties);

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -8,11 +8,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
-import org.traffichunter.titan.core.codec.stomp.StompVersion;
-import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClientProvider;
+import org.traffichunter.titan.core.transport.stomp.client.TitanStompClientProvider;
+import org.traffichunter.titan.core.transport.stomp.client.VertxStompClientProvider;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
@@ -61,54 +61,14 @@ public class TitanStompClientAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "titanStompClientProvider")
     public StompClientProvider titanStompClientProvider(ObjectProvider<EventLoopGroups> titanStompClientEventLoopGroups) {
-        return new StompClientProvider() {
-            @Override
-            public String name() {
-                return "titan";
-            }
-
-            @Override
-            public String version() {
-                return StompVersion.STOMP_1_2.getVersion();
-            }
-
-            @Override
-            public boolean supports(String transport, String version) {
-                return name().equalsIgnoreCase(transport) && version().equals(version);
-            }
-
-            @Override
-            public StompClient create(StompClientOption option) {
-                return TitanStompClient.open(titanStompClientEventLoopGroups.getObject(), option);
-            }
-        };
+        return new TitanStompClientProvider(titanStompClientEventLoopGroups::getObject);
     }
 
     @Bean
     @ConditionalOnClass(VertxStompClient.class)
     @ConditionalOnMissingBean(name = "vertxStompClientProvider")
     public StompClientProvider vertxStompClientProvider() {
-        return new StompClientProvider() {
-            @Override
-            public String name() {
-                return "vertx";
-            }
-
-            @Override
-            public String version() {
-                return StompVersion.STOMP_1_2.getVersion();
-            }
-
-            @Override
-            public boolean supports(String transport, String version) {
-                return name().equalsIgnoreCase(transport) && version().equals(version);
-            }
-
-            @Override
-            public StompClient create(StompClientOption option) {
-                return VertxStompClient.open(option);
-            }
-        };
+        return new VertxStompClientProvider();
     }
 
     @Bean

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.converter.*;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.springframework.util.ClassUtils;
 import org.traffichunter.titan.springframework.stomp.beans.TitanListenerAnnotationBeanPostProcessor;
 import org.traffichunter.titan.springframework.stomp.factory.SimpleTitanListenerContainerFactory;
 import org.traffichunter.titan.springframework.stomp.factory.TitanListenerContainerFactory;
@@ -34,6 +35,7 @@ import org.traffichunter.titan.springframework.stomp.messaging.converter.StompFr
 import org.traffichunter.titan.springframework.stomp.messaging.resolver.TitanPayloadHandlerMethodArgumentResolver;
 import org.traffichunter.titan.springframework.stomp.messaging.resolver.TitanStompHandlerMethodArgumentResolver;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -58,12 +60,13 @@ public class TitanListenerConfiguration {
 
     @Bean
     public SmartMessageConverter titanMessageConverter() {
-        List<MessageConverter> converters = List.of(
-                new StompFrameMessageConverter(),
-                new ByteArrayMessageConverter(),
-                new StringMessageConverter(),
-                new MappingJackson2MessageConverter()
-        );
+        List<MessageConverter> converters = new ArrayList<>();
+        converters.add(new StompFrameMessageConverter());
+        converters.add(new ByteArrayMessageConverter());
+        converters.add(new StringMessageConverter());
+        if (ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", getClass().getClassLoader())) {
+            converters.add(new MappingJackson2MessageConverter());
+        }
 
         return new CompositeMessageConverter(converters);
     }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainer.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainer.java
@@ -5,9 +5,9 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
 import org.springframework.util.ErrorHandler;
@@ -55,11 +55,11 @@ public final class TitanListenerContainer {
         }
 
         try {
-            StompClientConnection conn = manager.connection();
-            conn.subscribe(endpoint.destination(), frame -> {
+            StompClientOperations operations = manager.operations();
+            operations.subscribe(endpoint.destination(), frame -> {
                 try {
                     invoke(frame);
-                    acknowledgeIfPossible(frame, conn);
+                    acknowledgeIfPossible(frame, operations);
                 } catch (Exception e) {
                     log.error(
                             "Failed to invoke Titan listener handler. id={}, destination={}",
@@ -68,7 +68,7 @@ public final class TitanListenerContainer {
                             e
                     );
                     handleListenerError(e);
-                    negativeAcknowledgeIfPossible(frame, conn);
+                    negativeAcknowledgeIfPossible(frame, operations);
                 }
             });
             log.info("Started Titan listener. id={}, destination={}", endpoint.id(), endpoint.destination());
@@ -87,13 +87,13 @@ public final class TitanListenerContainer {
         }
 
         try {
-            StompClientConnection conn = manager.currentConnection();
-            if(conn == null) {
+            StompClientOperations operations = manager.currentOperations();
+            if(operations == null) {
                 return;
             }
 
-            if (conn.isConnected()) {
-                conn.unsubscribe(endpoint.destination());
+            if (operations.isConnected()) {
+                operations.unsubscribe(endpoint.destination());
             }
 
             log.info("Stopped Titan listener. id={}, destination={}", endpoint.id(), endpoint.destination());
@@ -132,7 +132,7 @@ public final class TitanListenerContainer {
         return listenerErrorHandler;
     }
 
-    private void invoke(StompFrame frame) throws Exception {
+    private void invoke(StompFrames frame) throws Exception {
         Message<byte[]> springMessage = TitanSpringMessageAdapter.from(frame);
 
         InvocableHandlerMethod invocable = new InvocableHandlerMethod(endpoint.bean(), endpoint.method());
@@ -143,8 +143,8 @@ public final class TitanListenerContainer {
     /**
      * Send ACK for MESSAGE frames that include a message-id.
      */
-    private void acknowledgeIfPossible(StompFrame frame, StompClientConnection connection) {
-        if (frame.getCommand() != StompCommand.MESSAGE) {
+    private void acknowledgeIfPossible(StompFrames frame, StompClientOperations operations) {
+        if (frame.command() != StompCommand.MESSAGE) {
             return;
         }
 
@@ -154,14 +154,14 @@ public final class TitanListenerContainer {
             return;
         }
 
-        connection.ack(messageId);
+        operations.ack(messageId);
     }
 
     /**
      * Send NACK for MESSAGE frames that include a message-id.
      */
-    private void negativeAcknowledgeIfPossible(StompFrame frame, StompClientConnection connection) {
-        if (frame.getCommand() != StompCommand.MESSAGE) {
+    private void negativeAcknowledgeIfPossible(StompFrames frame, StompClientOperations operations) {
+        if (frame.command() != StompCommand.MESSAGE) {
             return;
         }
 
@@ -171,7 +171,7 @@ public final class TitanListenerContainer {
             return;
         }
 
-        connection.nack(messageId);
+        operations.nack(messageId);
     }
 
     private void handleListenerError(Throwable error) {

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerEndpointRegistry.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerEndpointRegistry.java
@@ -52,6 +52,11 @@ public final class TitanListenerEndpointRegistry implements SmartLifecycle {
         return containers.stream().allMatch(TitanListenerContainer::isRunning);
     }
 
+    @Override
+    public int getPhase() {
+        return TitanClientManager.PHASE + 1;
+    }
+
     /**
      * Return whether all registered containers are stopped.
      */

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/TitanSpringMessageAdapter.java
@@ -26,7 +26,7 @@ package org.traffichunter.titan.springframework.stomp.messaging;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 
 /**
  * Converts Titan STOMP frames into Spring messaging messages.
@@ -40,12 +40,11 @@ public final class TitanSpringMessageAdapter {
 
     public static final String HDR_STOMP_FRAME = "titan.stomp.frame";
 
-    public static Message<byte[]> from(StompFrame frame) {
-        MessageBuilder<byte[]> builder = MessageBuilder.withPayload(frame.getBody().getBytes());
+    public static Message<byte[]> from(StompFrames frame) {
+        MessageBuilder<byte[]> builder = MessageBuilder.withPayload(frame.body());
 
-        frame.getHeaders()
-                .entrySet()
-                .forEach(entry -> builder.setHeader(entry.getKey().getName(), entry.getValue()));
+        frame.headers()
+                .forEach((key, value) -> builder.setHeader(key.getName(), value));
 
         builder.setHeader(HDR_STOMP_FRAME, frame);
         return builder.build();

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/StompFrameMessageConverter.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/converter/StompFrameMessageConverter.java
@@ -27,13 +27,13 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.AbstractMessageConverter;
 import org.springframework.util.MimeTypeUtils;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
 
 /**
- * Message converter that resolves the original {@link StompFrame}.
+ * Message converter that resolves the original {@link StompFrames}.
  * The frame is read from the internal Spring message header.
- * This supports listener method parameters of type {@code StompFrame}.
+ * This supports listener method parameters of type {@code StompFrames}.
  *
  * @author yun
  */
@@ -45,15 +45,15 @@ public final class StompFrameMessageConverter extends AbstractMessageConverter {
 
     @Override
     protected boolean supports(Class<?> clazz) {
-        return StompFrame.class.isAssignableFrom(clazz);
+        return StompFrames.class.isAssignableFrom(clazz);
     }
 
     @Override
     protected @Nullable Object convertFromInternal(Message<?> message, Class<?> targetClass, @Nullable Object conversionHint) {
-        if (!StompFrame.class.isAssignableFrom(targetClass)) {
+        if (!StompFrames.class.isAssignableFrom(targetClass)) {
             return null;
         }
 
-        return message.getHeaders().get(TitanSpringMessageAdapter.HDR_STOMP_FRAME, StompFrame.class);
+        return message.getHeaders().get(TitanSpringMessageAdapter.HDR_STOMP_FRAME, StompFrames.class);
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanPayloadHandlerMethodArgumentResolver.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanPayloadHandlerMethodArgumentResolver.java
@@ -29,7 +29,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 
 /**
  * Resolves listener method arguments from the STOMP message payload.
@@ -50,7 +50,7 @@ public class TitanPayloadHandlerMethodArgumentResolver implements HandlerMethodA
     public boolean supportsParameter(MethodParameter parameter) {
         Class<?> type = parameter.getParameterType();
 
-        return !Message.class.isAssignableFrom(type) && !StompFrame.class.isAssignableFrom(type);
+        return !Message.class.isAssignableFrom(type) && !StompFrames.class.isAssignableFrom(type);
     }
 
     @Override

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanStompHandlerMethodArgumentResolver.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanStompHandlerMethodArgumentResolver.java
@@ -29,10 +29,10 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 
 /**
- * Resolves Spring {@link Message} and Titan {@link StompFrame} parameters.
+ * Resolves Spring {@link Message} and Titan {@link StompFrames} parameters.
  * Delegates frame conversion to the configured Spring message converter.
  * Runs before payload conversion in the listener resolver chain.
  *
@@ -50,7 +50,7 @@ public class TitanStompHandlerMethodArgumentResolver implements HandlerMethodArg
     public boolean supportsParameter(MethodParameter parameter) {
         Class<?> type = parameter.getParameterType();
 
-        return Message.class.isAssignableFrom(type) || StompFrame.class.isAssignableFrom(type);
+        return Message.class.isAssignableFrom(type) || StompFrames.class.isAssignableFrom(type);
     }
 
     @Override

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanListenerConfigurationTest.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.handler.invocation.HandlerMethodArgumentRes
 import org.springframework.messaging.support.MessageBuilder;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.springframework.stomp.listener.TitanListenerConfiguration;
 import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
@@ -32,7 +33,7 @@ class TitanListenerConfigurationTest {
         );
         Message<byte[]> stompMessage = TitanSpringMessageAdapter.from(frame);
 
-        Object resolvedFrame = composite.resolveArgument(parameter("onFrame", StompFrame.class), stompMessage);
+        Object resolvedFrame = composite.resolveArgument(parameter("onFrame", StompFrames.class), stompMessage);
         Object resolvedPayload = composite.resolveArgument(parameter("onPayload", String.class), stompMessage);
 
         assertSame(frame, resolvedFrame);
@@ -57,7 +58,7 @@ class TitanListenerConfigurationTest {
     }
 
     static final class FixtureHandler {
-        void onFrame(StompFrame frame) {}
+        void onFrame(StompFrames frame) {}
         void onPayload(String payload) {}
         void onMessage(Message<byte[]> message) {}
     }

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanTemplateTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanTemplateTest.java
@@ -1,0 +1,87 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TitanTemplateTest {
+
+    private StompClientOperations operations;
+    private TitanTemplate template;
+    private StompFrames frame;
+
+    @BeforeEach
+    void setUp() {
+        StompClient client = mock(StompClient.class);
+        operations = mock(StompClientOperations.class);
+        frame = mock(StompFrames.class);
+
+        when(client.operations()).thenReturn(operations);
+        when(operations.isConnected()).thenReturn(true);
+        template = new TitanTemplate(new TitanClientManager(client, new TitanProperties()));
+    }
+
+    @Test
+    void sends_payload_through_operations() throws Exception {
+        when(operations.send(eq("/topic/test"), any(Buffer.class)))
+                .thenReturn(CompletableFuture.completedFuture(frame));
+
+        StompFrames result = template.send("/topic/test", "hello");
+
+        ArgumentCaptor<Buffer> payload = ArgumentCaptor.forClass(Buffer.class);
+        verify(operations).send(eq("/topic/test"), payload.capture());
+        assertThat(result).isSameAs(frame);
+        assertThat(new String(payload.getValue().getBytes(), StandardCharsets.UTF_8)).isEqualTo("hello");
+    }
+
+    @Test
+    void subscribes_through_operations() throws Exception {
+        when(operations.subscribe(eq("/topic/test"), any()))
+                .thenReturn(CompletableFuture.completedFuture("sub-1"));
+
+        String subscriptionId = template.subscribe("/topic/test");
+
+        assertThat(subscriptionId).isEqualTo("sub-1");
+        verify(operations).subscribe(eq("/topic/test"), any());
+    }
+
+    @Test
+    void unsubscribes_with_destination_as_subscription_id() throws Exception {
+        when(operations.unsubscribe(eq("/topic/test"), any()))
+                .thenReturn(CompletableFuture.completedFuture(frame));
+
+        StompFrames result = template.unsubscribe("/topic/test");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Elements, String>> headers = ArgumentCaptor.forClass(Map.class);
+        verify(operations).unsubscribe(eq("/topic/test"), headers.capture());
+        assertThat(result).isSameAs(frame);
+        assertThat(headers.getValue()).containsEntry(Elements.ID, "/topic/test");
+    }
+
+    @Test
+    void disconnects_through_operations() throws Exception {
+        when(operations.disconnect()).thenReturn(CompletableFuture.completedFuture(frame));
+
+        StompFrames result = template.disconnect();
+
+        verify(operations).disconnect();
+        assertThat(result).isSameAs(frame);
+    }
+}

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
@@ -1,0 +1,70 @@
+package org.traffichunter.titan.springframework.stomp.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientProvider;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.springframework.stomp.TitanProperties;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TitanStompClientAutoConfigurationTest {
+
+    @Test
+    void creates_titan_client_from_titan_client() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
+        when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
+        StompClientProvider provider = configuration.titanStompClientProvider(eventLoopGroups);
+        TitanProperties properties = new TitanProperties();
+        properties.setClient("titan");
+
+        StompClient client = configuration.titanStompClient(
+                List.of(provider),
+                StompClientOption.builder().build(),
+                properties
+        );
+
+        assertThat(client).isInstanceOf(TitanStompClient.class);
+    }
+
+    @Test
+    void creates_vertx_client_from_vertx_client() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        StompClientProvider provider = configuration.vertxStompClientProvider();
+        TitanProperties properties = new TitanProperties();
+        properties.setClient("vertx");
+
+        StompClient client = configuration.titanStompClient(
+                List.of(provider),
+                StompClientOption.builder().build(),
+                properties
+        );
+
+        assertThat(client).isInstanceOf(VertxStompClient.class);
+    }
+
+    @Test
+    void fails_when_client_has_no_provider() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        TitanProperties properties = new TitanProperties();
+        properties.setClient("missing");
+
+        assertThatThrownBy(() -> configuration.titanStompClient(
+                List.of(configuration.vertxStompClientProvider()),
+                StompClientOption.builder().build(),
+                properties
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("missing");
+    }
+}

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,11 +23,12 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
 import org.springframework.util.ErrorHandler;
-import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
-import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
@@ -34,17 +36,19 @@ import org.traffichunter.titan.springframework.stomp.factory.SimpleTitanListener
 
 class TitanListenerContainerFactoryTest {
 
-    private StompClientConnection connection;
+    private StompClientOperations operations;
     private TitanClientManager manager;
 
     @BeforeEach
     void setUp() {
-        TitanStompClient stompClient = mock(TitanStompClient.class);
-        connection = mock(StompClientConnection.class);
+        StompClient stompClient = mock(StompClient.class);
+        operations = mock(StompClientOperations.class);
         manager = new TitanClientManager(stompClient, new TitanProperties());
 
-        when(stompClient.connection()).thenReturn(connection);
-        when(connection.isConnected()).thenReturn(true);
+        when(stompClient.operations()).thenReturn(operations);
+        when(operations.isConnected()).thenReturn(true);
+        when(operations.subscribe(eq("/topic/test"), org.mockito.ArgumentMatchers.<Handler<StompFrames>>any()))
+                .thenReturn(CompletableFuture.completedFuture("/topic/test"));
     }
 
     @Test
@@ -88,8 +92,8 @@ class TitanListenerContainerFactoryTest {
         container.start();
         subscribedHandler().handle(messageFrame("msg-1"));
 
-        verify(connection).ack("msg-1");
-        verify(connection, never()).nack(anyString());
+        verify(operations).ack("msg-1");
+        verify(operations, never()).nack(anyString());
     }
 
     @Test
@@ -104,8 +108,8 @@ class TitanListenerContainerFactoryTest {
         subscribedHandler().handle(messageFrame("msg-2"));
 
         assertTrue(errorHandled.get());
-        verify(connection).nack("msg-2");
-        verify(connection, never()).ack(anyString());
+        verify(operations).nack("msg-2");
+        verify(operations, never()).ack(anyString());
     }
 
     private static TitanListenerEndpoint endpoint() throws NoSuchMethodException {
@@ -131,9 +135,9 @@ class TitanListenerContainerFactoryTest {
     }
 
     @SuppressWarnings("unchecked")
-    private Handler<StompFrame> subscribedHandler() {
-        ArgumentCaptor<Handler<StompFrame>> captor = ArgumentCaptor.forClass(Handler.class);
-        verify(connection).subscribe(eq("/topic/test"), captor.capture());
+    private Handler<StompFrames> subscribedHandler() {
+        ArgumentCaptor<Handler<StompFrames>> captor = ArgumentCaptor.forClass(Handler.class);
+        verify(operations).subscribe(eq("/topic/test"), captor.capture());
         return captor.getValue();
     }
 

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
@@ -26,7 +26,7 @@ import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
-import org.traffichunter.titan.core.transport.stomp.StompClient;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
@@ -39,7 +39,7 @@ class TitanListenerContainerFactoryTest {
 
     @BeforeEach
     void setUp() {
-        StompClient stompClient = mock(StompClient.class);
+        TitanStompClient stompClient = mock(TitanStompClient.class);
         connection = mock(StompClientConnection.class);
         manager = new TitanClientManager(stompClient, new TitanProperties());
 

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanArgumentResolverTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/messaging/resolver/TitanArgumentResolverTest.java
@@ -14,14 +14,13 @@ import org.springframework.core.MethodParameter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.converter.CompositeMessageConverter;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.MessageConversionException;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessageAdapter;
 import org.traffichunter.titan.springframework.stomp.messaging.converter.StompFrameMessageConverter;
@@ -31,16 +30,15 @@ class TitanArgumentResolverTest {
     private static final SmartMessageConverter CONVERTER = new CompositeMessageConverter(List.of(
             new StompFrameMessageConverter(),
             new ByteArrayMessageConverter(),
-            new StringMessageConverter(),
-            new MappingJackson2MessageConverter()
+            new StringMessageConverter()
     ));
 
     @Test
-    void stomp_resolver_supports_message_and_stomp_frame() throws Exception {
+    void stomp_resolver_supports_message_and_stomp_frames() throws Exception {
         TitanStompHandlerMethodArgumentResolver resolver = new TitanStompHandlerMethodArgumentResolver(CONVERTER);
 
         assertTrue(resolver.supportsParameter(parameter("onMessage", Message.class)));
-        assertTrue(resolver.supportsParameter(parameter("onFrame", StompFrame.class)));
+        assertTrue(resolver.supportsParameter(parameter("onFrame", StompFrames.class)));
         assertFalse(resolver.supportsParameter(parameter("onPayload", String.class)));
     }
 
@@ -55,12 +53,12 @@ class TitanArgumentResolverTest {
     }
 
     @Test
-    void stomp_resolver_converts_to_stomp_frame_parameter() throws Exception {
+    void stomp_resolver_converts_to_stomp_frames_parameter() throws Exception {
         TitanStompHandlerMethodArgumentResolver resolver = new TitanStompHandlerMethodArgumentResolver(CONVERTER);
         StompFrame frame = createFrame("hello");
         Message<byte[]> message = TitanSpringMessageAdapter.from(frame);
 
-        Object resolved = resolver.resolveArgument(parameter("onFrame", StompFrame.class), message);
+        Object resolved = resolver.resolveArgument(parameter("onFrame", StompFrames.class), message);
 
         assertSame(frame, resolved);
     }
@@ -71,7 +69,7 @@ class TitanArgumentResolverTest {
 
         assertTrue(resolver.supportsParameter(parameter("onPayload", String.class)));
         assertFalse(resolver.supportsParameter(parameter("onMessage", Message.class)));
-        assertFalse(resolver.supportsParameter(parameter("onFrame", StompFrame.class)));
+        assertFalse(resolver.supportsParameter(parameter("onFrame", StompFrames.class)));
     }
 
     @Test
@@ -106,7 +104,7 @@ class TitanArgumentResolverTest {
 
     static final class FixtureHandler {
         void onMessage(Message<byte[]> message) {}
-        void onFrame(StompFrame frame) {}
+        void onFrame(StompFrames frame) {}
         void onPayload(String payload) {}
         void onNumber(Integer number) {}
     }

--- a/titan-stomp/build.gradle.kts
+++ b/titan-stomp/build.gradle.kts
@@ -8,4 +8,6 @@ version = "1.0-SNAPSHOT"
 dependencies {
     api(project(":bootstrap"))
     api(project(":core"))
+
+    implementation(project.libs.vertx.stomp)
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
@@ -400,8 +400,14 @@ public class StompClientConnectionImpl implements StompClientConnection {
     }
 
     private void send(StompFrame frame, Completable<StompFrame> receiptPromise) {
+        if (!netChannel.isActive() || !netChannel.isConnected()) {
+            close();
+            receiptPromise.fail(new StompNetChannelException("Channel is closed"));
+            return;
+        }
+
         Buffer body = frame.getBody();
-        if (!frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
+        if (body.length() > 0 && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
             frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length()));
         }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.core.codec.stomp;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -44,7 +45,7 @@ import org.traffichunter.titan.core.util.inet.Frame;
  */
 @Getter
 @Slf4j
-public final class StompFrame implements Frame<Elements, String> {
+public final class StompFrame implements Frame<Elements, String>, StompFrames {
 
     public static final StompFrame ERR_STOMP_FRAME =
             new StompFrame(new StompHeaders(StompVersion.STOMP_1_2), StompCommand.ERROR);
@@ -88,6 +89,21 @@ public final class StompFrame implements Frame<Elements, String> {
                                     final byte[] body) {
 
         return new StompFrame(headers, command, body);
+    }
+
+    @Override
+    public StompCommand command() {
+        return command;
+    }
+
+    @Override
+    public Map<Elements, String> headers() {
+        return headers.toMap();
+    }
+
+    @Override
+    public byte[] body() {
+        return body.getBytes();
     }
 
     @Override

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrames.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrames.java
@@ -1,0 +1,47 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.stomp;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
+
+/**
+ * @author yun
+ */
+public interface StompFrames {
+
+    StompCommand command();
+
+    @Nullable String getHeader(final Elements key);
+
+    /**
+     * These headers are read-only.
+     */
+    Map<Elements, String> headers();
+
+    byte[] body();
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompHeaders.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompHeaders.java
@@ -88,6 +88,10 @@ public final class StompHeaders extends Headers<StompHeaders.Elements, String, S
         return sb.toString();
     }
 
+    public Map<StompHeaders.Elements, String> toMap() {
+        return Map.copyOf(map);
+    }
+
     public static String decode(final String value, final StompCommand command) {
 
         final boolean skipCommand = (command == StompCommand.CONNECT || command == StompCommand.CONNECTED);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrame.java
@@ -28,7 +28,6 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
-import org.traffichunter.titan.core.util.Assert;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrame.java
@@ -1,0 +1,112 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.stomp.vertx;
+
+import io.vertx.ext.stomp.Frame;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
+
+/**
+ * @author yun
+ */
+@NullMarked
+public final class VertxStompFrame implements StompFrames {
+
+    private final Frame frame;
+
+    private VertxStompFrame(Frame frame) {
+        this.frame = frame;
+    }
+
+    public static VertxStompFrame wrap(Frame frame) {
+        return new VertxStompFrame(frame);
+    }
+
+    public Frame unwrap() {
+        return frame;
+    }
+
+    @Override
+    public StompCommand command() {
+        return switch (frame.getCommand()) {
+            case CONNECT -> StompCommand.CONNECT;
+            case CONNECTED -> StompCommand.CONNECTED;
+            case STOMP -> StompCommand.STOMP;
+            case SEND -> StompCommand.SEND;
+            case SUBSCRIBE -> StompCommand.SUBSCRIBE;
+            case UNSUBSCRIBE -> StompCommand.UNSUBSCRIBE;
+            case ACK -> StompCommand.ACK;
+            case NACK -> StompCommand.NACK;
+            case BEGIN -> StompCommand.BEGIN;
+            case COMMIT -> StompCommand.COMMIT;
+            case ABORT -> StompCommand.ABORT;
+            case DISCONNECT -> StompCommand.DISCONNECT;
+            case MESSAGE -> StompCommand.MESSAGE;
+            case RECEIPT -> StompCommand.RECEIPT;
+            case ERROR -> StompCommand.ERROR;
+            case PING -> StompCommand.PING;
+            case UNKNOWN -> throw new IllegalArgumentException("Unknown Vert.x STOMP command");
+        };
+    }
+
+    @Override
+    public @Nullable String getHeader(Elements key) {
+        return frame.getHeader(key.getName());
+    }
+
+    @Override
+    public Map<Elements, String> headers() {
+        return convertToHeaders(frame.getHeaders());
+    }
+
+    @Override
+    public byte[] body() {
+        if (frame.getBody() == null) {
+            return new byte[]{};
+        }
+        return frame.getBodyAsByteArray();
+    }
+
+    private static Map<Elements, String> convertToHeaders(Map<String, String> headers) {
+        Map<String, Elements> knownHeaders = Elements.toMap();
+        Map<Elements, String> converted = new HashMap<>();
+
+        headers.forEach((name, value) -> {
+            Elements element = knownHeaders.get(name);
+            if (element != null) {
+                converted.put(element, value);
+            }
+        });
+
+        return Map.copyOf(converted);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompManagedServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompManagedServer.java
@@ -1,0 +1,101 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi.vertx;
+
+import io.vertx.core.Future;
+import io.vertx.ext.stomp.StompServer;
+import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.spi.ManagedServer;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author yun
+ */
+@Slf4j
+public final class VertxStompManagedServer implements ManagedServer {
+
+    private final StompServer server;
+    private final ServerSettings settings;
+
+    public VertxStompManagedServer(StompServer server, ServerSettings settings) {
+        this.server = server;
+        this.settings = settings;
+    }
+
+    @Override
+    public String name() {
+        return settings.serverName();
+    }
+
+    public StompServer server() {
+        return server;
+    }
+
+    @Override
+    public void start() {
+        try {
+            await(server.listen());
+            log.info("Started Vert.x STOMP server {} on {}:{}", name(), settings.host(), settings.port());
+        } catch (Exception e) {
+            stop();
+            throw new IllegalStateException("Failed to start Vert.x STOMP server " + name(), e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        RuntimeException rex = null;
+
+        try {
+            if (server.isListening()) {
+                await(server.close());
+            }
+        } catch (RuntimeException e) {
+            rex = e;
+        }
+
+        try {
+            await(server.close());
+        } catch (RuntimeException e) {
+            if (rex == null) {
+                rex = e;
+            }
+        }
+
+        if (rex != null) {
+            throw new IllegalStateException("Failed to stop Vert.x STOMP server " + name(), rex);
+        }
+    }
+
+    private static void await(Future<?> future) {
+        try {
+            future.await(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            throw new IllegalStateException("Timed out waiting for Vert.x STOMP operation", e);
+        }
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -1,0 +1,203 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi.vertx;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.stomp.StompServer;
+import io.vertx.ext.stomp.StompServerHandler;
+import io.vertx.ext.stomp.StompServerOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
+import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
+import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.core.spi.NetworkServerEngineProvider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author yun
+ */
+@Slf4j
+public final class VertxStompServerEngineProvider implements NetworkServerEngineProvider {
+
+    @Override
+    public String transport() {
+        return "vertx";
+    }
+
+    @Override
+    public String protocol() {
+        return "stomp";
+    }
+
+    @Override
+    public boolean supports(ServerSettings settings) {
+        return settings.hasTransport()
+                && transport().equalsIgnoreCase(settings.transport())
+                && protocol().equalsIgnoreCase(settings.protocol());
+    }
+
+    @Override
+    public NetworkServerEngineProvider setInboundHandler(ChannelInBoundHandler channelInBoundHandler) {
+        return this;
+    }
+
+    @Override
+    public NetworkServerEngineProvider setOutboundHandler(ChannelOutBoundHandler channelOutBoundHandler) {
+        return this;
+    }
+
+    @Override
+    public ManagedServer create(ServerSettings settings) {
+        Vertx vertx = Vertx.vertx(new VertxOptions()
+                .setEventLoopPoolSize(settings.primaryThreads())
+                .setWorkerPoolSize(settings.secondaryThreads()));
+        StompServerOptions stompServerOptions = buildOption(
+                settings.resolvedProtocolOptions(),
+                settings.resolvedTransportOptions()
+        ).setPort(settings.port()).setHost(settings.host());
+
+        StompServer stompServer = StompServer.create(vertx, stompServerOptions)
+                .handler(StompServerHandler.create(vertx));
+
+        return new VertxStompManagedServer(stompServer, settings);
+    }
+
+    private static StompServerOptions buildOption(Map<String, String> protocolOptions, Map<String, String> transportOptions) {
+        StompServerOptions options = new StompServerOptions();
+
+        int maxHeaderLength = intOption(protocolOptions, "max-header-length", options.getMaxHeaderLength());
+        int maxHeaders = intOption(protocolOptions, "max-headers", options.getMaxHeaders());
+        int maxBodyLength = intOption(protocolOptions, "max-body-length", options.getMaxBodyLength());
+        int maxFrameInTransaction = intOption(
+                protocolOptions,
+                "max-frame-in-transaction",
+                options.getMaxFrameInTransaction()
+        );
+        int timeFactor = intOption(protocolOptions, "time-factor", options.getTimeFactor());
+        int transactionChunkSize = intOption(
+                protocolOptions,
+                "transaction-chunk-size",
+                options.getTransactionChunkSize()
+        );
+        int maxSubscriptionsByClient = intOption(
+                protocolOptions,
+                "max-subscriptions-by-client",
+                options.getMaxSubscriptionsByClient()
+        );
+        int receiveBufferSize = firstIntOption(
+                transportOptions,
+                options.getReceiveBufferSize(),
+                "receive-buffer-size",
+                "child-receive-buffer-size"
+        );
+        int sendBufferSize = firstIntOption(
+                transportOptions,
+                options.getSendBufferSize(),
+                "send-buffer-size",
+                "child-send-buffer-size"
+        );
+        int acceptBacklog = intOption(transportOptions, "accept-backlog", options.getAcceptBacklog());
+        long heartbeatX = longOption(protocolOptions, "heartbeat-x", options.getHeartbeat().getLong("x"));
+        long heartbeatY = longOption(protocolOptions, "heartbeat-y", options.getHeartbeat().getLong("y"));
+        List<String> supportedVersions = stringListOption(protocolOptions, options.getSupportedVersions());
+        String websocketPath = stringOption(protocolOptions, "websocket-path", options.getWebsocketPath());
+
+        options.setMaxHeaderLength(maxHeaderLength);
+        options.setMaxHeaders(maxHeaders);
+        options.setMaxBodyLength(maxBodyLength);
+        options.setMaxFrameInTransaction(maxFrameInTransaction);
+        options.setSupportedVersions(supportedVersions);
+        options.setTimeFactor(timeFactor);
+        options.setTransactionChunkSize(transactionChunkSize);
+        options.setMaxSubscriptionsByClient(maxSubscriptionsByClient);
+        options.setHeartbeat(new JsonObject()
+                .put("x", heartbeatX)
+                .put("y", heartbeatY)
+        );
+        options.setReceiveBufferSize(receiveBufferSize);
+        options.setSendBufferSize(sendBufferSize);
+        options.setAcceptBacklog(acceptBacklog);
+        options.setWebsocketPath(websocketPath);
+
+        options.setSecured(booleanOption(protocolOptions, "secured", false));
+        options.setSendErrorOnNoSubscriptions(booleanOption(protocolOptions, "send-error-on-no-subscriptions", false));
+        options.setWebsocketBridge(booleanOption(protocolOptions, "websocket-bridge", false));
+        options.setTrailingLine(booleanOption(protocolOptions, "trailing-line", false));
+        options.setReuseAddress(booleanOption(transportOptions, "reuse-address", true));
+        options.setReusePort(booleanOption(transportOptions, "reuse-port", false));
+        options.setTcpNoDelay(booleanOption(transportOptions, "tcp-no-delay",
+                booleanOption(transportOptions, "child-tcp-no-delay", true)));
+        options.setTcpKeepAlive(booleanOption(transportOptions, "tcp-keep-alive",
+                booleanOption(transportOptions, "child-keep-alive", false)));
+
+        return options;
+    }
+
+    private static int intOption(Map<String, String> options, String key, int defaultValue) {
+        String value = options.get(key);
+        return value == null || value.isBlank() ? defaultValue : Integer.parseInt(value);
+    }
+
+    private static int firstIntOption(Map<String, String> options, int defaultValue, String... keys) {
+        for (String key : keys) {
+            String value = options.get(key);
+            if (value != null && !value.isBlank()) {
+                return Integer.parseInt(value);
+            }
+        }
+        return defaultValue;
+    }
+
+    private static long longOption(Map<String, String> options, String key, long defaultValue) {
+        String value = options.get(key);
+        return value == null || value.isBlank() ? defaultValue : Long.parseLong(value);
+    }
+
+    private static boolean booleanOption(Map<String, String> options, String key, boolean defaultValue) {
+        String value = options.get(key);
+        return value == null || value.isBlank() ? defaultValue : Boolean.parseBoolean(value);
+    }
+
+    private static String stringOption(Map<String, String> options, String key, String defaultValue) {
+        String value = options.get(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private static List<String> stringListOption(Map<String, String> options, List<String> defaultValue) {
+        String value = stringOption(options, "supported-versions", "");
+        if (value.isBlank()) {
+            return defaultValue;
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .toList();
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/package-info.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.spi.vertx;
+
+import org.jspecify.annotations.NullMarked;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
@@ -25,6 +25,7 @@ package org.traffichunter.titan.core.transport.stomp;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -42,6 +43,9 @@ import org.traffichunter.titan.core.codec.stomp.*;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.InetClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.client.TitanStompClientOperations;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.util.Handler;
 
@@ -52,13 +56,14 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
  * @author yun
  */
 @Slf4j
-public final class TitanStompClient {
+public final class TitanStompClient implements StompClient {
 
     private final InetClient inetClient;
     private final StompClientOption option;
 
     private Handler<StompClientHandler> stompClientHandler = handler -> {};
     private @Nullable StompClientConnection connection;
+    private @Nullable TitanStompClientOperations operations;
 
     private TitanStompClient(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
         this.option = option;
@@ -75,6 +80,21 @@ public final class TitanStompClient {
 
     public static TitanStompClient open(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
         return new TitanStompClient(groups, inetClient, option);
+    }
+
+    @Override
+    public StompClientOperations operations() {
+        TitanStompClientOperations operations = this.operations;
+        if (operations == null) {
+            operations = new TitanStompClientOperations(connection());
+            this.operations = operations;
+        }
+        return operations;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return inetClient.isShutdown();
     }
 
     @CanIgnoreReturnValue
@@ -95,6 +115,17 @@ public final class TitanStompClient {
         }
 
         inetClient.start();
+    }
+
+    @Override
+    public Future<StompClientOperations> connect() {
+        return connect(option.host(), option.port())
+                .map(connection -> {
+                    TitanStompClientOperations operations = new TitanStompClientOperations(connection);
+                    this.operations = operations;
+                    return (StompClientOperations) operations;
+                })
+                .future();
     }
 
     public Promise<StompClientConnection> connect(String host, int port) {
@@ -164,6 +195,7 @@ public final class TitanStompClient {
         stompClientHandler.handle(connection.handler());
         channel.chain().add(new StompChannelDecoder(option.maxFrameLength(), connection, connection.handler()));
         this.connection = connection;
+        this.operations = new TitanStompClientOperations(connection);
         return connection;
     }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
@@ -52,7 +52,7 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
  * @author yun
  */
 @Slf4j
-public final class StompClient {
+public final class TitanStompClient {
 
     private final InetClient inetClient;
     private final StompClientOption option;
@@ -60,7 +60,7 @@ public final class StompClient {
     private Handler<StompClientHandler> stompClientHandler = handler -> {};
     private @Nullable StompClientConnection connection;
 
-    private StompClient(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
+    private TitanStompClient(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
         this.option = option;
 
         if (inetClient == null) {
@@ -69,22 +69,22 @@ public final class StompClient {
         this.inetClient = inetClient;
     }
 
-    public static StompClient open(EventLoopGroups groups, StompClientOption option) {
+    public static TitanStompClient open(EventLoopGroups groups, StompClientOption option) {
         return open(groups, null, option);
     }
 
-    public static StompClient open(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
-        return new StompClient(groups, inetClient, option);
+    public static TitanStompClient open(EventLoopGroups groups, @Nullable InetClient inetClient, StompClientOption option) {
+        return new TitanStompClient(groups, inetClient, option);
     }
 
     @CanIgnoreReturnValue
-    public StompClient onChannel(Handler<Channel> channelHandler) {
+    public TitanStompClient onChannel(Handler<Channel> channelHandler) {
         inetClient.onChannel(channelHandler);
         return this;
     }
 
     @CanIgnoreReturnValue
-    public StompClient onStomp(Handler<StompClientHandler> stompClientHandler) {
+    public TitanStompClient onStomp(Handler<StompClientHandler> stompClientHandler) {
         this.stompClientHandler = stompClientHandler;
         return this;
     }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
@@ -1,0 +1,293 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.stomp.StompClient;
+import io.vertx.ext.stomp.StompClientOptions;
+import io.vertx.ext.stomp.StompClientConnection;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.codec.stomp.StompException;
+import org.traffichunter.titan.core.transport.option.InetClientOption;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.client.VertxStompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+
+import java.net.SocketOption;
+import java.net.StandardSocketOptions;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author yun
+ */
+public final class VertxStompClient implements org.traffichunter.titan.core.transport.stomp.client.StompClient {
+
+    private final StompClientOption option;
+    private final boolean managedVertx;
+    private @Nullable Vertx vertx;
+    private @Nullable StompClient client;
+    private @Nullable StompClientConnection connection;
+    private @Nullable VertxStompClientOperations operations;
+    private volatile boolean isShutdown;
+
+    private VertxStompClient(
+            @Nullable Vertx vertx,
+            @Nullable StompClient client,
+            StompClientOption option,
+            boolean managedVertx
+    ) {
+        this.vertx = vertx;
+        this.client = client;
+        this.option = option;
+        this.managedVertx = managedVertx;
+    }
+
+    public static VertxStompClient open(StompClientOption option) {
+        return new VertxStompClient(null, null, option, true);
+    }
+
+    public static VertxStompClient open(Vertx vertx, StompClientOption option) {
+        return new VertxStompClient(vertx, null, option, false);
+    }
+
+    public static VertxStompClient wrap(StompClient client, StompClientOption option) {
+        return new VertxStompClient(client.vertx(), client, option, false);
+    }
+
+    @Override
+    public void start() {
+        if (isShutdown) {
+            throw new StompException("Client has been shut down");
+        }
+        if (client != null && !client.isClosed()) {
+            throw new StompException("Client already started");
+        }
+
+        Vertx vertx = this.vertx;
+        if (vertx == null) {
+            vertx = Vertx.vertx();
+            this.vertx = vertx;
+        }
+        client = StompClient.create(vertx, toVertxOptions(option));
+    }
+
+    @Override
+    public Future<StompClientOperations> connect() {
+        StompClientConnection connection = this.connection;
+        if (connection != null && connection.isConnected()) {
+            return CompletableFuture.failedFuture(new StompException("STOMP client is already connected"));
+        }
+
+        StompClient nativeClient = this.client;
+        if (nativeClient == null || nativeClient.isClosed()) {
+            return CompletableFuture.failedFuture(new StompException("Client is not started"));
+        }
+
+        io.vertx.core.Future<StompClientOperations> client = nativeClient
+                .connect(option.port(), option.host())
+                .map(conn -> {
+                    VertxStompClientOperations operations = new VertxStompClientOperations(conn);
+                    this.connection = conn;
+                    this.operations = operations;
+                    return operations;
+                });
+
+        return VertxFutureWrapper.wrap(client);
+    }
+
+    @Override
+    public StompClientOperations operations() {
+        VertxStompClientOperations operations = this.operations;
+        if (operations == null) {
+            StompClientConnection connection = this.connection;
+            if (connection == null) {
+                throw new IllegalStateException("STOMP client is not connected");
+            }
+            operations = new VertxStompClientOperations(connection);
+            this.operations = operations;
+        }
+        return operations;
+    }
+
+    @Override
+    public boolean isStart() {
+        return client != null && !client.isClosed();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        StompClient client = this.client;
+        return isShutdown || client != null && client.isClosed();
+    }
+
+    @Override
+    public void shutdown(long timeout, TimeUnit unit) {
+        StompClient client = this.client;
+        try {
+            if (client != null && !client.isClosed()) {
+                client.close().await(timeout, unit);
+            }
+            Vertx vertx = this.vertx;
+            if (managedVertx && vertx != null) {
+                vertx.close().await(timeout, unit);
+            }
+        } catch (TimeoutException e) {
+            throw new StompException("Timed out shutting down Vert.x STOMP client", e);
+        } finally {
+            isShutdown = true;
+        }
+    }
+
+    public StompClientOption option() {
+        return option;
+    }
+
+    public StompClient client() {
+        StompClient client = this.client;
+        if (client == null || client.isClosed()) {
+            throw new IllegalStateException("STOMP client is not started");
+        }
+        return client;
+    }
+
+    public StompClientConnection connection() {
+        StompClientConnection connection = this.connection;
+        if (connection == null) {
+            throw new IllegalStateException("STOMP client is not connected");
+        }
+        return connection;
+    }
+
+    private static StompClientOptions toVertxOptions(StompClientOption option) {
+        StompClientOptions vertxOptions = new StompClientOptions()
+                .setHost(option.host())
+                .setPort(option.port())
+                .setAcceptedVersions(List.of(option.stompVersion().getVersion()))
+                .setAutoComputeContentLength(option.autoComputeContentLength())
+                .setUseStompFrame(option.useStompFrame())
+                .setBypassHostHeader(option.bypassHostHeader())
+                .setHeartbeat(new JsonObject()
+                        .put("x", option.heartbeatX())
+                        .put("y", option.heartbeatY())
+                );
+
+        if (option.login() != null) {
+            vertxOptions.setLogin(option.login());
+        }
+        if (option.passcode() != null) {
+            vertxOptions.setPasscode(option.passcode());
+        }
+        if (option.virtualHost() != null) {
+            vertxOptions.setVirtualHost(option.virtualHost());
+        }
+
+        applyInetOptions(vertxOptions, option.inetClientOption());
+        return vertxOptions;
+    }
+
+    private static void applyInetOptions(StompClientOptions vertxOptions, InetClientOption option) {
+        Map<SocketOption<?>, Object> socketOptions = option.socketOptions();
+        applyBoolean(socketOptions, StandardSocketOptions.TCP_NODELAY, vertxOptions::setTcpNoDelay);
+        applyBoolean(socketOptions, StandardSocketOptions.SO_KEEPALIVE, vertxOptions::setTcpKeepAlive);
+        applyBoolean(socketOptions, StandardSocketOptions.SO_REUSEADDR, vertxOptions::setReuseAddress);
+        applyInteger(socketOptions, StandardSocketOptions.SO_SNDBUF, vertxOptions::setSendBufferSize);
+        applyInteger(socketOptions, StandardSocketOptions.SO_RCVBUF, vertxOptions::setReceiveBufferSize);
+        applyInteger(socketOptions, StandardSocketOptions.SO_LINGER, vertxOptions::setSoLinger);
+    }
+
+    private static void applyBoolean(
+            Map<SocketOption<?>, Object> socketOptions,
+            SocketOption<Boolean> option,
+            BooleanOptionSetter setter
+    ) {
+        Object value = socketOptions.get(option);
+        if (value instanceof Boolean bool) {
+            setter.set(bool);
+        }
+    }
+
+    private static void applyInteger(
+            Map<SocketOption<?>, Object> socketOptions,
+            SocketOption<Integer> option,
+            IntegerOptionSetter setter
+    ) {
+        Object value = socketOptions.get(option);
+        if (value instanceof Integer number) {
+            setter.set(number);
+        }
+    }
+
+    private record VertxFutureWrapper<V>(CompletableFuture<V> future) implements Future<V> {
+
+        private VertxFutureWrapper(io.vertx.core.Future<V> future) {
+            this(future.toCompletionStage().toCompletableFuture());
+        }
+
+        static <V> Future<V> wrap(io.vertx.core.Future<V> future) {
+            return new VertxFutureWrapper<>(future);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return future.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return future.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return future.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return future.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return future.get(timeout, unit);
+        }
+    }
+
+    @FunctionalInterface
+    private interface BooleanOptionSetter {
+        void set(boolean value);
+    }
+
+    @FunctionalInterface
+    private interface IntegerOptionSetter {
+        void set(int value);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
@@ -23,8 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.transport.stomp.client;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -41,9 +39,7 @@ public interface StompClient {
 
     StompClientOperations operations();
 
-    @Nullable StompClientOperations currentOperations();
-
-    boolean isStarted();
+    boolean isStart();
 
     boolean isShutdown();
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
@@ -1,0 +1,51 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Transport-neutral lifecycle for a STOMP client.
+ *
+ * @author yun
+ */
+public interface StompClient {
+
+    void start();
+
+    Future<StompClientOperations> connect();
+
+    StompClientOperations operations();
+
+    @Nullable StompClientOperations currentOperations();
+
+    boolean isStarted();
+
+    boolean isShutdown();
+
+    void shutdown(long timeout, TimeUnit unit);
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientOperations.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientOperations.java
@@ -1,0 +1,61 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
+
+/**
+ * Transport-neutral STOMP client operations.
+ *
+ * @author yun
+ */
+public interface StompClientOperations {
+
+    Future<StompFrames> send(String destination, Buffer payload);
+
+    Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers);
+
+    Future<String> subscribe(String destination, Handler<StompFrames> handler);
+
+    Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler);
+
+    Future<StompFrames> unsubscribe(String subscriptionId);
+
+    Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers);
+
+    Future<StompFrames> ack(String messageId);
+
+    Future<StompFrames> nack(String messageId);
+
+    Future<StompFrames> disconnect();
+
+    boolean isConnected();
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientProvider.java
@@ -34,7 +34,9 @@ public interface StompClientProvider {
 
     String name();
 
-    boolean supports(String transport);
+    String version();
+
+    boolean supports(String transport, String version);
 
     StompClient create(StompClientOption option);
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClientProvider.java
@@ -1,0 +1,40 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+
+/**
+ * Service-provider contract for STOMP clients.
+ *
+ * @author yun
+ */
+public interface StompClientProvider {
+
+    String name();
+
+    boolean supports(String transport);
+
+    StompClient create(StompClientOption option);
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientOperations.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientOperations.java
@@ -27,6 +27,7 @@ import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -46,6 +47,7 @@ public final class TitanStompClientOperations implements StompClientOperations {
 
     @Override
     public Future<StompFrames> send(String destination, Buffer payload) {
+        validateDestination(destination);
         return connection.send(destination, payload)
                 .map(f -> (StompFrames) f)
                 .future();
@@ -53,6 +55,7 @@ public final class TitanStompClientOperations implements StompClientOperations {
 
     @Override
     public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+        validateDestination(destination);
         return connection.send(destination, payload, toHeaders(headers))
                 .map(f -> (StompFrames) f)
                 .future();
@@ -65,6 +68,7 @@ public final class TitanStompClientOperations implements StompClientOperations {
 
     @Override
     public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+        validateDestination(destination);
         StompHeaders stompHeaders = toHeaders(headers);
         String subscriptionId = stompHeaders.getOrDefault(Elements.ID, destination);
         return connection.subscribe(destination, stompHeaders, handler::handle)
@@ -116,5 +120,9 @@ public final class TitanStompClientOperations implements StompClientOperations {
         StompHeaders stompHeaders = StompHeaders.create();
         headers.forEach(stompHeaders::put);
         return stompHeaders;
+    }
+
+    private static void validateDestination(String destination) {
+        Destination.create(destination);
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientOperations.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientOperations.java
@@ -1,0 +1,120 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.traffichunter.titan.core.channel.stomp.StompClientConnection;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.Map;
+import java.util.concurrent.Future;
+
+/**
+ * @author yun
+ */
+public final class TitanStompClientOperations implements StompClientOperations {
+
+    private final StompClientConnection connection;
+
+    public TitanStompClientOperations(StompClientConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Future<StompFrames> send(String destination, Buffer payload) {
+        return connection.send(destination, payload)
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+        return connection.send(destination, payload, toHeaders(headers))
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+        return subscribe(destination, Map.of(), handler);
+    }
+
+    @Override
+    public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+        StompHeaders stompHeaders = toHeaders(headers);
+        String subscriptionId = stompHeaders.getOrDefault(Elements.ID, destination);
+        return connection.subscribe(destination, stompHeaders, handler::handle)
+                .map(frame -> subscriptionId)
+                .future();
+    }
+
+    @Override
+    public Future<StompFrames> unsubscribe(String subscriptionId) {
+        return unsubscribe(subscriptionId, Map.of());
+    }
+
+    @Override
+    public Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
+        StompHeaders stompHeaders = toHeaders(headers);
+        stompHeaders.put(Elements.ID, subscriptionId);
+        return connection.unsubscribe(subscriptionId, stompHeaders)
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public Future<StompFrames> ack(String messageId) {
+        return connection.ack(messageId)
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public Future<StompFrames> nack(String messageId) {
+        return connection.nack(messageId)
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public Future<StompFrames> disconnect() {
+        return connection.disconnect()
+                .map(f -> (StompFrames) f)
+                .future();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connection.isConnected();
+    }
+
+    private static StompHeaders toHeaders(Map<Elements, String> headers) {
+        StompHeaders stompHeaders = StompHeaders.create();
+        headers.forEach(stompHeaders::put);
+        return stompHeaders;
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompClientProvider.java
@@ -1,0 +1,63 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.codec.stomp.StompVersion;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+
+import java.util.function.Supplier;
+
+/**
+ * @author yun
+ */
+public final class TitanStompClientProvider implements StompClientProvider {
+
+    private final Supplier<EventLoopGroups> eventLoopGroups;
+
+    public TitanStompClientProvider(Supplier<EventLoopGroups> eventLoopGroups) {
+        this.eventLoopGroups = eventLoopGroups;
+    }
+
+    @Override
+    public String name() {
+        return "titan";
+    }
+
+    @Override
+    public String version() {
+        return StompVersion.STOMP_1_2.getVersion();
+    }
+
+    @Override
+    public boolean supports(String transport, String version) {
+        return name().equalsIgnoreCase(transport) && version().equals(version);
+    }
+
+    @Override
+    public StompClient create(StompClientOption option) {
+        return TitanStompClient.open(eventLoopGroups.get(), option);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperations.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperations.java
@@ -1,0 +1,160 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import io.vertx.ext.stomp.StompClientConnection;
+import org.jspecify.annotations.NullMarked;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.codec.stomp.vertx.VertxStompFrame;
+import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author yun
+ */
+public final class VertxStompClientOperations implements StompClientOperations {
+
+    private final StompClientConnection connection;
+
+    public VertxStompClientOperations(StompClientConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Future<StompFrames> send(String destination, Buffer payload) {
+        return toFuture(connection.send(destination, toVertxBuffer(payload)));
+    }
+
+    @Override
+    public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+        return toFuture(connection.send(destination, toVertxHeaders(headers), toVertxBuffer(payload)));
+    }
+
+    @Override
+    public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+        return VertxFutureWrapper.wrap(connection.subscribe(
+                destination,
+                frame -> handler.handle(VertxStompFrame.wrap(frame))
+        ));
+    }
+
+    @Override
+    public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+        return VertxFutureWrapper.wrap(connection.subscribe(
+                destination,
+                toVertxHeaders(headers),
+                frame -> handler.handle(VertxStompFrame.wrap(frame))
+        ));
+    }
+
+    @Override
+    public Future<StompFrames> unsubscribe(String subscriptionId) {
+        return toFuture(connection.unsubscribe(subscriptionId));
+    }
+
+    @Override
+    public Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
+        return toFuture(connection.unsubscribe(subscriptionId, toVertxHeaders(headers)));
+    }
+
+    @Override
+    public Future<StompFrames> ack(String messageId) {
+        return toFuture(connection.ack(messageId));
+    }
+
+    @Override
+    public Future<StompFrames> nack(String messageId) {
+        return toFuture(connection.nack(messageId));
+    }
+
+    @Override
+    public Future<StompFrames> disconnect() {
+        return toFuture(connection.disconnect());
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connection.isConnected();
+    }
+
+    @NullMarked
+    private record VertxFutureWrapper<V>(CompletableFuture<V> future) implements Future<V> {
+
+        private VertxFutureWrapper(io.vertx.core.Future<V> future) {
+            this(future.toCompletionStage().toCompletableFuture());
+        }
+
+        static <V> Future<V> wrap(io.vertx.core.Future<V> future) {
+            return new VertxFutureWrapper<>(future);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return future.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return future.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return future.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return future.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return future.get(timeout, unit);
+        }
+    }
+
+    private static Future<StompFrames> toFuture(io.vertx.core.Future<io.vertx.ext.stomp.Frame> future) {
+        return VertxFutureWrapper.wrap(future.map(VertxStompFrame::wrap));
+    }
+
+    private static io.vertx.core.buffer.Buffer toVertxBuffer(Buffer buffer) {
+        return io.vertx.core.buffer.Buffer.buffer(buffer.getBytes());
+    }
+
+    private static Map<String, String> toVertxHeaders(Map<Elements, String> headers) {
+        Map<String, String> converted = new HashMap<>();
+        headers.forEach((element, value) -> converted.put(element.getName(), value));
+        return converted;
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperations.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperations.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.NullMarked;
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 import org.traffichunter.titan.core.codec.stomp.vertx.VertxStompFrame;
+import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -52,16 +53,19 @@ public final class VertxStompClientOperations implements StompClientOperations {
 
     @Override
     public Future<StompFrames> send(String destination, Buffer payload) {
+        validateDestination(destination);
         return toFuture(connection.send(destination, toVertxBuffer(payload)));
     }
 
     @Override
     public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+        validateDestination(destination);
         return toFuture(connection.send(destination, toVertxHeaders(headers), toVertxBuffer(payload)));
     }
 
     @Override
     public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+        validateDestination(destination);
         return VertxFutureWrapper.wrap(connection.subscribe(
                 destination,
                 frame -> handler.handle(VertxStompFrame.wrap(frame))
@@ -70,6 +74,7 @@ public final class VertxStompClientOperations implements StompClientOperations {
 
     @Override
     public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+        validateDestination(destination);
         return VertxFutureWrapper.wrap(connection.subscribe(
                 destination,
                 toVertxHeaders(headers),
@@ -156,5 +161,9 @@ public final class VertxStompClientOperations implements StompClientOperations {
         Map<String, String> converted = new HashMap<>();
         headers.forEach((element, value) -> converted.put(element.getName(), value));
         return converted;
+    }
+
+    private static void validateDestination(String destination) {
+        Destination.create(destination);
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientProvider.java
@@ -1,0 +1,54 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import org.traffichunter.titan.core.codec.stomp.StompVersion;
+import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+
+/**
+ * @author yun
+ */
+public final class VertxStompClientProvider implements StompClientProvider {
+
+    @Override
+    public String name() {
+        return "vertx";
+    }
+
+    @Override
+    public String version() {
+        return StompVersion.STOMP_1_2.getVersion();
+    }
+
+    @Override
+    public boolean supports(String transport, String version) {
+        return name().equalsIgnoreCase(transport) && version().equals(version);
+    }
+
+    @Override
+    public StompClient create(StompClientOption option) {
+        return VertxStompClient.open(option);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/package-info.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Transport-neutral STOMP client contracts.
+ *
+ * <p>These contracts sit above native client connections so Spring and other integrations can
+ * use the same API for Titan TCP and Vert.x transports.</p>
+ *
+ * @author yun
+ */
+package org.traffichunter.titan.core.transport.stomp.client;

--- a/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
+++ b/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
@@ -1,1 +1,2 @@
 org.traffichunter.titan.core.spi.StompServerEngineProvider
+org.traffichunter.titan.core.spi.vertx.VertxStompServerEngineProvider

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrameTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/vertx/VertxStompFrameTest.java
@@ -1,0 +1,57 @@
+package org.traffichunter.titan.core.codec.stomp.vertx;
+
+import io.vertx.ext.stomp.Command;
+import io.vertx.ext.stomp.Frame;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VertxStompFrameTest {
+
+    @Test
+    void wraps_vertx_frame_as_stomp_frames() {
+        Frame frame = new Frame(
+                Command.MESSAGE,
+                Map.of(
+                        Frame.DESTINATION, "/topic/test",
+                        Frame.MESSAGE_ID, "msg-1",
+                        "custom-header", "ignored"
+                ),
+                io.vertx.core.buffer.Buffer.buffer("hello")
+        );
+
+        VertxStompFrame wrapped = VertxStompFrame.wrap(frame);
+
+        assertThat(wrapped.command()).isEqualTo(StompCommand.MESSAGE);
+        assertThat(wrapped.getHeader(StompHeaders.Elements.DESTINATION)).isEqualTo("/topic/test");
+        assertThat(wrapped.headers())
+                .containsEntry(StompHeaders.Elements.DESTINATION, "/topic/test")
+                .containsEntry(StompHeaders.Elements.MESSAGE_ID, "msg-1")
+                .doesNotContainKey(StompHeaders.Elements.CONTENT_TYPE);
+        assertThat(new String(wrapped.body(), StandardCharsets.UTF_8)).isEqualTo("hello");
+        assertThat(wrapped.unwrap()).isSameAs(frame);
+    }
+
+    @Test
+    void returns_empty_body_when_vertx_frame_body_is_null() {
+        VertxStompFrame wrapped = VertxStompFrame.wrap(new Frame().setCommand(Command.RECEIPT));
+
+        assertThat(wrapped.command()).isEqualTo(StompCommand.RECEIPT);
+        assertThat(wrapped.body()).isEmpty();
+    }
+
+    @Test
+    void rejects_unknown_vertx_command() {
+        VertxStompFrame wrapped = VertxStompFrame.wrap(new Frame().setCommand(Command.UNKNOWN));
+
+        assertThatThrownBy(wrapped::command)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown Vert.x STOMP command");
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
@@ -75,7 +75,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_client_can_connect_to_server_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -91,7 +91,7 @@ class StompIntegrationTest {
 
     @RepeatedTest(5)
     void stomp_reconnect_cycle_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -113,7 +113,7 @@ class StompIntegrationTest {
 
     @RepeatedTest(10)
     void stomp_ping_pong_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -129,7 +129,7 @@ class StompIntegrationTest {
     void stomp_send_with_text_body_test(StompTestServer testServer, Dispatcher dispatcher) throws Exception {
         Destination key = Destination.create("/queue/test");
         DispatcherQueue queue = dispatcher.getOrPut(key);
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -159,7 +159,7 @@ class StompIntegrationTest {
         AtomicReference<StompFrame> receivedFrame = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
 
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -197,7 +197,7 @@ class StompIntegrationTest {
         Destination key = Destination.create("/topic/unsub");
         DispatcherQueue queue = dispatcher.getOrPut(key);
 
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -231,7 +231,7 @@ class StompIntegrationTest {
         dispatcher.getOrPut(key2);
         dispatcher.getOrPut(key3);
 
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -265,7 +265,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_ack_command_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -278,7 +278,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_nack_command_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -291,7 +291,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_ack_within_transaction_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -323,7 +323,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_nack_within_transaction_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -357,7 +357,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_transaction_begin_commit_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -373,7 +373,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_transaction_begin_abort_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -392,7 +392,7 @@ class StompIntegrationTest {
         Destination key = Destination.create("/queue/tx-test");
         DispatcherQueue queue = dispatcher.getOrPut(key);
 
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION)
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION)
                 .onChannel(channel ->
                         channel.chain()
                             .add(new TestChannelInboundHandler(queue))
@@ -422,7 +422,7 @@ class StompIntegrationTest {
 
     @RepeatedTest(3)
     void stomp_multiple_transactions_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -446,7 +446,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_disconnect_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -466,7 +466,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_subscribe_to_nonexistent_destination_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();
@@ -483,7 +483,7 @@ class StompIntegrationTest {
 
     @Test
     void stomp_commit_without_begin_test(StompTestServer testServer) throws Exception {
-        StompClient client = StompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
+        TitanStompClient client = TitanStompClient.open(clientGroups(), StompClientOption.DEFAULT_STOMP_CLIENT_OPTION);
 
         try {
             client.start();

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/VertxStompClientTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/VertxStompClientTest.java
@@ -1,0 +1,91 @@
+package org.traffichunter.titan.core.transport.stomp;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.stomp.StompClientConnection;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.codec.stomp.StompException;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.client.VertxStompClientOperations;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class VertxStompClientTest {
+
+    @Test
+    void rejects_connect_before_start() {
+        VertxStompClient client = VertxStompClient.open(StompClientOption.builder().build());
+
+        assertThatThrownBy(() -> client.connect().get())
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(StompException.class)
+                .hasRootCauseMessage("Client is not started");
+    }
+
+    @Test
+    void connects_with_wrapped_native_client_and_caches_operations() throws Exception {
+        io.vertx.ext.stomp.StompClient nativeClient = mock(io.vertx.ext.stomp.StompClient.class);
+        StompClientConnection connection = mock(StompClientConnection.class);
+        StompClientOption option = StompClientOption.builder()
+                .host("127.0.0.1")
+                .port(61613)
+                .build();
+
+        when(nativeClient.vertx()).thenReturn(mock(Vertx.class));
+        when(nativeClient.isClosed()).thenReturn(false);
+        when(nativeClient.connect(61613, "127.0.0.1"))
+                .thenReturn(io.vertx.core.Future.succeededFuture(connection));
+
+        VertxStompClient client = VertxStompClient.wrap(nativeClient, option);
+
+        StompClientOperations operations = client.connect().get();
+
+        assertThat(operations).isInstanceOf(VertxStompClientOperations.class);
+        assertThat(client.operations()).isSameAs(operations);
+        assertThat(client.connection()).isSameAs(connection);
+    }
+
+    @Test
+    void rejects_connect_when_already_connected() throws Exception {
+        io.vertx.ext.stomp.StompClient nativeClient = mock(io.vertx.ext.stomp.StompClient.class);
+        StompClientConnection connection = mock(StompClientConnection.class);
+        StompClientOption option = StompClientOption.builder().build();
+
+        when(nativeClient.vertx()).thenReturn(mock(Vertx.class));
+        when(nativeClient.isClosed()).thenReturn(false);
+        when(nativeClient.connect(option.port(), option.host()))
+                .thenReturn(io.vertx.core.Future.succeededFuture(connection));
+        when(connection.isConnected()).thenReturn(true);
+
+        VertxStompClient client = VertxStompClient.wrap(nativeClient, option);
+        client.connect().get();
+
+        assertThatThrownBy(() -> client.connect().get())
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(StompException.class);
+    }
+
+    @Test
+    void shutdown_closes_native_client() {
+        io.vertx.ext.stomp.StompClient nativeClient = mock(io.vertx.ext.stomp.StompClient.class);
+        StompClientOption option = StompClientOption.builder().build();
+
+        when(nativeClient.vertx()).thenReturn(mock(Vertx.class));
+        when(nativeClient.isClosed()).thenReturn(false);
+        when(nativeClient.close()).thenReturn(io.vertx.core.Future.succeededFuture());
+
+        VertxStompClient client = VertxStompClient.wrap(nativeClient, option);
+
+        client.shutdown(1, TimeUnit.SECONDS);
+
+        verify(nativeClient).close();
+        assertThat(client.isShutdown()).isTrue();
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperationsTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompClientOperationsTest.java
@@ -1,0 +1,104 @@
+package org.traffichunter.titan.core.transport.stomp.client;
+
+import io.vertx.ext.stomp.Command;
+import io.vertx.ext.stomp.Frame;
+import io.vertx.ext.stomp.StompClientConnection;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class VertxStompClientOperationsTest {
+
+    @Test
+    void sends_with_converted_headers_and_payload() throws Exception {
+        StompClientConnection connection = mock(StompClientConnection.class);
+        Frame receipt = new Frame().setCommand(Command.RECEIPT);
+        when(connection.send(eq("/topic/test"), anyMap(), any(io.vertx.core.buffer.Buffer.class)))
+                .thenReturn(io.vertx.core.Future.succeededFuture(receipt));
+
+        VertxStompClientOperations operations = new VertxStompClientOperations(connection);
+
+        StompFrames result = operations.send(
+                "/topic/test",
+                Buffer.alloc("hello"),
+                Map.of(
+                        Elements.ID, "sub-1",
+                        Elements.RECEIPT, "receipt-1"
+                )
+        ).get();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<io.vertx.core.buffer.Buffer> payload = ArgumentCaptor.forClass(io.vertx.core.buffer.Buffer.class);
+        verify(connection).send(eq("/topic/test"), headers.capture(), payload.capture());
+
+        assertThat(result.command()).isEqualTo(StompCommand.RECEIPT);
+        assertThat(headers.getValue())
+                .containsEntry("id", "sub-1")
+                .containsEntry("receipt", "receipt-1");
+        assertThat(payload.getValue().toString(StandardCharsets.UTF_8)).isEqualTo("hello");
+    }
+
+    @Test
+    void subscribes_with_converted_headers_and_wrapped_message_handler() throws Exception {
+        StompClientConnection connection = mock(StompClientConnection.class);
+        when(connection.subscribe(
+                eq("/topic/test"),
+                anyMap(),
+                any()
+        )).thenReturn(io.vertx.core.Future.succeededFuture("sub-1"));
+
+        VertxStompClientOperations operations = new VertxStompClientOperations(connection);
+        AtomicReference<StompFrames> received = new AtomicReference<>();
+
+        String subscriptionId = operations.subscribe(
+                "/topic/test",
+                Map.of(Elements.ID, "sub-1"),
+                received::set
+        ).get();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<io.vertx.core.Handler<Frame>> handler = ArgumentCaptor.forClass(io.vertx.core.Handler.class);
+        verify(connection).subscribe(eq("/topic/test"), headers.capture(), handler.capture());
+
+        Frame message = new Frame(
+                Command.MESSAGE,
+                Map.of(Frame.DESTINATION, "/topic/test"),
+                io.vertx.core.buffer.Buffer.buffer("body")
+        );
+        handler.getValue().handle(message);
+
+        assertThat(subscriptionId).isEqualTo("sub-1");
+        assertThat(headers.getValue()).containsEntry("id", "sub-1");
+        assertThat(received.get()).isNotNull();
+        assertThat(received.get().command()).isEqualTo(StompCommand.MESSAGE);
+        assertThat(new String(received.get().body(), StandardCharsets.UTF_8)).isEqualTo("body");
+    }
+
+    @Test
+    void delegates_connection_state() {
+        StompClientConnection connection = mock(StompClientConnection.class);
+        when(connection.isConnected()).thenReturn(true);
+
+        VertxStompClientOperations operations = new VertxStompClientOperations(connection);
+
+        assertThat(operations.isConnected()).isTrue();
+    }
+}


### PR DESCRIPTION
## Motivation:

Titan currently has STOMP support coupled to the native client/server path, which makes it difficult to introduce Vert.x transport support without changing fanout and Spring client code. This PR introduces transport-neutral STOMP abstractions so Titan native and Vert.x implementations can coexist behind the same API.

## Modification:

- Add Vert.x STOMP server/client support and transport-neutral STOMP client adapters.
- Switch Spring STOMP client integration to the `StompClient` / `StompClientOperations` SPI.
- Add provider implementations for Titan native and Vert.x clients.
- Add fanout server adapters/exporters for Titan native and Vert.x STOMP transports.
- Refine fanout aggregation result handling.
- Split Spring smoke tests into Titan and Vert.x client contexts and verify the selected client/operations type.
- Update the pull request template to use Motivation, Modification, and Result sections.

## Result:

This PR enables selecting Titan native or Vert.x as the Spring STOMP client while keeping fanout and Spring-facing APIs transport-neutral.

Validation:

- `./gradlew test`