### PR TITLE
Add fault tolerance groundwork for Spring STOMP client

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/EventLoopRetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/EventLoopRetryExecutor.java
@@ -1,0 +1,152 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.EventLoop;
+import org.traffichunter.titan.core.channel.TaskEventLoop;
+import org.traffichunter.titan.core.concurrent.ScheduledPromise;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author yun
+ */
+public class EventLoopRetryExecutor implements RetryExecutor {
+
+    private final EventLoop eventLoop;
+    private final RetryPolicy retryPolicy;
+    private final RetryListener retryListener;
+
+    public EventLoopRetryExecutor(RetryPolicy retryPolicy) {
+        this(retryPolicy, RetryListener.NOOP);
+    }
+
+    public EventLoopRetryExecutor(RetryPolicy retryPolicy, RetryListener retryListener) {
+        this(new TaskEventLoop(), retryPolicy, retryListener);
+    }
+
+    public EventLoopRetryExecutor(EventLoop eventLoop, RetryListener retryListener, RetryPolicy retryPolicy) {
+        this(eventLoop, retryPolicy, retryListener);
+    }
+
+    private EventLoopRetryExecutor(
+            EventLoop eventLoop,
+            RetryPolicy retryPolicy,
+            RetryListener retryListener
+    ) {
+        this.eventLoop = eventLoop;
+        this.retryPolicy = retryPolicy;
+        this.retryListener = retryListener;
+    }
+
+    @Override
+    public RetryResult retry(Runnable callback) {
+        EventLoopRetryResult result = new EventLoopRetryResult();
+        schedule(Executors.callable(callback), result, 1);
+        return result;
+    }
+
+    @Override
+    public <T> RetryResult retry(Callable<T> callback) {
+        EventLoopRetryResult result = new EventLoopRetryResult();
+        schedule(callback, result, 1);
+        return result;
+    }
+
+    @Override
+    public void shutdown(long timeout, TimeUnit timeUnit) {
+        eventLoop.gracefullyShutdown(timeout, timeUnit);
+    }
+
+    private <T> void schedule(Callable<T> callback, EventLoopRetryResult result, int attempt) {
+        if (eventLoop.isNotStarted()) {
+            eventLoop.start();
+        }
+
+        if (result.isCancelled() || !retryPolicy.canRetry(attempt)) {
+            return;
+        }
+
+        Duration delay = retryPolicy.delay(attempt);
+        retryListener.onRetryScheduled(attempt, delay);
+        ScheduledPromise<?> scheduledPromise = eventLoop.schedule(() ->
+                run(callback, result, attempt), delay.toNanos(), TimeUnit.NANOSECONDS);
+
+        result.set(scheduledPromise);
+    }
+
+    private <T> void run(Callable<T> callback, EventLoopRetryResult result, int attempt) {
+        if (result.isCancelled()) {
+            return;
+        }
+
+        try {
+            callback.call();
+        } catch (Exception e) {
+            retryListener.onRetryFailed(attempt, e);
+            if (!retryPolicy.canRetry(attempt + 1)) {
+                retryListener.onRetryExhausted(attempt, e);
+                return;
+            }
+            schedule(callback, result, attempt + 1);
+        }
+    }
+
+    private static final class EventLoopRetryResult implements RetryResult {
+
+        private final AtomicBoolean cancellationRequested = new AtomicBoolean(false);
+        private final AtomicReference<@Nullable ScheduledPromise<?>> scheduledPromise = new AtomicReference<>();
+
+        @Override
+        public void cancel(boolean mayInterruptIfRunning) {
+            cancellationRequested.set(true);
+            ScheduledPromise<?> promise = scheduledPromise.get();
+            if (promise == null) {
+                return;
+            }
+
+            promise.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            ScheduledPromise<?> promise = scheduledPromise.get();
+            return cancellationRequested.get() || promise != null && promise.isCancelled();
+        }
+
+        private void set(ScheduledPromise<?> promise) {
+            if (!cancellationRequested.get()) {
+                scheduledPromise.set(promise);
+                return;
+            }
+            promise.cancel(false);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/EventLoopRetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/EventLoopRetryExecutor.java
@@ -36,6 +36,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * Retry executor backed by Titan's {@link EventLoop}.
+ *
+ * <p>This executor is useful when retry callbacks must run on Titan's event loop
+ * instead of a JDK scheduler thread. When constructed without an event loop, it
+ * creates and owns a {@link TaskEventLoop}.</p>
+ *
  * @author yun
  */
 public class EventLoopRetryExecutor implements RetryExecutor {
@@ -95,7 +101,7 @@ public class EventLoopRetryExecutor implements RetryExecutor {
         }
 
         Duration delay = retryPolicy.delay(attempt);
-        retryListener.onRetryScheduled(attempt, delay);
+        retryListener.onRetry(attempt, delay);
         ScheduledPromise<?> scheduledPromise = eventLoop.schedule(() ->
                 run(callback, result, attempt), delay.toNanos(), TimeUnit.NANOSECONDS);
 
@@ -115,6 +121,7 @@ public class EventLoopRetryExecutor implements RetryExecutor {
                 retryListener.onRetryExhausted(attempt, e);
                 return;
             }
+
             schedule(callback, result, attempt + 1);
         }
     }
@@ -146,6 +153,7 @@ public class EventLoopRetryExecutor implements RetryExecutor {
                 scheduledPromise.set(promise);
                 return;
             }
+
             promise.cancel(false);
         }
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
@@ -28,6 +28,14 @@ import java.time.Duration;
 /**
  * Retry policy that increases delay exponentially and caps it at a maximum delay.
  *
+ * <p>Attempt {@code 1} uses {@code initialDelay}. Each later attempt multiplies
+ * the previous delay by {@code multiplier} until {@code maxDelay} is reached.</p>
+ *
+ * @param maxAttempts maximum number of attempts, or {@link RetryPolicy#UNLIMITED_ATTEMPTS}
+ * @param initialDelay positive delay used for attempt {@code 1}
+ * @param maxDelay maximum delay returned by this policy
+ * @param multiplier multiplier applied between attempts
+ *
  * @author yun
  */
 public record ExponentialRetryPolicy(
@@ -43,9 +51,10 @@ public record ExponentialRetryPolicy(
     private static final int DEFAULT_MULTIPLIER = 2;
 
     public ExponentialRetryPolicy {
-        FixedRetryPolicy.validateMaxAttempts(maxAttempts);
-        FixedRetryPolicy.validateDelay(initialDelay);
-        FixedRetryPolicy.validateDelay(maxDelay);
+        RetryPolicy.validateMaxAttempts(maxAttempts);
+        RetryPolicy.validateDelay(initialDelay);
+        RetryPolicy.validateDelay(maxDelay);
+
         if (maxDelay.compareTo(initialDelay) < 0) {
             throw new IllegalArgumentException("maxDelay must be greater than or equal to initialDelay");
         }
@@ -77,10 +86,13 @@ public record ExponentialRetryPolicy(
         try {
             return delay.multipliedBy(multiplier);
         } catch (ArithmeticException e) {
-            return Duration.ofMillis(Long.MAX_VALUE);
+            return Duration.ofMillis(Long.MAX_VALUE); // Prevent numeric overflow.
         }
     }
 
+    /**
+     * Builder for {@link ExponentialRetryPolicy}.
+     */
     public static final class Builder {
 
         private int maxAttempts = DEFAULT_MAX_ATTEMPTS;

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
@@ -1,0 +1,123 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import java.time.Duration;
+
+/**
+ * Retry policy that increases delay exponentially and caps it at a maximum delay.
+ *
+ * @author yun
+ */
+public record ExponentialRetryPolicy(
+        int maxAttempts,
+        Duration initialDelay,
+        Duration maxDelay,
+        int multiplier
+) implements RetryPolicy {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final Duration DEFAULT_INITIAL_DELAY = Duration.ofSeconds(1);
+    private static final Duration DEFAULT_MAX_DELAY = Duration.ofSeconds(30);
+    private static final int DEFAULT_MULTIPLIER = 2;
+
+    public ExponentialRetryPolicy {
+        FixedRetryPolicy.validateMaxAttempts(maxAttempts);
+        FixedRetryPolicy.validateDelay(initialDelay);
+        FixedRetryPolicy.validateDelay(maxDelay);
+        if (maxDelay.compareTo(initialDelay) < 0) {
+            throw new IllegalArgumentException("maxDelay must be greater than or equal to initialDelay");
+        }
+        if (multiplier < 2) {
+            throw new IllegalArgumentException("multiplier must be greater than or equal to 2");
+        }
+    }
+
+    @Override
+    public Duration delay(int attempt) {
+        if (attempt < 1) {
+            throw new IllegalArgumentException("attempt must be greater than zero");
+        }
+        Duration delay = initialDelay;
+        for (int i = 1; i < attempt; i++) {
+            delay = multiply(delay, multiplier);
+            if (delay.compareTo(maxDelay) >= 0) {
+                return maxDelay;
+            }
+        }
+        return delay;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static Duration multiply(Duration delay, int multiplier) {
+        try {
+            return delay.multipliedBy(multiplier);
+        } catch (ArithmeticException e) {
+            return Duration.ofMillis(Long.MAX_VALUE);
+        }
+    }
+
+    public static final class Builder {
+
+        private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        private Duration initialDelay = DEFAULT_INITIAL_DELAY;
+        private Duration maxDelay = DEFAULT_MAX_DELAY;
+        private int multiplier = DEFAULT_MULTIPLIER;
+
+        private Builder() {
+        }
+
+        public Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder unlimitedAttempts() {
+            this.maxAttempts = RetryPolicy.UNLIMITED_ATTEMPTS;
+            return this;
+        }
+
+        public Builder initialDelay(Duration initialDelay) {
+            this.initialDelay = initialDelay;
+            return this;
+        }
+
+        public Builder maxDelay(Duration maxDelay) {
+            this.maxDelay = maxDelay;
+            return this;
+        }
+
+        public Builder multiplier(int multiplier) {
+            this.multiplier = multiplier;
+            return this;
+        }
+
+        public ExponentialRetryPolicy build() {
+            return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/FixedRetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/FixedRetryPolicy.java
@@ -28,6 +28,9 @@ import java.time.Duration;
 /**
  * Retry policy that returns the same delay for every retry attempt.
  *
+ * @param maxAttempts maximum number of attempts, or {@link RetryPolicy#UNLIMITED_ATTEMPTS}
+ * @param delay positive delay used for every attempt
+ *
  * @author yun
  */
 public record FixedRetryPolicy(
@@ -39,8 +42,8 @@ public record FixedRetryPolicy(
     private static final Duration DEFAULT_DELAY = Duration.ofSeconds(1);
 
     public FixedRetryPolicy {
-        validateMaxAttempts(maxAttempts);
-        validateDelay(delay);
+        RetryPolicy.validateMaxAttempts(maxAttempts);
+        RetryPolicy.validateDelay(delay);
     }
 
     @Override
@@ -55,19 +58,9 @@ public record FixedRetryPolicy(
         return new Builder();
     }
 
-    static void validateMaxAttempts(int maxAttempts) {
-        if (maxAttempts == RetryPolicy.UNLIMITED_ATTEMPTS || maxAttempts > 0) {
-            return;
-        }
-        throw new IllegalArgumentException("maxAttempts must be positive or UNLIMITED_ATTEMPTS");
-    }
-
-    static void validateDelay(Duration delay) {
-        if (delay.isNegative() || delay.isZero()) {
-            throw new IllegalArgumentException("delay must be positive");
-        }
-    }
-
+    /**
+     * Builder for {@link FixedRetryPolicy}.
+     */
     public static final class Builder {
 
         private int maxAttempts = DEFAULT_MAX_ATTEMPTS;

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/FixedRetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/FixedRetryPolicy.java
@@ -1,0 +1,98 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import java.time.Duration;
+
+/**
+ * Retry policy that returns the same delay for every retry attempt.
+ *
+ * @author yun
+ */
+public record FixedRetryPolicy(
+        int maxAttempts,
+        Duration delay
+) implements RetryPolicy {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 3;
+    private static final Duration DEFAULT_DELAY = Duration.ofSeconds(1);
+
+    public FixedRetryPolicy {
+        validateMaxAttempts(maxAttempts);
+        validateDelay(delay);
+    }
+
+    @Override
+    public Duration delay(int attempt) {
+        if (attempt < 1) {
+            throw new IllegalArgumentException("attempt must be greater than zero");
+        }
+        return delay;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    static void validateMaxAttempts(int maxAttempts) {
+        if (maxAttempts == RetryPolicy.UNLIMITED_ATTEMPTS || maxAttempts > 0) {
+            return;
+        }
+        throw new IllegalArgumentException("maxAttempts must be positive or UNLIMITED_ATTEMPTS");
+    }
+
+    static void validateDelay(Duration delay) {
+        if (delay.isNegative() || delay.isZero()) {
+            throw new IllegalArgumentException("delay must be positive");
+        }
+    }
+
+    public static final class Builder {
+
+        private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+        private Duration delay = DEFAULT_DELAY;
+
+        private Builder() {
+        }
+
+        public Builder maxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+            return this;
+        }
+
+        public Builder unlimitedAttempts() {
+            this.maxAttempts = RetryPolicy.UNLIMITED_ATTEMPTS;
+            return this;
+        }
+
+        public Builder delay(Duration delay) {
+            this.delay = delay;
+            return this;
+        }
+
+        public FixedRetryPolicy build() {
+            return new FixedRetryPolicy(maxAttempts, delay);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/JdkScheduledRetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/JdkScheduledRetryExecutor.java
@@ -31,6 +31,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
+ * Retry executor backed by a JDK {@link ScheduledExecutorService}.
+ *
+ * <p>This implementation is suitable for integration layers that do not need to
+ * run retry callbacks on Titan's event loop. When constructed without an executor,
+ * it creates and owns a single-threaded scheduled executor.</p>
+ *
  * @author yun
  */
 public class JdkScheduledRetryExecutor implements RetryExecutor {
@@ -94,7 +100,7 @@ public class JdkScheduledRetryExecutor implements RetryExecutor {
         }
 
         Duration delay = retryPolicy.delay(attempt);
-        retryListener.onRetryScheduled(attempt, delay);
+        retryListener.onRetry(attempt, delay);
         ScheduledFuture<?> future = executor.schedule(() -> run(callback, result, attempt), delay.toNanos(), TimeUnit.NANOSECONDS);
         result.set(future);
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/JdkScheduledRetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/JdkScheduledRetryExecutor.java
@@ -1,0 +1,149 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.Duration;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author yun
+ */
+public class JdkScheduledRetryExecutor implements RetryExecutor {
+
+    private final ScheduledExecutorService executor;
+    private final RetryPolicy retryPolicy;
+    private final RetryListener retryListener;
+
+    public JdkScheduledRetryExecutor(RetryPolicy retryPolicy) {
+        this(new ScheduledThreadPoolExecutor(1), retryPolicy, RetryListener.NOOP);
+    }
+
+    public JdkScheduledRetryExecutor(RetryPolicy retryPolicy, RetryListener retryListener) {
+        this(new ScheduledThreadPoolExecutor(1), retryPolicy, retryListener);
+    }
+
+    public JdkScheduledRetryExecutor(ScheduledExecutorService executor, RetryPolicy retryPolicy) {
+        this(executor, retryPolicy, RetryListener.NOOP);
+    }
+
+    public JdkScheduledRetryExecutor(
+            ScheduledExecutorService executor,
+            RetryPolicy retryPolicy,
+            RetryListener retryListener
+    ) {
+        this.executor = executor;
+        this.retryPolicy = retryPolicy;
+        this.retryListener = retryListener;
+    }
+
+    @Override
+    public RetryResult retry(Runnable callback) {
+        JdkRetryResult result = new JdkRetryResult();
+        schedule(Executors.callable(callback), result, 1);
+        return result;
+    }
+
+    @Override
+    public <T> RetryResult retry(Callable<T> callback) {
+        JdkRetryResult result = new JdkRetryResult();
+        schedule(callback, result, 1);
+        return result;
+    }
+
+    @Override
+    public void shutdown(long timeout, TimeUnit timeUnit) {
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(timeout, timeUnit)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            executor.shutdownNow();
+        }
+    }
+
+    private <T> void schedule(Callable<T> callback, JdkRetryResult result, int attempt) {
+        if (result.isCancelled() || !retryPolicy.canRetry(attempt)) {
+            return;
+        }
+
+        Duration delay = retryPolicy.delay(attempt);
+        retryListener.onRetryScheduled(attempt, delay);
+        ScheduledFuture<?> future = executor.schedule(() -> run(callback, result, attempt), delay.toNanos(), TimeUnit.NANOSECONDS);
+        result.set(future);
+    }
+
+    private <T> void run(Callable<T> callback, JdkRetryResult result, int attempt) {
+        if (result.isCancelled()) {
+            return;
+        }
+
+        try {
+            callback.call();
+        } catch (Exception e) {
+            retryListener.onRetryFailed(attempt, e);
+            if (!retryPolicy.canRetry(attempt + 1)) {
+                retryListener.onRetryExhausted(attempt, e);
+                return;
+            }
+            schedule(callback, result, attempt + 1);
+        }
+    }
+
+    private static final class JdkRetryResult implements RetryResult {
+
+        private final AtomicBoolean cancellationRequested = new AtomicBoolean(false);
+        private final AtomicReference<@Nullable ScheduledFuture<?>> future = new AtomicReference<>();
+
+        @Override
+        public void cancel(boolean mayInterruptIfRunning) {
+            cancellationRequested.set(true);
+            ScheduledFuture<?> scheduledFuture = future.get();
+            if (scheduledFuture == null) {
+                return;
+            }
+
+            scheduledFuture.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            ScheduledFuture<?> scheduledFuture = future.get();
+            return cancellationRequested.get() || scheduledFuture != null && scheduledFuture.isCancelled();
+        }
+
+        private void set(ScheduledFuture<?> scheduledFuture) {
+            if (!cancellationRequested.get()) {
+                future.set(scheduledFuture);
+                return;
+            }
+            scheduledFuture.cancel(false);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutor.java
@@ -1,0 +1,43 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author yun
+ */
+public interface RetryExecutor {
+
+    RetryResult retry(Runnable callback);
+
+    <T> RetryResult retry(Callable<T> callback);
+
+    default void shutdown() {
+        shutdown(30, TimeUnit.SECONDS);
+    }
+
+    void shutdown(long timeout, TimeUnit timeUnit);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutor.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutor.java
@@ -27,17 +27,50 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
+ * Schedules retry attempts for a callback.
+ *
+ * <p>The executor does not run the callback immediately. Calling {@link #retry(Runnable)}
+ * or {@link #retry(Callable)} schedules attempt {@code 1} after the delay returned by
+ * the configured {@link RetryPolicy}. If an attempt completes normally, retrying stops.
+ * If an attempt throws an exception, the executor schedules the next attempt while the
+ * policy still allows it.</p>
+ *
  * @author yun
  */
 public interface RetryExecutor {
 
+    /**
+     * Schedules a retryable runnable.
+     *
+     * @param callback callback to invoke on each attempt
+     * @return handle that can cancel the currently scheduled retry attempt
+     */
     RetryResult retry(Runnable callback);
 
+    /**
+     * Schedules a retryable callable.
+     *
+     * <p>The returned value is intentionally ignored. This executor only models retry
+     * scheduling and cancellation; consumers that need a result should capture it in
+     * their own state or future abstraction.</p>
+     *
+     * @param callback callback to invoke on each attempt
+     * @return handle that can cancel the currently scheduled retry attempt
+     */
     <T> RetryResult retry(Callable<T> callback);
 
+    /**
+     * Shuts down executor resources using the default timeout.
+     */
     default void shutdown() {
         shutdown(30, TimeUnit.SECONDS);
     }
 
+    /**
+     * Shuts down executor resources.
+     *
+     * @param timeout maximum time to wait for shutdown
+     * @param timeUnit timeout unit
+     */
     void shutdown(long timeout, TimeUnit timeUnit);
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutors.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutors.java
@@ -1,0 +1,75 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import org.traffichunter.titan.core.channel.EventLoop;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * @author yun
+ */
+public final class RetryExecutors {
+
+    public static EventLoopRetryExecutor eventLoopRetryExecutor(RetryPolicy retryPolicy, RetryListener retryListener) {
+        return new EventLoopRetryExecutor(retryPolicy, retryListener);
+    }
+
+    public static EventLoopRetryExecutor eventLoopRetryExecutor(EventLoop eventLoop, RetryListener retryListener, RetryPolicy retryPolicy) {
+        return new EventLoopRetryExecutor(eventLoop, retryListener, retryPolicy);
+    }
+
+    public static EventLoopRetryExecutor eventLoopRetryExecutor(
+            EventLoop eventLoop,
+            RetryPolicy retryPolicy,
+            RetryListener retryListener
+    ) {
+        return new EventLoopRetryExecutor(eventLoop, retryListener, retryPolicy);
+    }
+
+    public static JdkScheduledRetryExecutor jdkScheduledRetryExecutor(RetryPolicy retryPolicy) {
+        return new JdkScheduledRetryExecutor(retryPolicy);
+    }
+
+    public static JdkScheduledRetryExecutor jdkScheduledRetryExecutor(RetryPolicy retryPolicy, RetryListener retryListener) {
+        return new JdkScheduledRetryExecutor(retryPolicy, retryListener);
+    }
+
+    public static JdkScheduledRetryExecutor jdkScheduledRetryExecutor(
+            ScheduledExecutorService scheduledExecutorService,
+            RetryPolicy retryPolicy
+    ) {
+        return new JdkScheduledRetryExecutor(scheduledExecutorService, retryPolicy);
+    }
+
+    public static JdkScheduledRetryExecutor jdkScheduledRetryExecutor(
+            ScheduledExecutorService scheduledExecutorService,
+            RetryPolicy retryPolicy,
+            RetryListener retryListener
+    ) {
+        return new JdkScheduledRetryExecutor(scheduledExecutorService, retryPolicy, retryListener);
+    }
+
+    private RetryExecutors() { }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutors.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryExecutors.java
@@ -28,6 +28,11 @@ import org.traffichunter.titan.core.channel.EventLoop;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
+ * Factory methods for retry executors.
+ *
+ * <p>Use these helpers when callers should not depend on concrete executor
+ * constructors directly.</p>
+ *
  * @author yun
  */
 public final class RetryExecutors {

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryListener.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryListener.java
@@ -26,21 +26,45 @@ package org.traffichunter.titan.core.resilience.retry;
 import java.time.Duration;
 
 /**
- * Observer callbacks for retry attempts.
+ * Observer callbacks for retry scheduling and failures.
+ *
+ * <p>Listeners are called from the executor thread that owns the retry attempt.
+ * Implementations should avoid blocking work and should not throw exceptions.</p>
  *
  * @author yun
  */
 public interface RetryListener {
 
+    /**
+     * Listener that ignores every retry event.
+     */
     RetryListener NOOP = new RetryListener() {
     };
 
-    default void onRetryScheduled(int attempt, Duration delay) {
+    /**
+     * Called when an attempt is accepted by the policy and scheduled.
+     *
+     * @param attempt one-based retry attempt number
+     * @param delay delay before the attempt is executed
+     */
+    default void onRetry(int attempt, Duration delay) {
     }
 
+    /**
+     * Called after an attempt throws an exception.
+     *
+     * @param attempt one-based retry attempt number
+     * @param cause exception thrown by the callback
+     */
     default void onRetryFailed(int attempt, Throwable cause) {
     }
 
+    /**
+     * Called after the final allowed attempt fails.
+     *
+     * @param attempt one-based retry attempt number that exhausted the policy
+     * @param cause exception thrown by the final callback attempt
+     */
     default void onRetryExhausted(int attempt, Throwable cause) {
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryListener.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryListener.java
@@ -1,0 +1,46 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import java.time.Duration;
+
+/**
+ * Observer callbacks for retry attempts.
+ *
+ * @author yun
+ */
+public interface RetryListener {
+
+    RetryListener NOOP = new RetryListener() {
+    };
+
+    default void onRetryScheduled(int attempt, Duration delay) {
+    }
+
+    default void onRetryFailed(int attempt, Throwable cause) {
+    }
+
+    default void onRetryExhausted(int attempt, Throwable cause) {
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
@@ -1,0 +1,59 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+import java.time.Duration;
+
+/**
+ * Retry delay policy shared by transport and integration modules.
+ *
+ * <p>Attempts are one-based. The first retry attempt is {@code 1}, the second
+ * retry attempt is {@code 2}, and so on.</p>
+ *
+ * @author yun
+ */
+public interface RetryPolicy {
+
+    int UNLIMITED_ATTEMPTS = -1;
+
+    static RetryPolicy fixed(int maxAttempts, Duration delay) {
+        return new FixedRetryPolicy(maxAttempts, delay);
+    }
+
+    static RetryPolicy exponential(int maxAttempts, Duration initialDelay, Duration maxDelay, int multiplier) {
+        return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier);
+    }
+
+    int maxAttempts();
+
+    Duration delay(int attempt);
+
+    default boolean canRetry(int attempt) {
+        if (attempt < 1) {
+            throw new IllegalArgumentException("attempt must be greater than zero");
+        }
+        int maxAttempts = maxAttempts();
+        return maxAttempts == UNLIMITED_ATTEMPTS || attempt <= maxAttempts;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
@@ -35,24 +35,76 @@ import java.time.Duration;
  */
 public interface RetryPolicy {
 
+    static void validateMaxAttempts(int maxAttempts) {
+        if (maxAttempts == RetryPolicy.UNLIMITED_ATTEMPTS || maxAttempts > 0) {
+            return;
+        }
+        throw new IllegalArgumentException("maxAttempts must be positive or UNLIMITED_ATTEMPTS");
+    }
+
+    static void validateDelay(Duration delay) {
+        if (delay.isNegative() || delay.isZero()) {
+            throw new IllegalArgumentException("delay must be positive");
+        }
+    }
+
+    /**
+     * Sentinel value for policies that never stop by attempt count.
+     */
     int UNLIMITED_ATTEMPTS = -1;
 
+    /**
+     * Creates a policy that uses the same delay for every attempt.
+     *
+     * @param maxAttempts maximum number of attempts, or {@link #UNLIMITED_ATTEMPTS}
+     * @param delay delay used for every attempt
+     * @return fixed retry policy
+     */
     static RetryPolicy fixed(int maxAttempts, Duration delay) {
         return new FixedRetryPolicy(maxAttempts, delay);
     }
 
+    /**
+     * Creates a policy that multiplies the previous delay until a maximum delay is reached.
+     *
+     * @param maxAttempts maximum number of attempts, or {@link #UNLIMITED_ATTEMPTS}
+     * @param initialDelay delay used for attempt {@code 1}
+     * @param maxDelay upper bound for calculated delays
+     * @param multiplier multiplier applied between attempts
+     * @return exponential retry policy
+     */
     static RetryPolicy exponential(int maxAttempts, Duration initialDelay, Duration maxDelay, int multiplier) {
         return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier);
     }
 
+    /**
+     * Returns the maximum number of attempts allowed by this policy.
+     *
+     * @return positive attempt count, or {@link #UNLIMITED_ATTEMPTS}
+     */
     int maxAttempts();
 
+    /**
+     * Returns the delay before the given attempt is executed.
+     *
+     * @param attempt one-based retry attempt number
+     * @return delay for the attempt
+     * @throws IllegalArgumentException when {@code attempt} is less than {@code 1}
+     */
     Duration delay(int attempt);
 
+    /**
+     * Returns whether the given attempt is allowed by this policy.
+     *
+     * @param attempt one-based retry attempt number
+     * @return {@code true} when the attempt can be scheduled
+     * @throws IllegalArgumentException when {@code attempt} is less than {@code 1}
+     */
     default boolean canRetry(int attempt) {
         if (attempt < 1) {
             throw new IllegalArgumentException("attempt must be greater than zero");
         }
+
         int maxAttempts = maxAttempts();
         return maxAttempts == UNLIMITED_ATTEMPTS || attempt <= maxAttempts;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryResult.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryResult.java
@@ -24,13 +24,31 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.resilience.retry;
 
 /**
+ * Handle for a retry sequence scheduled by a {@link RetryExecutor}.
+ *
+ * <p>Cancellation is best-effort. It cancels the currently scheduled attempt when one
+ * exists and prevents future attempts from being scheduled.</p>
+ *
  * @author yun
  */
 public interface RetryResult {
 
-    default void cancel() {cancel(false); }
+    /**
+     * Cancels the retry sequence without interrupting a running attempt.
+     */
+    default void cancel() { cancel(false); }
 
+    /**
+     * Cancels the retry sequence.
+     *
+     * @param mayInterruptIfRunning whether a running scheduled task may be interrupted
+     */
     void cancel(boolean mayInterruptIfRunning);
 
+    /**
+     * Returns whether cancellation has been requested or observed by the scheduled task.
+     *
+     * @return {@code true} when this retry sequence is cancelled
+     */
     boolean isCancelled();
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryResult.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryResult.java
@@ -1,0 +1,36 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.retry;
+
+/**
+ * @author yun
+ */
+public interface RetryResult {
+
+    default void cancel() {cancel(false); }
+
+    void cancel(boolean mayInterruptIfRunning);
+
+    boolean isCancelled();
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Small retry and backoff policies shared across Titan modules.
+ *
+ * <p>This package only calculates retry eligibility and delay. Transport,
+ * reconnect, resubscribe, and listener recovery behavior belongs to the module
+ * applying the policy.</p>
+ *
+ * @author yun
+ */
+@NullMarked
+@Unstable
+package org.traffichunter.titan.core.resilience.retry;
+
+import org.jspecify.annotations.NullMarked;
+import org.traffichunter.titan.core.util.Unstable;

--- a/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
@@ -60,7 +60,7 @@ public abstract class AbstractTransport<C extends Channel> {
 
     public abstract void start();
 
-    public boolean isStart() {
+    public boolean isStarted() {
         return channelRegistry.isActive();
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -235,7 +235,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
     }
 
     @Override
-    public boolean isStart() {
+    public boolean isStarted() {
         return state.get() == State.STARTED;
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -203,7 +203,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
     }
 
     @Override
-    public boolean isStart() {
+    public boolean isStarted() {
         State current = state.get();
         return current == State.STARTED || current == State.LISTENING;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/util/Unstable.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/Unstable.java
@@ -1,0 +1,47 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks APIs that are intentionally public but may still change.
+ *
+ * @author yun
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.METHOD,
+        ElementType.PACKAGE,
+        ElementType.TYPE
+})
+public @interface Unstable {
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryExecutorTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryExecutorTest.java
@@ -186,7 +186,7 @@ class RetryExecutorTest {
         private final List<String> events = java.util.Collections.synchronizedList(new ArrayList<>());
 
         @Override
-        public void onRetryScheduled(int attempt, Duration delay) {
+        public void onRetry(int attempt, Duration delay) {
             events.add("scheduled:" + attempt);
         }
 

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryExecutorTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryExecutorTest.java
@@ -1,0 +1,207 @@
+package org.traffichunter.titan.core.test.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.EventLoop;
+import org.traffichunter.titan.core.channel.TaskEventLoop;
+import org.traffichunter.titan.core.resilience.retry.EventLoopRetryExecutor;
+import org.traffichunter.titan.core.resilience.retry.FixedRetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.JdkScheduledRetryExecutor;
+import org.traffichunter.titan.core.resilience.retry.RetryListener;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.RetryResult;
+
+class RetryExecutorTest {
+
+    private final EventLoop eventLoop = new TaskEventLoop();
+
+    @AfterEach
+    void tearDown() {
+        if (eventLoop.isStarted()) {
+            eventLoop.gracefullyShutdown(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void jdk_executor_retries_until_callback_succeeds() {
+        JdkScheduledRetryExecutor executor = new JdkScheduledRetryExecutor(shortRetryPolicy());
+        AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch success = new CountDownLatch(1);
+
+        executor.retry(() -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new IllegalStateException("try again");
+            }
+            success.countDown();
+        });
+
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(success.getCount()).isZero();
+            assertThat(attempts).hasValue(3);
+        });
+        executor.shutdown();
+    }
+
+    @Test
+    void jdk_executor_stops_when_attempts_are_exhausted() {
+        RecordingRetryListener listener = new RecordingRetryListener();
+        JdkScheduledRetryExecutor executor = new JdkScheduledRetryExecutor(
+                java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),
+                shortRetryPolicy(),
+                listener
+        );
+        AtomicInteger attempts = new AtomicInteger();
+
+        executor.retry(() -> {
+            attempts.incrementAndGet();
+            throw new IllegalStateException("always fails");
+        });
+
+        Awaitility.await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(attempts).hasValue(3));
+        assertThat(listener.events()).containsExactly(
+                "scheduled:1",
+                "failed:1",
+                "scheduled:2",
+                "failed:2",
+                "scheduled:3",
+                "failed:3",
+                "exhausted:3"
+        );
+        executor.shutdown();
+    }
+
+    @Test
+    void jdk_executor_cancels_scheduled_retry() {
+        JdkScheduledRetryExecutor executor = new JdkScheduledRetryExecutor(
+                RetryPolicy.fixed(1, Duration.ofMillis(200))
+        );
+        AtomicInteger attempts = new AtomicInteger();
+
+        RetryResult result = executor.retry(attempts::incrementAndGet);
+        result.cancel();
+
+        Awaitility.await().during(250, TimeUnit.MILLISECONDS)
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(attempts).hasValue(0));
+        assertThat(result.isCancelled()).isTrue();
+        executor.shutdown();
+    }
+
+    @Test
+    void jdk_executor_reports_cancelled_even_before_schedule_reference_is_visible() {
+        JdkScheduledRetryExecutor executor = new JdkScheduledRetryExecutor(
+                RetryPolicy.fixed(1, Duration.ofMillis(200))
+        );
+
+        RetryResult result = executor.retry(() -> { });
+        result.cancel();
+
+        assertThat(result.isCancelled()).isTrue();
+        executor.shutdown();
+    }
+
+    @Test
+    void event_loop_executor_retries_until_callback_succeeds() {
+        eventLoop.start();
+        RecordingRetryListener listener = new RecordingRetryListener();
+        EventLoopRetryExecutor executor = new EventLoopRetryExecutor(eventLoop, listener, shortRetryPolicy());
+        AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch success = new CountDownLatch(1);
+
+        executor.retry(() -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new IllegalStateException("try again");
+            }
+            success.countDown();
+        });
+
+        Awaitility.await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertThat(success.getCount()).isZero();
+            assertThat(attempts).hasValue(3);
+        });
+        assertThat(listener.events()).containsExactly(
+                "scheduled:1",
+                "failed:1",
+                "scheduled:2",
+                "failed:2",
+                "scheduled:3"
+        );
+    }
+
+    @Test
+    void event_loop_executor_cancels_scheduled_retry() {
+        eventLoop.start();
+        EventLoopRetryExecutor executor = new EventLoopRetryExecutor(
+                eventLoop,
+                RetryListener.NOOP,
+                RetryPolicy.fixed(1, Duration.ofMillis(200))
+        );
+        AtomicInteger attempts = new AtomicInteger();
+
+        RetryResult result = executor.retry(attempts::incrementAndGet);
+        result.cancel();
+
+        Awaitility.await().during(250, TimeUnit.MILLISECONDS)
+                .atMost(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> assertThat(attempts).hasValue(0));
+        assertThat(result.isCancelled()).isTrue();
+    }
+
+    @Test
+    void event_loop_executor_reports_cancelled_even_before_schedule_reference_is_visible() {
+        eventLoop.start();
+        EventLoopRetryExecutor executor = new EventLoopRetryExecutor(
+                eventLoop,
+                RetryListener.NOOP,
+                RetryPolicy.fixed(1, Duration.ofMillis(200))
+        );
+
+        RetryResult result = executor.retry(() -> { });
+        result.cancel();
+
+        assertThat(result.isCancelled()).isTrue();
+    }
+
+    private static FixedRetryPolicy shortRetryPolicy() {
+        return FixedRetryPolicy.builder()
+                .maxAttempts(3)
+                .delay(Duration.ofMillis(10))
+                .build();
+    }
+
+    @NullMarked
+    private static final class RecordingRetryListener implements RetryListener {
+
+        private final List<String> events = java.util.Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void onRetryScheduled(int attempt, Duration delay) {
+            events.add("scheduled:" + attempt);
+        }
+
+        @Override
+        public void onRetryFailed(int attempt, Throwable cause) {
+            events.add("failed:" + attempt);
+        }
+
+        @Override
+        public void onRetryExhausted(int attempt, Throwable cause) {
+            events.add("exhausted:" + attempt);
+        }
+
+        private List<String> events() {
+            return List.copyOf(events);
+        }
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryPolicyTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryPolicyTest.java
@@ -1,0 +1,121 @@
+package org.traffichunter.titan.core.test.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.resilience.retry.ExponentialRetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.FixedRetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
+
+class RetryPolicyTest {
+
+    @Test
+    void fixed_policy_returns_same_delay_for_each_attempt() {
+        RetryPolicy policy = RetryPolicy.fixed(3, Duration.ofMillis(100));
+
+        assertThat(policy.canRetry(1)).isTrue();
+        assertThat(policy.canRetry(3)).isTrue();
+        assertThat(policy.canRetry(4)).isFalse();
+        assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(100));
+        assertThat(policy.delay(3)).isEqualTo(Duration.ofMillis(100));
+    }
+
+    @Test
+    void unlimited_attempts_never_exhaust() {
+        RetryPolicy policy = RetryPolicy.fixed(RetryPolicy.UNLIMITED_ATTEMPTS, Duration.ofMillis(100));
+
+        assertThat(policy.canRetry(1)).isTrue();
+        assertThat(policy.canRetry(10_000)).isTrue();
+    }
+
+    @Test
+    void exponential_policy_increases_delay_until_max_delay() {
+        RetryPolicy policy = RetryPolicy.exponential(
+                5,
+                Duration.ofMillis(100),
+                Duration.ofMillis(1_000),
+                2
+        );
+
+        assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(100));
+        assertThat(policy.delay(2)).isEqualTo(Duration.ofMillis(200));
+        assertThat(policy.delay(3)).isEqualTo(Duration.ofMillis(400));
+        assertThat(policy.delay(4)).isEqualTo(Duration.ofMillis(800));
+        assertThat(policy.delay(5)).isEqualTo(Duration.ofMillis(1_000));
+    }
+
+    @Test
+    void policies_reject_invalid_values() {
+        assertThatThrownBy(() -> RetryPolicy.fixed(0, Duration.ofMillis(100)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxAttempts");
+        assertThatThrownBy(() -> RetryPolicy.fixed(1, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("delay");
+        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(50), 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxDelay");
+        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(100), 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("multiplier");
+        assertThatThrownBy(() -> RetryPolicy.fixed(1, Duration.ofMillis(100)).delay(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("attempt");
+    }
+
+    @Nested
+    class BuilderTest {
+
+        @Test
+        void fixed_policy_builder_creates_policy_with_configured_values() {
+            FixedRetryPolicy policy = FixedRetryPolicy.builder()
+                    .maxAttempts(5)
+                    .delay(Duration.ofMillis(250))
+                    .build();
+
+            assertThat(policy.maxAttempts()).isEqualTo(5);
+            assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(250));
+        }
+
+        @Test
+        void fixed_policy_builder_supports_unlimited_attempts() {
+            FixedRetryPolicy policy = FixedRetryPolicy.builder()
+                    .unlimitedAttempts()
+                    .delay(Duration.ofMillis(250))
+                    .build();
+
+            assertThat(policy.canRetry(1_000)).isTrue();
+        }
+
+        @Test
+        void exponential_policy_builder_creates_policy_with_configured_values() {
+            ExponentialRetryPolicy policy = ExponentialRetryPolicy.builder()
+                    .maxAttempts(4)
+                    .initialDelay(Duration.ofMillis(100))
+                    .maxDelay(Duration.ofMillis(1_000))
+                    .multiplier(3)
+                    .build();
+
+            assertThat(policy.maxAttempts()).isEqualTo(4);
+            assertThat(policy.multiplier()).isEqualTo(3);
+            assertThat(policy.maxDelay()).isEqualTo(Duration.ofMillis(1_000));
+            assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(100));
+            assertThat(policy.delay(2)).isEqualTo(Duration.ofMillis(300));
+            assertThat(policy.delay(3)).isEqualTo(Duration.ofMillis(900));
+            assertThat(policy.delay(4)).isEqualTo(Duration.ofMillis(1_000));
+        }
+
+        @Test
+        void exponential_policy_builder_uses_defaults() {
+            ExponentialRetryPolicy policy = ExponentialRetryPolicy.builder().build();
+
+            assertThat(policy.maxAttempts()).isEqualTo(3);
+            assertThat(policy.multiplier()).isEqualTo(2);
+            assertThat(policy.delay(1)).isEqualTo(Duration.ofSeconds(1));
+            assertThat(policy.delay(3)).isEqualTo(Duration.ofSeconds(4));
+        }
+    }
+}

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -50,6 +50,13 @@ spring:
     connect-timeout-millis: 30000
     heartbeat-x: 1000
     heartbeat-y: 1000
+    retry:
+      enabled: false
+      type: exp # fix or exp
+      max-attempts: 3
+      delay: 1s
+      max-delay: 30s
+      multiplier: 2
 ```
 
 ## Send Messages

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -28,7 +28,7 @@ import org.traffichunter.titan.springframework.stomp.annotation.EnableTitan;
 @SpringBootApplication
 public class Application {
 
-    public static void main(String[] args) {
+    static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
 }
@@ -41,6 +41,7 @@ spring:
   titan:
     auto-start: true
     auto-connect: true
+    client: titan # titan or vertx
     host: 127.0.0.1
     port: 61613
     login: guest
@@ -77,7 +78,7 @@ public class NotificationPublisher {
 ```java
 import java.util.concurrent.Future;
 import org.springframework.stereotype.Service;
-import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.springframework.stomp.TitanTemplate;
 
 @Service
@@ -89,7 +90,7 @@ public class AsyncNotificationPublisher {
         this.titanTemplate = titanTemplate;
     }
 
-    public Future<StompFrame> publish(String payload) throws Exception {
+    public Future<StompFrames> publish(String payload) throws Exception {
         return titanTemplate.async().send("/topic/notifications", payload);
     }
 }
@@ -114,3 +115,19 @@ public class NotificationListener {
 Use `TitanTemplate` for imperative send/subscribe operations and
 `TitanTemplate.async()` when the caller wants a `Future`. Use `@TitanListener`
 for annotation-driven message handling.
+
+## Lifecycle And Acknowledgement
+
+`spring.titan.client` selects the STOMP client implementation. `titan` uses the
+native Titan client, while `vertx` uses the Vert.x STOMP client adapter. Both are
+exposed through the same Spring API.
+
+When `auto-start` is enabled, the Spring context starts the configured client.
+When `auto-connect` is enabled, the manager connects during startup. If a caller
+uses `TitanTemplate` or a listener before a connection exists, the manager starts
+and connects the client before resolving operations.
+
+`@TitanListener` acknowledges `MESSAGE` frames after the listener method returns
+successfully. If listener invocation fails, the configured error handler is
+called and the frame is negatively acknowledged when a `message-id` header is
+available.

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/TcpFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/TcpFanoutExporter.java
@@ -56,7 +56,7 @@ public class TcpFanoutExporter implements FanoutExporter {
 
     @Override
     public AggregationResult export(Destination destination, Buffer payload) {
-        Assert.checkState(inetServer.isStart(), "Cannot send an unstarted inet server");
+        Assert.checkState(inetServer.isStarted(), "Cannot send an unstarted inet server");
 
         int attempted = 0;
         int succeeded = 0;

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
@@ -126,7 +126,7 @@ class FanoutExporterTest {
 
     @Test
     void tcpFanoutExporter_returns_completed_result_counts() {
-        when(inetServer.isStart()).thenReturn(true);
+        when(inetServer.isStarted()).thenReturn(true);
 
         ChannelRegistry<NetChannel> registry = new ChannelRegistry<>();
         NetChannel channelOk = mock(NetChannel.class);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,4 +40,5 @@ spring-context = { module = "org.springframework:spring-context", version.ref = 
 spring-beans = { module = "org.springframework:spring-beans", version.ref = "spring" }
 spring-messaging = { module = "org.springframework:spring-messaging", version.ref = "spring" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot"}
+spring-boot-test = { module = "org.springframework.boot:spring-boot-test", version.ref = "spring-boot"}
 spring-boot-configure-processor = { module = "org.springframework.boot:spring-boot-configuration-processor", version.ref = "spring-boot"}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
@@ -150,7 +150,7 @@ class TitanFanoutSmokeTest {
     }
 
     private static void shutdown(TitanStompClient client) {
-        if (client != null && client.isStart()) {
+        if (client != null && client.isStarted()) {
             client.shutdown(10, TimeUnit.SECONDS);
         }
     }

--- a/titan-spring-client/build.gradle.kts
+++ b/titan-spring-client/build.gradle.kts
@@ -12,5 +12,7 @@ dependencies {
     implementation(project.libs.spring.messaging)
     implementation(project.libs.jackson.databind)
 
+    testImplementation(project.libs.spring.boot.test)
+
     annotationProcessor(project.libs.spring.boot.configure.processor)
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -1,11 +1,15 @@
 package org.traffichunter.titan.springframework.stomp;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
+import org.traffichunter.titan.core.resilience.retry.RetryExecutor;
+import org.traffichunter.titan.core.resilience.retry.RetryExecutors;
+import org.traffichunter.titan.core.resilience.retry.RetryListener;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 
@@ -19,15 +23,26 @@ import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations
 public final class TitanClientManager implements SmartLifecycle {
 
     private static final Logger log = LoggerFactory.getLogger(TitanClientManager.class);
+
+    private static final long DEFAULT_TIMEOUT = 30;
     public static final int PHASE = Integer.MAX_VALUE - 100;
 
     private final StompClient stompClient;
     private final TitanProperties properties;
+    private final @Nullable RetryExecutor retryExecutor;
+
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     public TitanClientManager(StompClient stompClient, TitanProperties properties) {
         this.stompClient = stompClient;
         this.properties = properties;
+
+        TitanProperties.Retry retry = properties.getRetry();
+        if (retry.isEnabled()) {
+            this.retryExecutor = RetryExecutors.eventLoopRetryExecutor(retry.toPolicy(), new LoggingRetryListener());
+        } else {
+            this.retryExecutor = null;
+        }
     }
 
     @Override
@@ -41,8 +56,18 @@ public final class TitanClientManager implements SmartLifecycle {
                 stompClient.start();
             }
             if (properties.isAutoConnect()) {
-                connect();
+                if (retryExecutor == null) {
+                    connect();
+                } else {
+                    try {
+                        connect();
+                    } catch (Exception e) {
+                        log.warn("Failed to connect Titan STOMP client. Scheduling retry.", e);
+                        retryExecutor.retry(this::connect);
+                    }
+                }
             }
+            log.info("Started Titan Client Manager");
         } catch (Exception e) {
             running.set(false);
             throw new IllegalStateException("Failed to start Titan STOMP client manager", e);
@@ -54,8 +79,13 @@ public final class TitanClientManager implements SmartLifecycle {
         if (!running.compareAndSet(true, false)) {
             return;
         }
+
         try {
-            stompClient.shutdown(30, TimeUnit.SECONDS);
+            stompClient.shutdown(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+            if (retryExecutor != null) {
+                retryExecutor.shutdown(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+            }
+            log.info("Shutting down Titan STOMP client manager");
         } catch (Exception e) {
             log.warn("Failed to shutdown STOMP client cleanly", e);
         }
@@ -115,6 +145,24 @@ public final class TitanClientManager implements SmartLifecycle {
             return stompClient.operations().isConnected();
         } catch (IllegalStateException e) {
             return false;
+        }
+    }
+
+    private static final class LoggingRetryListener implements RetryListener {
+
+        @Override
+        public void onRetry(int attempt, Duration delay) {
+            log.warn("Retry scheduled attempt #{}, delay={}", attempt, delay);
+        }
+
+        @Override
+        public void onRetryFailed(int attempt, Throwable cause) {
+            log.warn("Retry failed attempt #{}, cause={}", attempt, cause.getMessage());
+        }
+
+        @Override
+        public void onRetryExhausted(int attempt, Throwable cause) {
+            log.warn("Retry exhausted attempt #{}, cause={}", attempt, cause.getMessage());
         }
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanClientManager.java
@@ -37,7 +37,7 @@ public final class TitanClientManager implements SmartLifecycle {
         }
 
         try {
-            if (!stompClient.isStart()) {
+            if (!stompClient.isStarted()) {
                 stompClient.start();
             }
             if (properties.isAutoConnect()) {
@@ -83,8 +83,11 @@ public final class TitanClientManager implements SmartLifecycle {
     }
 
     public StompClientOperations connect() throws Exception {
-        return stompClient
-                .connect()
+        if (!stompClient.isStarted()) {
+            stompClient.start();
+        }
+
+        return stompClient.connect()
                 .get(properties.getConnectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -1,6 +1,8 @@
 package org.traffichunter.titan.springframework.stomp;
 
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
 
 /**
  * Configuration properties for the Titan Spring STOMP client.
@@ -47,6 +49,8 @@ public class TitanProperties {
     private boolean useStompFrame = false;
 
     private boolean bypassHostHeader = false;
+
+    private final Retry retry = new Retry();
 
     public boolean isEnabled() {
         return enabled;
@@ -194,5 +198,84 @@ public class TitanProperties {
 
     public void setClient(String client) {
         this.client = client;
+    }
+
+    public Retry getRetry() {
+        return retry;
+    }
+
+    public static class Retry {
+
+        private boolean enabled = false;
+
+        private Type type = Type.EXP;
+
+        private int maxAttempts = 3;
+
+        private Duration delay = Duration.ofSeconds(1);
+
+        private Duration maxDelay = Duration.ofSeconds(30);
+
+        private int multiplier = 2;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        public void setType(Type type) {
+            this.type = type;
+        }
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+
+        public Duration getDelay() {
+            return delay;
+        }
+
+        public void setDelay(Duration delay) {
+            this.delay = delay;
+        }
+
+        public Duration getMaxDelay() {
+            return maxDelay;
+        }
+
+        public void setMaxDelay(Duration maxDelay) {
+            this.maxDelay = maxDelay;
+        }
+
+        public int getMultiplier() {
+            return multiplier;
+        }
+
+        public void setMultiplier(int multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        public RetryPolicy toPolicy() {
+            return switch (type) {
+                case FIX -> RetryPolicy.fixed(maxAttempts, delay);
+                case EXP -> RetryPolicy.exponential(maxAttempts, delay, maxDelay, multiplier);
+            };
+        }
+
+        public enum Type {
+            FIX,
+            EXP
+        }
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainer.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainer.java
@@ -13,6 +13,7 @@ import org.traffichunter.titan.springframework.stomp.messaging.TitanSpringMessag
 import org.springframework.util.ErrorHandler;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
 
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 
@@ -56,7 +57,7 @@ public final class TitanListenerContainer {
 
         try {
             StompClientOperations operations = manager.operations();
-            operations.subscribe(endpoint.destination(), frame -> {
+            String subscriptionId = operations.subscribe(endpoint.destination(), frame -> {
                 try {
                     invoke(frame);
                     acknowledgeIfPossible(frame, operations);
@@ -70,8 +71,14 @@ public final class TitanListenerContainer {
                     handleListenerError(e);
                     negativeAcknowledgeIfPossible(frame, operations);
                 }
-            });
-            log.info("Started Titan listener. id={}, destination={}", endpoint.id(), endpoint.destination());
+            }).get(manager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
+
+            log.info(
+                    "Started Titan listener. id={}, destination={}, subscriptionId={}",
+                    endpoint.id(),
+                    endpoint.destination(),
+                    subscriptionId
+            );
         } catch (Exception e) {
             running.set(false);
             throw new IllegalStateException("Failed to start listener " + endpoint.id(), e);
@@ -93,7 +100,8 @@ public final class TitanListenerContainer {
             }
 
             if (operations.isConnected()) {
-                operations.unsubscribe(endpoint.destination());
+                operations.unsubscribe(endpoint.destination())
+                        .get(manager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
             }
 
             log.info("Stopped Titan listener. id={}, destination={}", endpoint.id(), endpoint.destination());

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
@@ -1,18 +1,19 @@
 package org.traffichunter.titan.springframework.stomp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
-
-import static org.mockito.Mockito.mock;
 
 class TitanClientManagerTest {
 
@@ -52,6 +53,24 @@ class TitanClientManagerTest {
         verify(client).start();
         verify(client, never()).connect();
         assertThat(manager.isRunning()).isTrue();
+    }
+
+    @Test
+    void start_connects_immediately_and_retries_when_retry_is_enabled() {
+        properties.getRetry().setEnabled(true);
+        properties.getRetry().setType(TitanProperties.Retry.Type.FIX);
+        properties.getRetry().setMaxAttempts(2);
+        properties.getRetry().setDelay(Duration.ofMillis(10));
+        when(client.connect())
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("connect failed")))
+                .thenReturn(CompletableFuture.completedFuture(operations));
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        manager.start();
+
+        verify(client).connect();
+        verify(client, timeout(1000).times(2)).connect();
+        manager.stop();
     }
 
     @Test

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
@@ -1,0 +1,100 @@
+package org.traffichunter.titan.springframework.stomp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
+
+import static org.mockito.Mockito.mock;
+
+class TitanClientManagerTest {
+
+    private StompClient client;
+    private StompClientOperations operations;
+    private TitanProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        client = mock(StompClient.class);
+        operations = mock(StompClientOperations.class);
+        properties = new TitanProperties();
+
+        when(client.connect()).thenReturn(CompletableFuture.completedFuture(operations));
+        when(client.operations()).thenReturn(operations);
+    }
+
+    @Test
+    void start_starts_client_and_connects_when_auto_connect_enabled() throws Exception {
+        when(client.isStarted()).thenReturn(false, true);
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        manager.start();
+
+        verify(client).start();
+        verify(client).connect();
+        assertThat(manager.isRunning()).isTrue();
+    }
+
+    @Test
+    void start_only_starts_client_when_auto_connect_disabled() {
+        properties.setAutoConnect(false);
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        manager.start();
+
+        verify(client).start();
+        verify(client, never()).connect();
+        assertThat(manager.isRunning()).isTrue();
+    }
+
+    @Test
+    void operations_start_and_connect_client_when_no_connection_exists() throws Exception {
+        when(client.operations())
+                .thenThrow(new IllegalStateException("not connected"))
+                .thenReturn(operations);
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        StompClientOperations resolved = manager.operations();
+
+        assertThat(resolved).isSameAs(operations);
+        verify(client).start();
+        verify(client).connect();
+    }
+
+    @Test
+    void operations_reuses_current_connection_when_connected() throws Exception {
+        when(operations.isConnected()).thenReturn(true);
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        StompClientOperations resolved = manager.operations();
+
+        assertThat(resolved).isSameAs(operations);
+        verify(client, never()).connect();
+    }
+
+    @Test
+    void current_operations_returns_null_when_no_connection_exists() {
+        when(client.operations()).thenThrow(new IllegalStateException("not connected"));
+        TitanClientManager manager = new TitanClientManager(client, properties);
+
+        assertThat(manager.currentOperations()).isNull();
+    }
+
+    @Test
+    void stop_shuts_down_client_with_configured_timeout_window() {
+        TitanClientManager manager = new TitanClientManager(client, properties);
+        manager.start();
+
+        manager.stop();
+
+        verify(client).shutdown(30, TimeUnit.SECONDS);
+        assertThat(manager.isRunning()).isFalse();
+    }
+}

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
@@ -4,7 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.resilience.retry.ExponentialRetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.FixedRetryPolicy;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
 
 class TitanPropertiesTest {
 
@@ -21,6 +25,12 @@ class TitanPropertiesTest {
         assertTrue(properties.isAutoComputeContentLength());
         assertFalse(properties.isUseStompFrame());
         assertFalse(properties.isBypassHostHeader());
+        assertFalse(properties.getRetry().isEnabled());
+        assertEquals(TitanProperties.Retry.Type.EXP, properties.getRetry().getType());
+        assertEquals(3, properties.getRetry().getMaxAttempts());
+        assertEquals(Duration.ofSeconds(1), properties.getRetry().getDelay());
+        assertEquals(Duration.ofSeconds(30), properties.getRetry().getMaxDelay());
+        assertEquals(2, properties.getRetry().getMultiplier());
     }
 
     @Test
@@ -41,5 +51,37 @@ class TitanPropertiesTest {
         properties.setSecondaryThreads(4);
 
         assertEquals(4, properties.getSecondaryThreads());
+    }
+
+    @Test
+    void retry_properties_create_fixed_retry_policy() {
+        TitanProperties properties = new TitanProperties();
+        properties.getRetry().setType(TitanProperties.Retry.Type.FIX);
+        properties.getRetry().setMaxAttempts(5);
+        properties.getRetry().setDelay(Duration.ofMillis(250));
+
+        RetryPolicy policy = properties.getRetry().toPolicy();
+
+        assertTrue(policy instanceof FixedRetryPolicy);
+        assertEquals(5, policy.maxAttempts());
+        assertEquals(Duration.ofMillis(250), policy.delay(1));
+    }
+
+    @Test
+    void retry_properties_create_exponential_retry_policy() {
+        TitanProperties properties = new TitanProperties();
+        properties.getRetry().setMaxAttempts(4);
+        properties.getRetry().setDelay(Duration.ofMillis(100));
+        properties.getRetry().setMaxDelay(Duration.ofMillis(1_000));
+        properties.getRetry().setMultiplier(3);
+
+        RetryPolicy policy = properties.getRetry().toPolicy();
+
+        assertTrue(policy instanceof ExponentialRetryPolicy);
+        assertEquals(4, policy.maxAttempts());
+        assertEquals(Duration.ofMillis(100), policy.delay(1));
+        assertEquals(Duration.ofMillis(300), policy.delay(2));
+        assertEquals(Duration.ofMillis(900), policy.delay(3));
+        assertEquals(Duration.ofMillis(1_000), policy.delay(4));
     }
 }

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanTemplateTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanTemplateTest.java
@@ -23,16 +23,18 @@ import static org.mockito.Mockito.when;
 class TitanTemplateTest {
 
     private StompClientOperations operations;
+    private StompClient client;
     private TitanTemplate template;
     private StompFrames frame;
 
     @BeforeEach
     void setUp() {
-        StompClient client = mock(StompClient.class);
+        client = mock(StompClient.class);
         operations = mock(StompClientOperations.class);
         frame = mock(StompFrames.class);
 
         when(client.operations()).thenReturn(operations);
+        when(client.connect()).thenReturn(CompletableFuture.completedFuture(operations));
         when(operations.isConnected()).thenReturn(true);
         template = new TitanTemplate(new TitanClientManager(client, new TitanProperties()));
     }
@@ -48,6 +50,21 @@ class TitanTemplateTest {
         verify(operations).send(eq("/topic/test"), payload.capture());
         assertThat(result).isSameAs(frame);
         assertThat(new String(payload.getValue().getBytes(), StandardCharsets.UTF_8)).isEqualTo("hello");
+    }
+
+    @Test
+    void sends_after_manager_connects_when_no_connection_exists() throws Exception {
+        when(client.operations())
+                .thenThrow(new IllegalStateException("not connected"))
+                .thenReturn(operations);
+        when(operations.send(eq("/topic/test"), any(Buffer.class)))
+                .thenReturn(CompletableFuture.completedFuture(frame));
+
+        StompFrames result = template.send("/topic/test", "hello");
+
+        verify(client).start();
+        verify(client).connect();
+        assertThat(result).isSameAs(frame);
     }
 
     @Test

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
@@ -2,22 +2,34 @@ package org.traffichunter.titan.springframework.stomp.autoconfigure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
+import org.traffichunter.titan.core.transport.stomp.client.StompClientOperations;
 import org.traffichunter.titan.core.transport.stomp.client.StompClientProvider;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TitanStompClientAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TitanStompClientAutoConfiguration.class));
 
     @Test
     void creates_titan_client_from_titan_client() {
@@ -66,5 +78,63 @@ class TitanStompClientAutoConfigurationTest {
         ))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("missing");
+    }
+
+    @Test
+    void lifecycle_starts_and_connects_client_when_auto_start_and_auto_connect_are_enabled() {
+        StompClientOperations operations = mock(StompClientOperations.class);
+        StompClient client = lifecycleClient(operations);
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TitanClientManager.class);
+                    assertThat(context.getBean(TitanClientManager.class).isRunning()).isTrue();
+                    verify(client).start();
+                    verify(client).connect();
+                });
+    }
+
+    @Test
+    void lifecycle_only_starts_client_when_auto_connect_is_disabled() {
+        StompClientOperations operations = mock(StompClientOperations.class);
+        StompClient client = lifecycleClient(operations);
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues("spring.titan.auto-connect=false")
+                .run(context -> {
+                    assertThat(context.getBean(TitanClientManager.class).isRunning()).isTrue();
+                    verify(client).start();
+                    verify(client, never()).connect();
+                });
+    }
+
+    @Test
+    void lifecycle_does_not_start_client_when_auto_start_is_disabled() {
+        StompClientOperations operations = mock(StompClientOperations.class);
+        StompClient client = lifecycleClient(operations);
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues("spring.titan.auto-start=false")
+                .run(context -> {
+                    assertThat(context.getBean(TitanClientManager.class).isRunning()).isFalse();
+                    verify(client, never()).start();
+                    verify(client, never()).connect();
+                });
+    }
+
+    private static StompClient lifecycleClient(StompClientOperations operations) {
+        AtomicBoolean started = new AtomicBoolean(false);
+        StompClient client = mock(StompClient.class);
+        when(client.isStarted()).thenAnswer(invocation -> started.get());
+        doAnswer(invocation -> {
+            started.set(true);
+            return null;
+        }).when(client).start();
+        when(client.connect()).thenReturn(CompletableFuture.completedFuture(operations));
+        when(client.operations()).thenReturn(operations);
+        return client;
     }
 }

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
 import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
@@ -14,6 +15,7 @@ import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanProperties;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -122,6 +124,36 @@ class TitanStompClientAutoConfigurationTest {
                     assertThat(context.getBean(TitanClientManager.class).isRunning()).isFalse();
                     verify(client, never()).start();
                     verify(client, never()).connect();
+                });
+    }
+
+    @Test
+    void binds_retry_properties() {
+        StompClient client = lifecycleClient(mock(StompClientOperations.class));
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues(
+                        "spring.titan.auto-start=false",
+                        "spring.titan.retry.enabled=true",
+                        "spring.titan.retry.type=fix",
+                        "spring.titan.retry.max-attempts=7",
+                        "spring.titan.retry.delay=250ms",
+                        "spring.titan.retry.max-delay=5s",
+                        "spring.titan.retry.multiplier=3"
+                )
+                .run(context -> {
+                    TitanProperties.Retry retry = context.getBean(TitanProperties.class).getRetry();
+                    RetryPolicy policy = retry.toPolicy();
+
+                    assertThat(retry.isEnabled()).isTrue();
+                    assertThat(retry.getType()).isEqualTo(TitanProperties.Retry.Type.FIX);
+                    assertThat(retry.getMaxAttempts()).isEqualTo(7);
+                    assertThat(retry.getDelay()).isEqualTo(Duration.ofMillis(250));
+                    assertThat(retry.getMaxDelay()).isEqualTo(Duration.ofSeconds(5));
+                    assertThat(retry.getMultiplier()).isEqualTo(3);
+                    assertThat(policy.maxAttempts()).isEqualTo(7);
+                    assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(250));
                 });
     }
 

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerContainerFactoryTest.java
@@ -3,6 +3,7 @@ package org.traffichunter.titan.springframework.stomp.listener;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -110,6 +111,31 @@ class TitanListenerContainerFactoryTest {
         assertTrue(errorHandled.get());
         verify(operations).nack("msg-2");
         verify(operations, never()).ack(anyString());
+    }
+
+    @Test
+    void listener_container_stops_by_unsubscribing_active_destination() throws Exception {
+        when(operations.unsubscribe("/topic/test"))
+                .thenReturn(CompletableFuture.completedFuture(mock(StompFrames.class)));
+        TitanListenerContainer container = listenerContainer(endpoint("handle"));
+
+        container.start();
+        container.stop();
+
+        verify(operations).unsubscribe("/topic/test");
+        assertTrue(container.isStopped());
+    }
+
+    @Test
+    void listener_container_resets_running_when_subscribe_fails() throws Exception {
+        when(operations.subscribe(eq("/topic/test"), org.mockito.ArgumentMatchers.<Handler<StompFrames>>any()))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("subscribe failed")));
+        TitanListenerContainer container = listenerContainer(endpoint("handle"));
+
+        assertThatThrownBy(container::start)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to start listener");
+        assertTrue(container.isStopped());
     }
 
     private static TitanListenerEndpoint endpoint() throws NoSuchMethodException {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -154,7 +154,7 @@ public final class StompServer {
     }
 
     public boolean isStart() {
-        return inetServer.isStart();
+        return inetServer.isStarted();
     }
 
     public StompServerOption option() {
@@ -166,7 +166,7 @@ public final class StompServer {
     }
 
     public void shutdown(long timeout, TimeUnit unit) {
-        Assert.checkState(inetServer.isStart(), "inetServer is not started");
+        Assert.checkState(inetServer.isStarted(), "inetServer is not started");
         ScheduledPromise<?> task = inactiveConnectionCleanupTask;
         if (task != null) {
             task.cancel();
@@ -180,7 +180,7 @@ public final class StompServer {
     }
 
     private void listen(InetSocketAddress address, ChannelPromise resultPromise) {
-        Assert.checkState(inetServer.isStart(), "inetServer is not started");
+        Assert.checkState(inetServer.isStarted(), "inetServer is not started");
 
         inetServer.listen(address)
                 .addListener(listenFuture -> {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
@@ -27,7 +27,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -110,7 +109,7 @@ public final class TitanStompClient implements StompClient {
     }
 
     public void start() {
-        if(inetClient.isStart()) {
+        if(inetClient.isStarted()) {
             throw new StompException("Client already started");
         }
 
@@ -162,8 +161,8 @@ public final class TitanStompClient implements StompClient {
         return inetClient.remoteAddress();
     }
 
-    public boolean isStart() {
-        return inetClient.isStart();
+    public boolean isStarted() {
+        return inetClient.isStarted();
     }
 
     public boolean isClosed() {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
@@ -138,7 +138,7 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
     }
 
     @Override
-    public boolean isStart() {
+    public boolean isStarted() {
         return client != null && !client.isClosed();
     }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompClient.java
@@ -39,7 +39,7 @@ public interface StompClient {
 
     StompClientOperations operations();
 
-    boolean isStart();
+    boolean isStarted();
 
     boolean isShutdown();
 


### PR DESCRIPTION
## Motivation:

Improve the Spring STOMP client reliability before adding larger reconnect and recovery features. This PR stabilizes lifecycle behavior, introduces shared retry primitives, and wires retry configuration into the Spring client.

## Modification:

- Add shared retry support in core.
  - Fixed and exponential retry policies
  - EventLoop and JDK scheduled retry executors
  - Retry listener callbacks and cancellation handle
- Stabilize Spring client lifecycle behavior.
  - Auto-start and auto-connect coverage
  - Safe shutdown behavior
  - Retry scheduling after an initial connect failure when retry is enabled
- Add Spring retry configuration.
  - `spring.titan.retry.enabled`
  - `spring.titan.retry.type`
  - `spring.titan.retry.max-attempts`
  - `spring.titan.retry.delay`
  - `spring.titan.retry.max-delay`
  - `spring.titan.retry.multiplier`
- Strengthen listener ACK/NACK and error handling tests.
- Document Spring retry configuration.

## Result:

Adds fault-tolerance groundwork for reconnect and retry behavior while keeping the Spring client API shape stable.

Validated with:

- `./gradlew test`
- `./gradlew :core:test`
- `./gradlew :core:test :titan-spring-client:test`
