### PR TITLE
Use random IDs for channel sessions

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
@@ -58,8 +58,8 @@ public abstract class AbstractChannel implements Channel {
     private final ChannelHandShakeEventListener initializer;
     private final ChannelHandlerChain chain;
     private volatile Instant lastActiveAt = Instant.now();
-    private final String channelId = IdGenerator.uuid();
-    private final String sessionId = IdGenerator.uuid();
+    private final String channelId = IdGenerator.randomId("channel");
+    private final String sessionId = IdGenerator.randomId("session");
 
     private static final AtomicReferenceFieldUpdater<AbstractChannel, ChannelState> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(AbstractChannel.class, ChannelState.class, "state");

--- a/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
@@ -23,7 +23,10 @@
  */
 package org.traffichunter.titan.core.util;
 
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.Configurations;
 
 /**
@@ -31,8 +34,22 @@ import org.traffichunter.titan.bootstrap.Configurations;
  */
 public final class IdGenerator {
 
-    public static String uuid(){
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int RANDOM_ID_BYTES = 16;
+
+    public static String uuid() {
         return UUID.randomUUID().toString();
+    }
+
+    public static String randomId(@Nullable String prefix) {
+        if (prefix == null) {
+            prefix = "titan";
+        }
+
+        byte[] bytes = new byte[RANDOM_ID_BYTES];
+        SECURE_RANDOM.nextBytes(bytes);
+
+        return prefix + "-" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     public static String name() {

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
@@ -1,0 +1,30 @@
+package org.traffichunter.titan.core.test.implementation;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.IdGenerator;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author yun
+ */
+class IdGeneratorTest {
+
+    @Test
+    void generate_random_id_test() {
+        String randomId = IdGenerator.randomId(null);
+
+        assertThat(randomId).isNotNull();
+        assertThat(randomId).startsWith("titan-");
+        assertThat(randomId).hasSize("titan-".length() + 22);
+    }
+
+    @Test
+    void generate_random_id_prefix_test() {
+        String randomId = IdGenerator.randomId("qwer");
+
+        assertThat(randomId).isNotNull();
+        assertThat(randomId).startsWith("qwer-");
+        assertThat(randomId).hasSize("qwer-".length() + 22);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
@@ -58,7 +58,7 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 @Slf4j
 public class StompClientConnectionImpl implements StompClientConnection {
 
-    private final String sessionId = IdGenerator.uuid();
+    private final String sessionId = IdGenerator.randomId("session");
     private final NetChannel netChannel;
     private final StompClientHandler stompClientHandler;
     private final StompClientOption option;


### PR DESCRIPTION
## Motivation:

Channel and STOMP session identifiers currently use UUID strings directly. That works, but the generated values are longer than necessary for internal session tracking. `IdGenerator.randomId(...)` provides a shorter base64url random identifier, so session IDs can use that shared generator instead.

## Modification:

- Add `IdGenerator.randomId(...)` support backed by a reusable `SecureRandom`.
- Generate channel IDs with the `channel` prefix and session IDs with the `session` prefix.
- Apply random session IDs to `StompClientConnectionImpl`.
- Add tests for default/custom prefixes and the 16-byte base64url encoded ID length.

## Result:

Channel and STOMP client sessions now use compact random IDs such as `session-...` instead of UUID strings, while UUID generation remains available for existing protocol IDs.

Validation:

- `./gradlew :core:test :titan-stomp:test`
