### PR TITLE
Add monitoring runtime and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,17 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
       - name: Build
         run: ./gradlew --no-daemon build --stacktrace
+
+      - name: Test Go CLI
+        working-directory: titan-cli
+        run: go test ./...
 
       - name: Upload test reports
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,37 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Test Go CLI
+        working-directory: titan-cli
+        run: go test ./...
+
       - name: Build
         run: ./gradlew --no-daemon -PversionName="${GITHUB_REF_NAME}" clean build --stacktrace
+
+      - name: Build Go CLI
+        shell: bash
+        working-directory: titan-cli
+        run: |
+          set -euo pipefail
+
+          mkdir -p dist
+          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+            os="${target%/*}"
+            arch="${target#*/}"
+            name="titan-cli-${GITHUB_REF_NAME}-${os}-${arch}"
+
+            GOOS="${os}" GOARCH="${arch}" go build \
+              -ldflags "-X main.version=${GITHUB_REF_NAME}" \
+              -o "dist/${name}/titan" \
+              .
+
+            tar -C "dist/${name}" -czf "dist/${name}.tar.gz" titan
+          done
 
       - name: Collect release assets
         shell: bash
@@ -48,13 +77,14 @@ jobs:
 
           test -f "${server_jar}"
           cp "${server_jar}" release-assets/
