### PR TITLE
Route release docs updates through pull requests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -66,6 +67,8 @@ jobs:
 
       - name: Update README and docs version
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -80,8 +83,36 @@ jobs:
             exit 0
           fi
 
+          docs_branch="release-docs/${GITHUB_REF_NAME}"
+          git fetch origin "+refs/heads/${docs_branch}:refs/remotes/origin/${docs_branch}" || true
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${docs_branch}"
           git add README.md docs/examples
           git commit -m "Update docs for ${GITHUB_REF_NAME}"
-          git push origin main
+          git push --force-with-lease origin "HEAD:${docs_branch}"
+
+          if gh pr list --base main --head "${docs_branch}" --state open --json number --jq 'length' | grep -q '^0$'; then
+            cat > pr-body.md <<EOF
+          ## Motivation:
+
+          Keep README and documentation examples aligned with the latest release version.
+
+          ## Modification:
+
+          Update README and docs examples to reference ${GITHUB_REF_NAME}.
+
+          ## Result:
+
+          Docs now reference ${GITHUB_REF_NAME}.
+          EOF
+
+            gh pr create \
+              --base main \
+              --head "${docs_branch}" \
+              --title "Update docs for ${GITHUB_REF_NAME}" \
+              --body-file pr-body.md
+          else
+            echo "Docs update PR already exists for ${docs_branch}"
+          fi

--- a/README.md
+++ b/README.md
@@ -34,26 +34,26 @@ repositories {
 Spring client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.6.0")
+implementation("org.traffichunter.titan:titan-spring-client:0.6.1")
 ```
 
 STOMP client/server:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.6.0")
+implementation("org.traffichunter.titan:titan-stomp:0.6.1")
 ```
 
 Fanout support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-fanout:0.6.0")
+implementation("org.traffichunter.titan:titan-fanout:0.6.1")
 ```
 
 Bootstrap/runtime support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.6.0")
-implementation("org.traffichunter.titan:titan-core:0.6.0")
+implementation("org.traffichunter.titan:titan-bootstrap:0.6.1")
+implementation("org.traffichunter.titan:titan-core:0.6.1")
 ```
 
 ## Standalone Server
@@ -63,15 +63,15 @@ Download the executable server jar from GitHub Releases.
 Using `curl`:
 
 ```bash
-curl -L -o titan-server-0.6.0.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.6.0/titan-server-0.6.0.jar
+curl -L -o titan-server-0.6.1.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.6.1/titan-server-0.6.1.jar
 ```
 
 Using `wget`:
 
 ```bash
-wget -O titan-server-0.6.0.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.6.0/titan-server-0.6.0.jar
+wget -O titan-server-0.6.1.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.6.1/titan-server-0.6.1.jar
 ```
 
 Create `titan-env.yml`.
@@ -97,7 +97,7 @@ titan:
 Run Titan.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.6.0.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.6.1.jar
 ```
 
 ## Examples

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.6.0")
+implementation("org.traffichunter.titan:titan-stomp:0.6.1")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.6.0")
-implementation("org.traffichunter.titan:titan-core:0.6.0")
-implementation("org.traffichunter.titan:titan-stomp:0.6.0")
-implementation("org.traffichunter.titan:titan-fanout:0.6.0")
+implementation("org.traffichunter.titan:titan-bootstrap:0.6.1")
+implementation("org.traffichunter.titan:titan-core:0.6.1")
+implementation("org.traffichunter.titan:titan-stomp:0.6.1")
+implementation("org.traffichunter.titan:titan-fanout:0.6.1")
 ```
 
 ### `titan-env.yml`

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.6.0")
+implementation("org.traffichunter.titan:titan-spring-client:0.6.1")
 ```
 
 ## Enable Titan

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanClientManagerTest.java
@@ -2,6 +2,7 @@ package org.traffichunter.titan.springframework.stomp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -179,7 +180,8 @@ class TitanClientManagerTest {
         captureConnectionDroppedHandler().handle(operations);
 
         verify(client, timeout(1000).times(2)).connect();
-        assertThat(manager.isReconnecting()).isFalse();
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(manager.isReconnecting()).isFalse());
     }
 
     @Test
@@ -191,7 +193,8 @@ class TitanClientManagerTest {
         captureExceptionHandler().handle(new IllegalStateException("connection lost"));
 
         verify(client, timeout(1000).times(2)).connect();
-        assertThat(manager.isReconnecting()).isFalse();
+        await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(manager.isReconnecting()).isFalse());
     }
 
     @Test


### PR DESCRIPTION
## Motivation:

The 0.6.1 release published successfully, but the release workflow failed when it tried to push README and docs updates directly to the protected main branch.

## Modification:

- Update the release workflow to push documentation changes to a release-docs/<version> branch.
- Create a pull request for release documentation updates instead of pushing to main.
- Update README and docs examples to reference 0.6.1.

## Result:

Release documentation updates can pass through the protected branch workflow, and the published 0.6.1 release is reflected in README and examples.

Validation:

- ./gradlew updateReleaseDocsVersion -PreleaseVersion=0.6.1 --no-configuration-cache
- YAML parse check for .github/workflows/release.yml
- bash -n for the extracted release docs update step
- git diff --check origin/main...HEAD