+          cp titan-cli/dist/*.tar.gz release-assets/
 
           ls -la release-assets
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" release-assets/*.jar --verify-tag --title "Release ${GITHUB_REF_NAME}" --generate-notes
+        run: gh release create "${GITHUB_REF_NAME}" release-assets/* --verify-tag --title "Release ${GITHUB_REF_NAME}" --generate-notes
 
       - name: Publish to Maven Central
         env:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Spring Boot client integration.
 - Destination-based routing with `/queue/...` and `/topic/...` style paths.
 - Fanout delivery for publish-subscribe scenarios.
 - Pluggable runtime through SPI.
+- Local HTTP monitoring API with a terminal-first CLI.
 - Spring Boot integration with `TitanTemplate` and `@TitanListener`.
 
 Titan is best suited for real-time, in-memory dispatch scenarios such as
@@ -49,6 +50,12 @@ Fanout support:
 implementation("org.traffichunter.titan:titan-fanout:0.6.1")
 ```
 
+Monitoring support:
+
+```kotlin
+implementation("org.traffichunter.titan:titan-monitor:0.6.1")
+```
+
 Bootstrap/runtime support:
 
 ```kotlin
@@ -78,6 +85,11 @@ Create `titan-env.yml`.
 
 ```yaml
 titan:
+  monitor:
+    enabled: true
+    host: 127.0.0.1
+    port: 7777
+    # token: change-me
   servers:
     - name: stomp-dispatch
       protocol: stomp
@@ -98,6 +110,29 @@ Run Titan.
 
 ```bash
 java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.6.1.jar
+```
+
+Inspect the running server from a terminal. The release page provides
+prebuilt `titan-cli-<version>-<os>-<arch>.tar.gz` archives, or you can run the
+CLI from source while developing.
+
+```bash
+# prebuilt archive example
+tar -xzf titan-cli-0.6.1-linux-amd64.tar.gz
+./titan monitor status --addr http://localhost:7777
+
+# source checkout example
+cd titan-cli
+go run . monitor status --addr http://localhost:7777
+go run . monitor queues --addr http://localhost:7777
+go run . monitor watch --addr http://localhost:7777 --interval 1s
+```
+
+The monitor HTTP API is served under `/titan`.
+
+```bash
+curl http://localhost:7777/titan/monitor/health
+curl http://localhost:7777/titan/monitor/snapshot
 ```
 
 ## Examples
@@ -121,6 +156,7 @@ java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.6.1.jar
 - `titan-core`: provides event loop, channel, transport, and runtime primitives.
 - `titan-stomp`: provides STOMP codec, server, client, and STOMP transport integration.
 - `titan-fanout`: routes one published message to all matching subscribers.
+- `titan-monitor`: exposes JVM and dispatcher queue monitoring snapshots.
 - `titan-spring-client`: provides Spring Boot auto-configuration, `TitanTemplate`, and `@TitanListener`.
 
 ## Repository Modules
@@ -129,7 +165,8 @@ java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.6.1.jar
 - `core`: transport/event loop/channel/dispatcher/concurrency primitives.
 - `titan-stomp`: STOMP codec, STOMP server/client transport, STOMP engine provider.
 - `fanout`: fanout gateway and exporter implementations.
-- `monitor`: experimental monitoring module, not ready for general use.
+- `monitor`: monitoring snapshot model, JMX collectors, and Jetty HTTP endpoint.
+- `titan-cli`: Go CLI for rendering monitoring snapshots in the terminal.
 - `titan-spring-client`: Spring Boot auto-configuration and listener/template API.
 - `smoke-test`: smoke applications and integration tests.
 - `benchmark`: JMH benchmark setup.
@@ -140,6 +177,7 @@ Requirements:
 
 - JDK 21+
 - Gradle wrapper (`./gradlew`)
+- Go 1.22+ for `titan-cli`
 
 Run tests:
 
@@ -164,7 +202,7 @@ Build the standalone server jar:
 
 - Primary production focus is STOMP over TCP.
 - Reliability strategies such as nack/retry/error-policy in Spring listener container are still evolving.
-- Monitoring is still under development and not ready for general use.
+- Monitoring currently focuses on local JVM and dispatcher queue visibility.
 
 ## License
 

--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     runtimeOnly(project(":core"))
     runtimeOnly(project(":titan-stomp"))
     runtimeOnly(project(":fanout"))
+    runtimeOnly(project(":monitor"))
 }
 
 val manifestPath = "src/main/resources/META-INF/MANIFEST.MF"

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
@@ -36,10 +36,42 @@ import lombok.Builder;
  */
 @Builder
 public record Settings(
-        List<ServerSettings> servers
+        List<ServerSettings> servers,
+        MonitorSettings monitor
 ) {
 
     public Settings {
-        servers = List.copyOf(servers);
+        servers = servers == null ? List.of() : List.copyOf(servers);
+        if (monitor == null) {
+            monitor = MonitorSettings.disabled();
+        }
+    }
+
+    public record MonitorSettings(
+            boolean enabled,
+            String host,
+            int port,
+            String token,
+            int threadPoolSize
+    ) {
+
+        public static MonitorSettings disabled() {
+            return new MonitorSettings(false, "127.0.0.1", 7777, "", 8);
+        }
+
+        public MonitorSettings {
+            if (host == null || host.isBlank()) {
+                host = "127.0.0.1";
+            }
+            if (port <= 0 || port > 65535) {
+                port = 7777;
+            }
+            if (token == null) {
+                token = "";
+            }
+            if (threadPoolSize <= 0) {
+                threadPoolSize = 8;
+            }
+        }
     }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
@@ -31,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.bootstrap.Settings;
 import org.traffichunter.titan.bootstrap.environment.proprerty.RootYamlProperty;
+import org.traffichunter.titan.bootstrap.environment.proprerty.sub.MonitorProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.ServerProperty;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -110,7 +111,21 @@ final class YamlConfigurationInitializer implements ConfigurationInitializer {
 
         return Settings.builder()
                 .servers(servers)
+                .monitor(mapMonitor(root.getTitan() == null ? null : root.getTitan().getMonitor()))
                 .build();
+    }
+
+    private static Settings.MonitorSettings mapMonitor(final MonitorProperty property) {
+        if (property == null) {
+            return Settings.MonitorSettings.disabled();
+        }
+        return new Settings.MonitorSettings(
+                property.isEnabled(),
+                property.getHost(),
+                property.getPort(),
+                property.getToken(),
+                property.getThreadPoolSize()
+        );
     }
 
     private static ServerSettings mapServer(final ServerProperty property) {

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/MonitorProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/MonitorProperty.java
@@ -36,6 +36,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MonitorProperty {
 
+    private boolean enabled;
+
+    private String host;
+
+    private int port;
+
+    private String token;
+
+    private int threadPoolSize;
+
     private long initialDelay;
 
     private long delay;

--- a/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/environment/ConfigurationInitializerTest.java
+++ b/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/environment/ConfigurationInitializerTest.java
@@ -1,0 +1,67 @@
+package org.traffichunter.titan.bootstrap.environment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.bootstrap.Settings;
+
+class ConfigurationInitializerTest {
+
+    @Test
+    void load_maps_monitor_settings() {
+        String yaml = """
+                titan:
+                  monitor:
+                    enabled: true
+                    host: 127.0.0.1
+                    port: 8777
+                    token: secret
+                    thread-pool-size: 12
+                  servers:
+                    - name: stomp
+                      protocol: stomp
+                      transport: nio
+                      port: 7777
+                """;
+
+        Settings settings = ConfigurationInitializer.getDefault("unused")
+                .load(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(settings.monitor().enabled()).isTrue();
+        assertThat(settings.monitor().host()).isEqualTo("127.0.0.1");
+        assertThat(settings.monitor().port()).isEqualTo(8777);
+        assertThat(settings.monitor().token()).isEqualTo("secret");
+        assertThat(settings.monitor().threadPoolSize()).isEqualTo(12);
+    }
+
+    @Test
+    void load_defaults_monitor_to_disabled_when_missing() {
+        String yaml = """
+                titan:
+                  servers:
+                    - name: stomp
+                      protocol: stomp
+                      transport: nio
+                      port: 7777
+                """;
+
+        Settings settings = ConfigurationInitializer.getDefault("unused")
+                .load(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(settings.monitor().enabled()).isFalse();
+        assertThat(settings.monitor().host()).isEqualTo("127.0.0.1");
+        assertThat(settings.monitor().port()).isEqualTo(7777);
+    }
+
+    @Test
+    void settings_builder_defaults_missing_sections() {
+        Settings settings = Settings.builder().build();
+
+        assertThat(settings.servers()).isEmpty();
+        assertThat(settings.monitor().enabled()).isFalse();
+        assertThat(settings.monitor().host()).isEqualTo("127.0.0.1");
+        assertThat(settings.monitor().port()).isEqualTo(7777);
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ val publishedArtifacts = mapOf(
     "titan-stomp" to "titan-stomp",
     "titan-spring-client" to "titan-spring-client",
     "fanout" to "titan-fanout",
+    "monitor" to "titan-monitor",
 )
 
 configure(publishedArtifacts.keys.map { project(":$it") }) {

--- a/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
+++ b/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
@@ -35,6 +35,7 @@ import org.traffichunter.titan.bootstrap.Settings;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.FanoutLauncher;
 import org.traffichunter.titan.core.spi.NetworkServerEngineProvider;
+import org.traffichunter.titan.core.spi.RuntimeLauncher;
 
 /**
  * Core runtime entry point invoked by {@link org.traffichunter.titan.bootstrap.TitanBootstrap}.
@@ -96,9 +97,22 @@ public class TitanApplication implements ApplicationStarter {
             throw new CoreApplicationException("No managed servers found");
         }
 
+        RuntimeLauncher.load().forEach(launcher ->
+                launcher.start(settings, List.copyOf(managedServers))
+                        .forEach(closeable -> SHUTDOWN_HOOK.addShutdownCallback(() -> closeQuietly(closeable)))
+        );
+
         managedServers.forEach(managedServer ->
                 SHUTDOWN_HOOK.addShutdownCallback(managedServer::stop)
         );
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            log.warn("Failed to stop runtime extension cleanly", e);
+        }
     }
 
     public static class CoreApplicationException extends RuntimeException {

--- a/core/src/main/java/org/traffichunter/titan/core/httpserver/jetty/EmbeddedJettyHttpServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/httpserver/jetty/EmbeddedJettyHttpServer.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.thread.ThreadPool;
@@ -56,21 +57,26 @@ public class EmbeddedJettyHttpServer implements HttpServer {
 
     private final int port;
 
+    private final String host;
+
     private EmbeddedJettyHttpServer(final Builder builder) {
         this.handler = builder.handler;
         this.handler.setContextPath(ROOT_PATH);
         this.port = builder.port;
+        this.host = builder.host;
         registerServlets(this.handler, builder.contextServlets);
+        registerServletInstances(this.handler, builder.contextServletInstances);
 
         this.server = new Server(builder.threadPool);
         this.connector = new ServerConnector(server);
+        this.connector.setHost(host);
         this.connector.setPort(port);
         this.server.addConnector(connector);
         this.server.setHandler(handler);
         gracefulShutdown(builder.isGracefulShutdown);
 
         log.info("Embedded Jetty HTTP server ver. {}", server.getServerInfo());
-        log.info("Embedded Jetty HTTP server started on port. {}", this.port);
+        log.info("Embedded Jetty HTTP server started on address. {}:{}", this.host, this.port);
         log.info("Embedded Jetty HTTP server started on servlet context path. {}", this.handler.getContextPath());
     }
 
@@ -111,6 +117,13 @@ public class EmbeddedJettyHttpServer implements HttpServer {
                 servletContextHandler.addServlet(contextServlet.servletClass(), contextServlet.pathSpec()));
     }
 
+    private void registerServletInstances(final ServletContextHandler servletContextHandler,
+                                          final List<ContextServletInstance> contextServlets) {
+
+        contextServlets.forEach(contextServlet ->
+                servletContextHandler.addServlet(new ServletHolder(contextServlet.servlet()), contextServlet.pathSpec()));
+    }
+
     private void gracefulShutdown(final boolean isEnable) {
         server.setStopTimeout(5000);
         server.setStopAtShutdown(isEnable);
@@ -121,11 +134,15 @@ public class EmbeddedJettyHttpServer implements HttpServer {
 
         private ThreadPool threadPool;
 
+        private String host = "0.0.0.0";
+
         private int port = DEFAULT_PORT;
 
         private ServletContextHandler handler;
 
         private final List<ContextServlet> contextServlets = new ArrayList<>();
+
+        private final List<ContextServletInstance> contextServletInstances = new ArrayList<>();
 
         private boolean isGracefulShutdown = false;
 
@@ -159,6 +176,12 @@ public class EmbeddedJettyHttpServer implements HttpServer {
             return this;
         }
 
+        @CanIgnoreReturnValue
+        public Builder host(final String host) {
+            this.host = host;
+            return this;
+        }
+
         // Options is (ServletContextHandler.SESSIONS == 1)
         @CanIgnoreReturnValue
         public Builder contextHandler(final int options) {
@@ -178,10 +201,18 @@ public class EmbeddedJettyHttpServer implements HttpServer {
             return this;
         }
 
+        @CanIgnoreReturnValue
+        public Builder addContextServlet(final ContextServletInstance contextServlet) {
+            this.contextServletInstances.add(contextServlet);
+            return this;
+        }
+
         public EmbeddedJettyHttpServer build() {
             return new EmbeddedJettyHttpServer(this);
         }
     }
 
     public record ContextServlet(Class<? extends Servlet> servletClass, String pathSpec) { }
+
+    public record ContextServletInstance(Servlet servlet, String pathSpec) { }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueue.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueue.java
@@ -33,6 +33,7 @@ import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.concurrent.Pausable;
 import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbean;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
 
 /**
  * Queue of messages for one destination.
@@ -45,11 +46,15 @@ import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbean;
 public interface DispatcherQueue extends Pausable, Iterator<Message>, DispatcherQueueMbean {
 
     static DispatcherQueue create(Destination key) {
-        return new MessageDispatcherQueue(key);
+        DispatcherQueue queue = new MessageDispatcherQueue(key);
+        DispatcherQueueMbeans.register(queue);
+        return queue;
     }
 
     static DispatcherQueue create(Destination key, int capacity) {
-        return new MessageDispatcherQueue(key, capacity);
+        DispatcherQueue queue = new MessageDispatcherQueue(key, capacity);
+        DispatcherQueueMbeans.register(queue);
+        return queue;
     }
 
     /**

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueue.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueue.java
@@ -73,6 +73,11 @@ class MessageDispatcherQueue implements DispatcherQueue {
     }
 
     @Override
+    public String getDestination() {
+        return destination.path();
+    }
+
+    @Override
     public boolean equalsTo(final Destination key) {
         return destination.equals(key);
     }
@@ -135,6 +140,11 @@ class MessageDispatcherQueue implements DispatcherQueue {
     }
 
     @Override
+    public boolean isPaused() {
+        return isPaused;
+    }
+
+    @Override
     public List<Message> pressure() {
         List<Message> messages = new ArrayList<>();
         queue.drainTo(messages);
@@ -173,8 +183,18 @@ class MessageDispatcherQueue implements DispatcherQueue {
     }
 
     @Override
+    public int getCapacity() {
+        return capacity();
+    }
+
+    @Override
     public int size() {
         return queue.size();
+    }
+
+    @Override
+    public int getSize() {
+        return size();
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/spi/RuntimeLauncher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/RuntimeLauncher.java
@@ -1,0 +1,23 @@
+package org.traffichunter.titan.core.spi;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.traffichunter.titan.bootstrap.Settings;
+
+public interface RuntimeLauncher {
+
+    static List<RuntimeLauncher> load() {
+        return ServiceLoader.load(RuntimeLauncher.class, RuntimeLauncher.class.getClassLoader())
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .sorted(Comparator.comparingInt(RuntimeLauncher::order))
+                .toList();
+    }
+
+    default int order() {
+        return 0;
+    }
+
+    List<AutoCloseable> start(Settings settings, List<ManagedServer> managedServers);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbean.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbean.java
@@ -27,4 +27,12 @@ package org.traffichunter.titan.core.util.mbeans;
  * @author yungwang-o
  */
 public interface DispatcherQueueMbean {
+
+    String getDestination();
+
+    int getSize();
+
+    int getCapacity();
+
+    boolean isPaused();
 }

--- a/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbeans.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbeans.java
@@ -1,0 +1,42 @@
+package org.traffichunter.titan.core.util.mbeans;
+
+import java.lang.management.ManagementFactory;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+
+public final class DispatcherQueueMbeans {
+
+    public static final String DOMAIN = "org.traffichunter.titan";
+    public static final String TYPE = "DispatcherQueue";
+
+    public static ObjectName objectName(String destination) {
+        try {
+            return new ObjectName(DOMAIN + ":type=" + TYPE + ",destination=" + ObjectName.quote(destination));
+        } catch (JMException e) {
+            throw new IllegalArgumentException("Invalid dispatcher queue destination: " + destination, e);
+        }
+    }
+
+    public static ObjectName register(DispatcherQueueMbean queue) {
+        return register(ManagementFactory.getPlatformMBeanServer(), queue);
+    }
+
+    public static ObjectName register(MBeanServer server, DispatcherQueueMbean queue) {
+        ObjectName name = objectName(queue.getDestination());
+        try {
+            StandardMBean mbean = new StandardMBean(queue, DispatcherQueueMbean.class);
+            if (server.isRegistered(name)) {
+                server.unregisterMBean(name);
+            }
+            server.registerMBean(mbean, name);
+            return name;
+        } catch (JMException e) {
+            throw new IllegalStateException("Failed to register dispatcher queue MBean: " + name, e);
+        }
+    }
+
+    private DispatcherQueueMbeans() {
+    }
+}

--- a/monitor/build.gradle.kts
+++ b/monitor/build.gradle.kts
@@ -3,4 +3,6 @@ version = "1.0-SNAPSHOT"
 
 dependencies {
     implementation(project(":bootstrap"))
+    implementation(project(":core"))
+    implementation(project.libs.jetty.servlet)
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncher.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncher.java
@@ -34,6 +34,9 @@ public final class MonitorRuntimeLauncher implements RuntimeLauncher {
 
     private static String version() {
         Package pkg = MonitorRuntimeLauncher.class.getPackage();
+        if (pkg == null) {
+            return "unknown";
+        }
         String version = pkg.getImplementationVersion();
         return version == null || version.isBlank() ? "unknown" : version;
     }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncher.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncher.java
@@ -1,0 +1,40 @@
+package org.traffichunter.titan.monitor;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traffichunter.titan.bootstrap.Settings;
+import org.traffichunter.titan.core.spi.ManagedServer;
+import org.traffichunter.titan.core.spi.RuntimeLauncher;
+import org.traffichunter.titan.monitor.http.MonitoringHttpServer;
+
+public final class MonitorRuntimeLauncher implements RuntimeLauncher {
+
+    private static final Logger log = LoggerFactory.getLogger(MonitorRuntimeLauncher.class);
+
+    @Override
+    public List<AutoCloseable> start(Settings settings, List<ManagedServer> managedServers) {
+        Settings.MonitorSettings monitor = settings.monitor();
+        if (!monitor.enabled()) {
+            return List.of();
+        }
+
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService(version()))
+                .host(monitor.host())
+                .port(monitor.port())
+                .threadPoolSize(monitor.threadPoolSize())
+                .token(monitor.token())
+                .build();
+        Thread thread = new Thread(server::start, "titan-monitor-http");
+        thread.setDaemon(true);
+        thread.start();
+        log.info("Started Titan monitor HTTP server at {}:{}", monitor.host(), monitor.port());
+        return List.of(server::close);
+    }
+
+    private static String version() {
+        Package pkg = MonitorRuntimeLauncher.class.getPackage();
+        String version = pkg.getImplementationVersion();
+        return version == null || version.isBlank() ? "unknown" : version;
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/MonitoringSnapshotService.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/MonitoringSnapshotService.java
@@ -1,0 +1,71 @@
+package org.traffichunter.titan.monitor;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import org.traffichunter.titan.monitor.jmx.cpu.JmxCpuMbeanCollector;
+import org.traffichunter.titan.monitor.jmx.heap.JmxHeapMbeanCollector;
+import org.traffichunter.titan.monitor.jmx.queue.JmxDispatcherQueueCollector;
+import org.traffichunter.titan.monitor.jmx.thread.JmxThreadMbeanCollector;
+import org.traffichunter.titan.monitor.model.JvmSnapshot;
+import org.traffichunter.titan.monitor.model.MonitoringSnapshot;
+import org.traffichunter.titan.monitor.model.ServerSnapshot;
+
+public final class MonitoringSnapshotService {
+
+    private final Clock clock;
+    private final Instant startedAt;
+    private final String version;
+    private final JmxCpuMbeanCollector cpuCollector;
+    private final JmxHeapMbeanCollector heapCollector;
+    private final JmxThreadMbeanCollector threadCollector;
+    private final JmxDispatcherQueueCollector queueCollector;
+
+    public MonitoringSnapshotService(String version) {
+        this(
+                Clock.systemUTC(),
+                Instant.now(),
+                version,
+                new JmxCpuMbeanCollector(),
+                new JmxHeapMbeanCollector(),
+                new JmxThreadMbeanCollector(),
+                new JmxDispatcherQueueCollector()
+        );
+    }
+
+    public MonitoringSnapshotService(
+            Clock clock,
+            Instant startedAt,
+            String version,
+            JmxCpuMbeanCollector cpuCollector,
+            JmxHeapMbeanCollector heapCollector,
+            JmxThreadMbeanCollector threadCollector,
+            JmxDispatcherQueueCollector queueCollector
+    ) {
+        this.clock = clock;
+        this.startedAt = startedAt;
+        this.version = version;
+        this.cpuCollector = cpuCollector;
+        this.heapCollector = heapCollector;
+        this.threadCollector = threadCollector;
+        this.queueCollector = queueCollector;
+    }
+
+    public MonitoringSnapshot snapshot() {
+        Instant timestamp = clock.instant();
+        return new MonitoringSnapshot(
+                new ServerSnapshot(
+                        version,
+                        startedAt,
+                        timestamp,
+                        Duration.between(startedAt, timestamp).toMillis()
+                ),
+                new JvmSnapshot(
+                        cpuCollector.collect(),
+                        heapCollector.collect(),
+                        threadCollector.collect()
+                ),
+                queueCollector.collect()
+        );
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
@@ -18,6 +18,10 @@ public final class MonitoringAuthorization {
         if (!required()) {
             return true;
         }
-        return ("Bearer " + token).equals(request.getHeader("Authorization"));
+        return getBearerToken(token).equals(request.getHeader("Authorization"));
+    }
+
+    private static String getBearerToken(String token) {
+        return "Bearer " + token;
     }
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
@@ -1,0 +1,23 @@
+package org.traffichunter.titan.monitor.http;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class MonitoringAuthorization {
+
+    private final String token;
+
+    public MonitoringAuthorization(String token) {
+        this.token = token;
+    }
+
+    public boolean required() {
+        return token != null && !token.isBlank();
+    }
+
+    public boolean allows(HttpServletRequest request) {
+        if (!required()) {
+            return true;
+        }
+        return ("Bearer " + token).equals(request.getHeader("Authorization"));
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHealthServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHealthServlet.java
@@ -1,0 +1,27 @@
+package org.traffichunter.titan.monitor.http;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.traffichunter.titan.core.httpserver.ContentType;
+
+public final class MonitoringHealthServlet extends HttpServlet {
+
+    private final MonitoringAuthorization authorization;
+
+    public MonitoringHealthServlet(MonitoringAuthorization authorization) {
+        this.authorization = authorization;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!authorization.allows(request)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(ContentType.APPLICATION_JSON);
+        response.getWriter().write("{\"status\":\"UP\"}");
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
@@ -1,0 +1,98 @@
+package org.traffichunter.titan.monitor.http;
+
+import jakarta.servlet.Servlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traffichunter.titan.core.httpserver.HttpServer;
+import org.traffichunter.titan.core.httpserver.jetty.EmbeddedJettyHttpServer;
+import org.traffichunter.titan.core.httpserver.threadpool.JettyThreadPool;
+import org.traffichunter.titan.monitor.MonitoringSnapshotService;
+
+public final class MonitoringHttpServer implements HttpServer {
+
+    public static final String SNAPSHOT_PATH = "/monitor/snapshot";
+    public static final String HEALTH_PATH = "/monitor/health";
+    public static final String DEFAULT_HOST = "127.0.0.1";
+    public static final int DEFAULT_PORT = 7777;
+
+    private static final Logger log = LoggerFactory.getLogger(MonitoringHttpServer.class);
+
+    private final EmbeddedJettyHttpServer server;
+
+    private MonitoringHttpServer(Builder builder) {
+        MonitoringAuthorization authorization = new MonitoringAuthorization(builder.token);
+        if (!authorization.required()) {
+            log.warn("Titan monitor token is not configured. Bind monitor HTTP server to a trusted interface only.");
+        }
+
+        this.server = EmbeddedJettyHttpServer.builder()
+                .host(builder.host)
+                .port(builder.port)
+                .threadPool(JettyThreadPool._QUEUED, builder.threadPoolSize)
+                .contextHandler(0)
+                .addContextServlet(servlet(new MonitoringSnapshotServlet(builder.service, authorization), SNAPSHOT_PATH))
+                .addContextServlet(servlet(new MonitoringHealthServlet(authorization), HEALTH_PATH))
+                .gracefulShutdown(true)
+                .build();
+    }
+
+    public static Builder builder(MonitoringSnapshotService service) {
+        return new Builder(service);
+    }
+
+    @Override
+    public int getPort() {
+        return server.getPort();
+    }
+
+    @Override
+    public void start() {
+        server.start();
+    }
+
+    @Override
+    public void close() {
+        server.close();
+    }
+
+    private static EmbeddedJettyHttpServer.ContextServletInstance servlet(Servlet servlet, String path) {
+        return new EmbeddedJettyHttpServer.ContextServletInstance(servlet, path);
+    }
+
+    public static final class Builder {
+
+        private final MonitoringSnapshotService service;
+        private String host = DEFAULT_HOST;
+        private int port = DEFAULT_PORT;
+        private int threadPoolSize = 8;
+        private String token;
+
+        private Builder(MonitoringSnapshotService service) {
+            this.service = service;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder threadPoolSize(int threadPoolSize) {
+            this.threadPoolSize = threadPoolSize;
+            return this;
+        }
+
+        public Builder token(String token) {
+            this.token = token;
+            return this;
+        }
+
+        public MonitoringHttpServer build() {
+            return new MonitoringHttpServer(this);
+        }
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
@@ -65,7 +65,7 @@ public final class MonitoringHttpServer implements HttpServer {
         private String host = DEFAULT_HOST;
         private int port = DEFAULT_PORT;
         private int threadPoolSize = 8;
-        private String token;
+        private String token = "";
 
         private Builder(MonitoringSnapshotService service) {
             this.service = service;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringSnapshotServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringSnapshotServlet.java
@@ -1,0 +1,36 @@
+package org.traffichunter.titan.monitor.http;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.traffichunter.titan.core.codec.json.Json;
+import org.traffichunter.titan.core.httpserver.ContentType;
+import org.traffichunter.titan.monitor.MonitoringSnapshotService;
+
+public final class MonitoringSnapshotServlet extends HttpServlet {
+
+    private final MonitoringSnapshotService service;
+    private final MonitoringAuthorization authorization;
+
+    public MonitoringSnapshotServlet(MonitoringSnapshotService service, MonitoringAuthorization authorization) {
+        this.service = service;
+        this.authorization = authorization;
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!authorization.allows(request)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        String json = Json.serialize(service.snapshot());
+        if (json == null) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(ContentType.APPLICATION_JSON);
+        response.getWriter().write(json);
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.monitor.http;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/cpu/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/cpu/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.traffichunter.titan.monitor.jmx.cpu;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/heap/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/heap/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.traffichunter.titan.monitor.jmx.heap;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.traffichunter.titan.monitor.jmx;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollector.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollector.java
@@ -41,6 +41,10 @@ public final class JmxDispatcherQueueCollector {
     }
 
     private <T> T attribute(ObjectName name, String attribute, Class<T> type) throws Exception {
-        return type.cast(server.getAttribute(name, attribute));
+        Object value = server.getAttribute(name, attribute);
+        if (value == null) {
+            throw new IllegalStateException("Missing dispatcher queue MBean attribute: " + attribute);
+        }
+        return type.cast(value);
     }
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollector.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollector.java
@@ -1,0 +1,46 @@
+package org.traffichunter.titan.monitor.jmx.queue;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
+import org.traffichunter.titan.monitor.model.QueueSnapshot;
+
+public final class JmxDispatcherQueueCollector {
+
+    private final MBeanServerConnection server;
+
+    public JmxDispatcherQueueCollector() {
+        this(ManagementFactory.getPlatformMBeanServer());
+    }
+
+    public JmxDispatcherQueueCollector(MBeanServerConnection server) {
+        this.server = server;
+    }
+
+    public List<QueueSnapshot> collect() {
+        try {
+            ObjectName query = new ObjectName(DispatcherQueueMbeans.DOMAIN + ":type=" + DispatcherQueueMbeans.TYPE + ",*");
+            List<QueueSnapshot> queues = new ArrayList<>();
+            for (ObjectName name : server.queryNames(query, null)) {
+                queues.add(new QueueSnapshot(
+                        attribute(name, "Destination", String.class),
+                        attribute(name, "Size", Integer.class),
+                        attribute(name, "Capacity", Integer.class),
+                        attribute(name, "Paused", Boolean.class)
+                ));
+            }
+            queues.sort(Comparator.comparing(QueueSnapshot::destination));
+            return List.copyOf(queues);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to collect dispatcher queue MBeans", e);
+        }
+    }
+
+    private <T> T attribute(ObjectName name, String attribute, Class<T> type) throws Exception {
+        return type.cast(server.getAttribute(name, attribute));
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/queue/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.traffichunter.titan.monitor.jmx.queue;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/JmxThreadMbeanCollector.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/JmxThreadMbeanCollector.java
@@ -49,8 +49,8 @@ public final class JmxThreadMbeanCollector implements JmxMbeanCollector<ThreadDa
 
         return ThreadData.builder()
                 .threadCount(threadMXBean.getThreadCount())
-                .getPeekThreadCount(threadMXBean.getPeakThreadCount())
-                .getTotalStartThreadCount(threadMXBean.getTotalStartedThreadCount())
+                .peakThreadCount(threadMXBean.getPeakThreadCount())
+                .totalStartedThreadCount(threadMXBean.getTotalStartedThreadCount())
                 .build();
     }
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/ThreadData.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/ThreadData.java
@@ -34,9 +34,9 @@ public record ThreadData(
 
         int threadCount,
 
-        int getPeekThreadCount,
+        int peakThreadCount,
 
-        long getTotalStartThreadCount
+        long totalStartedThreadCount
 
 ) implements ThreshHold {
 

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.traffichunter.titan.monitor.jmx.thread;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/JvmSnapshot.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/JvmSnapshot.java
@@ -1,0 +1,8 @@
+package org.traffichunter.titan.monitor.model;
+
+import org.traffichunter.titan.monitor.jmx.cpu.CpuData;
+import org.traffichunter.titan.monitor.jmx.heap.HeapData;
+import org.traffichunter.titan.monitor.jmx.thread.ThreadData;
+
+public record JvmSnapshot(CpuData cpu, HeapData heap, ThreadData thread) {
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/MonitoringSnapshot.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/MonitoringSnapshot.java
@@ -1,0 +1,6 @@
+package org.traffichunter.titan.monitor.model;
+
+import java.util.List;
+
+public record MonitoringSnapshot(ServerSnapshot server, JvmSnapshot jvm, List<QueueSnapshot> queues) {
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/QueueSnapshot.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/QueueSnapshot.java
@@ -1,0 +1,4 @@
+package org.traffichunter.titan.monitor.model;
+
+public record QueueSnapshot(String destination, int size, int capacity, boolean paused) {
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/ServerSnapshot.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/ServerSnapshot.java
@@ -1,0 +1,6 @@
+package org.traffichunter.titan.monitor.model;
+
+import java.time.Instant;
+
+public record ServerSnapshot(String version, Instant startedAt, Instant timestamp, long uptimeMillis) {
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.monitor.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/package-info.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.monitor;
+
+import org.jspecify.annotations.NullMarked;

--- a/monitor/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.RuntimeLauncher
+++ b/monitor/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.RuntimeLauncher
@@ -1,0 +1,1 @@
+org.traffichunter.titan.monitor.MonitorRuntimeLauncher

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncherTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncherTest.java
@@ -1,0 +1,30 @@
+package org.traffichunter.titan.monitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.bootstrap.Settings;
+import org.traffichunter.titan.core.spi.RuntimeLauncher;
+
+class MonitorRuntimeLauncherTest {
+
+    @Test
+    void runtime_launcher_is_discoverable_by_service_loader() {
+        List<RuntimeLauncher> launchers = RuntimeLauncher.load();
+
+        assertThat(launchers)
+                .anySatisfy(launcher -> assertThat(launcher).isInstanceOf(MonitorRuntimeLauncher.class));
+    }
+
+    @Test
+    void runtime_launcher_stays_idle_when_monitor_is_disabled() {
+        MonitorRuntimeLauncher launcher = new MonitorRuntimeLauncher();
+        Settings settings = Settings.builder()
+                .servers(List.of())
+                .monitor(Settings.MonitorSettings.disabled())
+                .build();
+
+        assertThat(launcher.start(settings, List.of())).isEmpty();
+    }
+}

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/MonitoringSnapshotServiceTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/MonitoringSnapshotServiceTest.java
@@ -1,0 +1,40 @@
+package org.traffichunter.titan.monitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.codec.json.Json;
+import org.traffichunter.titan.monitor.jmx.cpu.JmxCpuMbeanCollector;
+import org.traffichunter.titan.monitor.jmx.heap.JmxHeapMbeanCollector;
+import org.traffichunter.titan.monitor.jmx.queue.JmxDispatcherQueueCollector;
+import org.traffichunter.titan.monitor.jmx.thread.JmxThreadMbeanCollector;
+import org.traffichunter.titan.monitor.model.MonitoringSnapshot;
+
+class MonitoringSnapshotServiceTest {
+
+    @Test
+    void snapshot_contains_server_jvm_and_queue_sections() {
+        Instant startedAt = Instant.parse("2026-06-06T00:00:00Z");
+        MonitoringSnapshotService service = new MonitoringSnapshotService(
+                Clock.fixed(startedAt.plusSeconds(5), ZoneOffset.UTC),
+                startedAt,
+                "0.6.1",
+                new JmxCpuMbeanCollector(),
+                new JmxHeapMbeanCollector(),
+                new JmxThreadMbeanCollector(),
+                new JmxDispatcherQueueCollector()
+        );
+
+        MonitoringSnapshot snapshot = service.snapshot();
+        String json = Json.serialize(snapshot);
+
+        assertThat(snapshot.server().version()).isEqualTo("0.6.1");
+        assertThat(snapshot.server().uptimeMillis()).isEqualTo(5000);
+        assertThat(snapshot.jvm()).isNotNull();
+        assertThat(snapshot.queues()).isNotNull();
+        assertThat(json).contains("\"server\"", "\"jvm\"", "\"queues\"");
+    }
+}

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
@@ -1,0 +1,120 @@
+package org.traffichunter.titan.monitor.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.monitor.MonitoringSnapshotService;
+
+class MonitoringHttpServerTest {
+
+    @Test
+    void exposes_health_and_snapshot_endpoints() throws Exception {
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> health = client.send(
+                        request(port, MonitoringHttpServer.HEALTH_PATH),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(health.statusCode()).isEqualTo(200);
+            });
+
+            HttpResponse<String> snapshot = client.send(
+                    request(port, MonitoringHttpServer.SNAPSHOT_PATH),
+                    HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(snapshot.statusCode()).isEqualTo(200);
+            assertThat(snapshot.body()).contains("\"server\"", "\"jvm\"", "\"queues\"");
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void rejects_snapshot_without_configured_token() throws Exception {
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-auth-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> health = client.send(
+                        request(port, MonitoringHttpServer.HEALTH_PATH),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(health.statusCode()).isEqualTo(401);
+            });
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void allows_snapshot_with_configured_bearer_token() throws Exception {
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-auth-success-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> snapshot = client.send(
+                        request(port, MonitoringHttpServer.SNAPSHOT_PATH, "secret"),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(snapshot.statusCode()).isEqualTo(200);
+                assertThat(snapshot.body()).contains("\"server\"", "\"jvm\"", "\"queues\"");
+            });
+        } finally {
+            server.close();
+        }
+    }
+
+    private static HttpRequest request(int port, String path) {
+        return HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/titan" + path)).GET().build();
+    }
+
+    private static HttpRequest request(int port, String path, String token) {
+        return HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/titan" + path))
+                .header("Authorization", "Bearer " + token)
+                .GET()
+                .build();
+    }
+
+    private static int availablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollectorTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollectorTest.java
@@ -1,0 +1,38 @@
+package org.traffichunter.titan.monitor.jmx.queue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
+import org.traffichunter.titan.monitor.model.QueueSnapshot;
+
+class JmxDispatcherQueueCollectorTest {
+
+    @Test
+    void collect_reads_dispatcher_queue_mbean_attributes() {
+        MBeanServer server = MBeanServerFactory.createMBeanServer();
+        DispatcherQueue queue = DispatcherQueue.create(Destination.create("/queue/orders"), 10);
+        queue.enqueue(Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(Destination.create("/queue/orders"))
+                .createdAt(Instant.now())
+                .producerId("test")
+                .body(Buffer.alloc("hello".getBytes()))
+                .build());
+        queue.pause();
+        DispatcherQueueMbeans.register(server, queue);
+
+        List<QueueSnapshot> queues = new JmxDispatcherQueueCollector(server).collect();
+
+        assertThat(queues).containsExactly(new QueueSnapshot("/queue/orders", 1, 10, true));
+    }
+}

--- a/titan-cli/go.mod
+++ b/titan-cli/go.mod
@@ -1,0 +1,3 @@
+module github.com/traffic-hunter/titan/titan-cli
+
+go 1.22

--- a/titan-cli/internal/cli/cli.go
+++ b/titan-cli/internal/cli/cli.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/traffic-hunter/titan/titan-cli/internal/monitor"
+	"github.com/traffic-hunter/titan/titan-cli/internal/render"
+)
+
+const defaultAddr = "http://localhost:7777"
+
+func Run(args []string, stdout io.Writer, stderr io.Writer, version string) int {
+	if len(args) == 0 {
+		usage(stderr)
+		return 2
+	}
+	if args[0] == "version" {
+		fmt.Fprintln(stdout, version)
+		return 0
+	}
+	if args[0] != "monitor" {
+		fmt.Fprintf(stderr, "unknown command %q\n", args[0])
+		usage(stderr)
+		return 2
+	}
+	return runMonitor(args[1:], stdout, stderr)
+}
+
+func runMonitor(args []string, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		monitorUsage(stderr)
+		return 2
+	}
+
+	switch args[0] {
+	case "status":
+		return snapshotCommand(args[1:], stdout, stderr, render.Status)
+	case "queues":
+		return snapshotCommand(args[1:], stdout, stderr, func(w io.Writer, s monitor.Snapshot) {
+			render.Queues(w, s.Queues)
+		})
+	case "jvm":
+		return snapshotCommand(args[1:], stdout, stderr, render.JVM)
+	case "watch":
+		return watchCommand(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown monitor command %q\n", args[0])
+		monitorUsage(stderr)
+		return 2
+	}
+}
+
+func snapshotCommand(args []string, stdout io.Writer, stderr io.Writer, renderer func(io.Writer, monitor.Snapshot)) int {
+	flags := flag.NewFlagSet("snapshot", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	addr := flags.String("addr", defaultAddr, "Titan monitor HTTP address")
+	token := flags.String("token", "", "Titan monitor bearer token")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	snapshot, err := monitor.NewClient(*addr, *token).Snapshot(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to fetch monitor snapshot: %v\n", err)
+		return 1
+	}
+	renderer(stdout, snapshot)
+	return 0
+}
+
+func watchCommand(args []string, stdout io.Writer, stderr io.Writer) int {
+	flags := flag.NewFlagSet("watch", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	addr := flags.String("addr", defaultAddr, "Titan monitor HTTP address")
+	token := flags.String("token", "", "Titan monitor bearer token")
+	interval := flags.Duration("interval", time.Second, "Refresh interval")
+	once := flags.Bool("once", false, "Render one frame and exit")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	client := monitor.NewClient(*addr, *token)
+	for {
+		snapshot, err := client.Snapshot(context.Background())
+		if err != nil {
+			fmt.Fprintf(stderr, "failed to fetch monitor snapshot: %v\n", err)
+			return 1
+		}
+		fmt.Fprint(stdout, "\033[H\033[2J")
+		render.Status(stdout, snapshot)
+		fmt.Fprintln(stdout)
+		render.Queues(stdout, snapshot.Queues)
+		if *once {
+			return 0
+		}
+		time.Sleep(*interval)
+	}
+}
+
+func usage(w io.Writer) {
+	fmt.Fprintln(w, "usage: titan <version|monitor>")
+	fmt.Fprintln(w, "usage: titan monitor <status|watch|queues|jvm> [flags]")
+}
+
+func monitorUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: titan monitor <status|watch|queues|jvm> [--addr http://localhost:7777] [--token token]")
+}

--- a/titan-cli/internal/cli/cli_test.go
+++ b/titan-cli/internal/cli/cli_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRejectsUnknownCommand(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := Run([]string{"unknown"}, &bytes.Buffer{}, &stderr, "test")
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown command") {
+		t.Fatalf("expected unknown command message, got %q", stderr.String())
+	}
+}
+
+func TestRunRejectsUnknownMonitorCommand(t *testing.T) {
+	var stderr bytes.Buffer
+
+	code := Run([]string{"monitor", "unknown"}, &bytes.Buffer{}, &stderr, "test")
+
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown monitor command") {
+		t.Fatalf("expected unknown monitor command message, got %q", stderr.String())
+	}
+}
+
+func TestRunPrintsVersion(t *testing.T) {
+	var stdout bytes.Buffer
+
+	code := Run([]string{"version"}, &stdout, &bytes.Buffer{}, "0.7.0")
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if strings.TrimSpace(stdout.String()) != "0.7.0" {
+		t.Fatalf("expected version output, got %q", stdout.String())
+	}
+}

--- a/titan-cli/internal/monitor/client.go
+++ b/titan-cli/internal/monitor/client.go
@@ -1,0 +1,52 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+}
+
+func NewClient(addr string, token string) Client {
+	return Client{
+		baseURL: strings.TrimRight(addr, "/"),
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+func (c Client) Snapshot(ctx context.Context) (Snapshot, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/titan/monitor/snapshot", nil)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if c.token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return Snapshot{}, fmt.Errorf("monitor endpoint returned %s", response.Status)
+	}
+
+	var snapshot Snapshot
+	if err := json.NewDecoder(response.Body).Decode(&snapshot); err != nil {
+		return Snapshot{}, err
+	}
+	return snapshot, nil
+}

--- a/titan-cli/internal/monitor/client_test.go
+++ b/titan-cli/internal/monitor/client_test.go
@@ -1,0 +1,40 @@
+package monitor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSnapshotSendsBearerToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("missing bearer token")
+		}
+		_, _ = w.Write([]byte(`{"server":{"version":"test","uptimeMillis":1},"jvm":{"cpu":{},"heap":{},"thread":{}},"queues":[]}`))
+	}))
+	defer server.Close()
+
+	snapshot, err := NewClient(server.URL, "secret").Snapshot(context.Background())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if snapshot.Server.Version != "test" {
+		t.Fatalf("expected test version, got %q", snapshot.Server.Version)
+	}
+}
+
+func TestSnapshotReturnsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := NewClient(server.URL, "").Snapshot(context.Background())
+
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/titan-cli/internal/monitor/model.go
+++ b/titan-cli/internal/monitor/model.go
@@ -1,0 +1,46 @@
+package monitor
+
+type Snapshot struct {
+	Server ServerSnapshot  `json:"server"`
+	JVM    JVMSnapshot     `json:"jvm"`
+	Queues []QueueSnapshot `json:"queues"`
+}
+
+type ServerSnapshot struct {
+	Version      string `json:"version"`
+	StartedAt    any    `json:"startedAt"`
+	Timestamp    any    `json:"timestamp"`
+	UptimeMillis int64  `json:"uptimeMillis"`
+}
+
+type JVMSnapshot struct {
+	CPU    CPUSnapshot    `json:"cpu"`
+	Heap   HeapSnapshot   `json:"heap"`
+	Thread ThreadSnapshot `json:"thread"`
+}
+
+type CPUSnapshot struct {
+	SystemCPULoad       float64 `json:"systemCpuLoad"`
+	ProcessCPULoad      float64 `json:"processCpuLoad"`
+	AvailableProcessors int64   `json:"availableProcessors"`
+}
+
+type HeapSnapshot struct {
+	Init      int64 `json:"init"`
+	Used      int64 `json:"used"`
+	Committed int64 `json:"committed"`
+	Max       int64 `json:"max"`
+}
+
+type ThreadSnapshot struct {
+	ThreadCount             int   `json:"threadCount"`
+	PeakThreadCount         int   `json:"peakThreadCount"`
+	TotalStartedThreadCount int64 `json:"totalStartedThreadCount"`
+}
+
+type QueueSnapshot struct {
+	Destination string `json:"destination"`
+	Size        int    `json:"size"`
+	Capacity    int    `json:"capacity"`
+	Paused      bool   `json:"paused"`
+}

--- a/titan-cli/internal/render/render.go
+++ b/titan-cli/internal/render/render.go
@@ -1,0 +1,115 @@
+package render
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/traffic-hunter/titan/titan-cli/internal/monitor"
+)
+
+func Status(w io.Writer, snapshot monitor.Snapshot) {
+	fmt.Fprintf(w, "Titan %s\n", valueOrUnknown(snapshot.Server.Version))
+	fmt.Fprintf(w, "Uptime: %s\n", (time.Duration(snapshot.Server.UptimeMillis) * time.Millisecond).Round(time.Second))
+	fmt.Fprintf(w, "CPU   : %s system  %s process\n", percent(snapshot.JVM.CPU.SystemCPULoad), percent(snapshot.JVM.CPU.ProcessCPULoad))
+	fmt.Fprintf(w, "Heap  : %s / %s %s\n", byteSize(snapshot.JVM.Heap.Used), byteSize(snapshot.JVM.Heap.Max), bar(ratio(snapshot.JVM.Heap.Used, snapshot.JVM.Heap.Max), 24))
+	fmt.Fprintf(w, "Thread: %d current  %d peak\n", snapshot.JVM.Thread.ThreadCount, snapshot.JVM.Thread.PeakThreadCount)
+	fmt.Fprintf(w, "Queues: %d destinations\n", len(snapshot.Queues))
+}
+
+func JVM(w io.Writer, snapshot monitor.Snapshot) {
+	fmt.Fprintln(w, "JVM")
+	fmt.Fprintf(w, "CPU system : %s %s\n", percent(snapshot.JVM.CPU.SystemCPULoad), bar(snapshot.JVM.CPU.SystemCPULoad, 24))
+	fmt.Fprintf(w, "CPU process: %s %s\n", percent(snapshot.JVM.CPU.ProcessCPULoad), bar(snapshot.JVM.CPU.ProcessCPULoad, 24))
+	fmt.Fprintf(w, "Processors : %d\n", snapshot.JVM.CPU.AvailableProcessors)
+	fmt.Fprintf(w, "Heap used  : %s / %s %s\n", byteSize(snapshot.JVM.Heap.Used), byteSize(snapshot.JVM.Heap.Max), bar(ratio(snapshot.JVM.Heap.Used, snapshot.JVM.Heap.Max), 24))
+	fmt.Fprintf(w, "Heap commit: %s\n", byteSize(snapshot.JVM.Heap.Committed))
+	fmt.Fprintf(w, "Threads    : %d current, %d peak, %d total started\n",
+		snapshot.JVM.Thread.ThreadCount,
+		snapshot.JVM.Thread.PeakThreadCount,
+		snapshot.JVM.Thread.TotalStartedThreadCount,
+	)
+}
+
+func Queues(w io.Writer, queues []monitor.QueueSnapshot) {
+	copied := append([]monitor.QueueSnapshot(nil), queues...)
+	sort.Slice(copied, func(i, j int) bool {
+		return copied[i].Destination < copied[j].Destination
+	})
+
+	fmt.Fprintln(w, "Queues")
+	fmt.Fprintln(w, "DESTINATION                              SIZE   CAP    STATE   PRESSURE")
+	for _, queue := range copied {
+		state := "run"
+		if queue.Paused {
+			state = "pause"
+		}
+		fmt.Fprintf(w, "%-40s %5d %5d  %-6s %s\n",
+			truncate(queue.Destination, 40),
+			queue.Size,
+			queue.Capacity,
+			state,
+			bar(ratio(int64(queue.Size), int64(queue.Capacity)), 18),
+		)
+	}
+}
+
+func percent(value float64) string {
+	if value < 0 {
+		return "unknown"
+	}
+	return fmt.Sprintf("%5.1f%%", value*100)
+}
+
+func ratio(used int64, max int64) float64 {
+	if max <= 0 {
+		return 0
+	}
+	return float64(used) / float64(max)
+}
+
+func bar(value float64, width int) string {
+	if value < 0 {
+		value = 0
+	}
+	if value > 1 {
+		value = 1
+	}
+	filled := int(value * float64(width))
+	return "[" + strings.Repeat("#", filled) + strings.Repeat(".", width-filled) + "]"
+}
+
+func byteSize(value int64) string {
+	if value < 0 {
+		return "unknown"
+	}
+	const unit = 1024
+	if value < unit {
+		return fmt.Sprintf("%dB", value)
+	}
+	div, exp := int64(unit), 0
+	for n := value / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%ciB", float64(value)/float64(div), "KMGTPE"[exp])
+}
+
+func truncate(value string, length int) string {
+	if len(value) <= length {
+		return value
+	}
+	if length <= 1 {
+		return value[:length]
+	}
+	return value[:length-1] + "~"
+}
+
+func valueOrUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/titan-cli/internal/render/render_test.go
+++ b/titan-cli/internal/render/render_test.go
@@ -1,0 +1,62 @@
+package render
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/traffic-hunter/titan/titan-cli/internal/monitor"
+)
+
+func TestStatusRendersCoreFields(t *testing.T) {
+	var out bytes.Buffer
+
+	Status(&out, fixture())
+
+	text := out.String()
+	for _, expected := range []string{"Titan 0.6.1", "CPU", "Heap", "Queues: 1 destinations"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected %q in output:\n%s", expected, text)
+		}
+	}
+}
+
+func TestQueuesRendersDestinationPressure(t *testing.T) {
+	var out bytes.Buffer
+
+	Queues(&out, fixture().Queues)
+
+	text := out.String()
+	for _, expected := range []string{"/queue/orders", "pause", "[#########.........]"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected %q in output:\n%s", expected, text)
+		}
+	}
+}
+
+func fixture() monitor.Snapshot {
+	return monitor.Snapshot{
+		Server: monitor.ServerSnapshot{
+			Version:      "0.6.1",
+			UptimeMillis: 123000,
+		},
+		JVM: monitor.JVMSnapshot{
+			CPU: monitor.CPUSnapshot{
+				SystemCPULoad:       0.25,
+				ProcessCPULoad:      0.10,
+				AvailableProcessors: 8,
+			},
+			Heap: monitor.HeapSnapshot{
+				Used: 512,
+				Max:  1024,
+			},
+			Thread: monitor.ThreadSnapshot{
+				ThreadCount:     4,
+				PeakThreadCount: 8,
+			},
+		},
+		Queues: []monitor.QueueSnapshot{
+			{Destination: "/queue/orders", Size: 5, Capacity: 10, Paused: true},
+		},
+	}
+}

--- a/titan-cli/main.go
+++ b/titan-cli/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/traffic-hunter/titan/titan-cli/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	os.Exit(cli.Run(os.Args[1:], os.Stdout, os.Stderr, version))
+}


### PR DESCRIPTION
## Motivation:

Add a first monitoring surface for the next release so Titan can expose JVM, server, and dispatcher queue state without introducing a web UI. The monitoring work was reintroduced through this branch after reverting the accidental direct push to main.

## Modification:

- Add a monitor runtime with Jetty HTTP endpoints for health and JSON snapshots.
- Register dispatcher queues through JMX and collect queue snapshots.
- Add a Go-based titan CLI for terminal status, watch, queues, and JVM views.
- Wire monitor configuration, Maven publication, CI, release packaging, and README usage notes.
- Apply JSpecify nullness annotations across the monitor module.

## Result:

Titan can expose local monitoring snapshots and consume them through the CLI. Validation: `GOCACHE=/private/tmp/titan-go-build-cache go test ./...`, `./gradlew --no-daemon build --stacktrace --no-configuration-cache`, `git diff --check`, workflow YAML parse.
