### PR TITLE
Add retry jitter

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
@@ -59,12 +59,8 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
     }
 
     @Override
-    public void bind(InetSocketAddress address) {
-        try {
-            channel().bind(address);
-        } catch (IOException e) {
-            setState(getState(), ChannelState.INIT);
-        }
+    public void bind(InetSocketAddress address) throws IOException {
+        channel().bind(address);
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/ExponentialRetryPolicy.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.resilience.retry;
 
 import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Retry policy that increases delay exponentially and caps it at a maximum delay.
@@ -42,13 +43,16 @@ public record ExponentialRetryPolicy(
         int maxAttempts,
         Duration initialDelay,
         Duration maxDelay,
-        int multiplier
+        int multiplier,
+        boolean jitter
 ) implements RetryPolicy {
 
     private static final int DEFAULT_MAX_ATTEMPTS = 3;
     private static final Duration DEFAULT_INITIAL_DELAY = Duration.ofSeconds(1);
     private static final Duration DEFAULT_MAX_DELAY = Duration.ofSeconds(30);
     private static final int DEFAULT_MULTIPLIER = 2;
+
+    private static final ThreadLocalRandom RANDOM = ThreadLocalRandom.current();
 
     public ExponentialRetryPolicy {
         RetryPolicy.validateMaxAttempts(maxAttempts);
@@ -68,6 +72,7 @@ public record ExponentialRetryPolicy(
         if (attempt < 1) {
             throw new IllegalArgumentException("attempt must be greater than zero");
         }
+
         Duration delay = initialDelay;
         for (int i = 1; i < attempt; i++) {
             delay = multiply(delay, multiplier);
@@ -75,11 +80,26 @@ public record ExponentialRetryPolicy(
                 return maxDelay;
             }
         }
+
+        if (jitter) {
+            return jitter(initialDelay, delay);
+        }
         return delay;
     }
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    private static Duration jitter(Duration initialDelay, Duration delay) {
+        long min = initialDelay.toMillis();
+        long max = delay.toMillis();
+        if (min >= max) {
+            return delay;
+        }
+
+        long jitter = RANDOM.nextLong(min, max + 1);
+        return Duration.ofMillis(jitter);
     }
 
     private static Duration multiply(Duration delay, int multiplier) {
@@ -99,6 +119,7 @@ public record ExponentialRetryPolicy(
         private Duration initialDelay = DEFAULT_INITIAL_DELAY;
         private Duration maxDelay = DEFAULT_MAX_DELAY;
         private int multiplier = DEFAULT_MULTIPLIER;
+        private boolean jitter = false;
 
         private Builder() {
         }
@@ -128,8 +149,13 @@ public record ExponentialRetryPolicy(
             return this;
         }
 
+        public Builder jitter(boolean jitter) {
+            this.jitter = jitter;
+            return this;
+        }
+
         public ExponentialRetryPolicy build() {
-            return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier);
+            return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier, jitter);
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/retry/RetryPolicy.java
@@ -64,6 +64,15 @@ public interface RetryPolicy {
         return new FixedRetryPolicy(maxAttempts, delay);
     }
 
+    static RetryPolicy exponentialWithJitter(
+            int maxAttempts,
+            Duration initialDelay,
+            Duration maxDelay,
+            int multiplier
+    ) {
+        return exponential(maxAttempts, initialDelay, maxDelay, multiplier, true);
+    }
+
     /**
      * Creates a policy that multiplies the previous delay until a maximum delay is reached.
      *
@@ -71,10 +80,17 @@ public interface RetryPolicy {
      * @param initialDelay delay used for attempt {@code 1}
      * @param maxDelay upper bound for calculated delays
      * @param multiplier multiplier applied between attempts
+     * @param jitter whether to add random jitter to delays
      * @return exponential retry policy
      */
-    static RetryPolicy exponential(int maxAttempts, Duration initialDelay, Duration maxDelay, int multiplier) {
-        return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier);
+    static RetryPolicy exponential(
+            int maxAttempts,
+            Duration initialDelay,
+            Duration maxDelay,
+            int multiplier,
+            boolean jitter
+    ) {
+        return new ExponentialRetryPolicy(maxAttempts, initialDelay, maxDelay, multiplier, jitter);
     }
 
     /**

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryPolicyTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/RetryPolicyTest.java
@@ -37,7 +37,8 @@ class RetryPolicyTest {
                 5,
                 Duration.ofMillis(100),
                 Duration.ofMillis(1_000),
-                2
+                2,
+                false
         );
 
         assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(100));
@@ -48,6 +49,22 @@ class RetryPolicyTest {
     }
 
     @Test
+    void exponential_policy_increases_delay_until_max_delay_with_jitter() {
+        RetryPolicy policy = RetryPolicy.exponentialWithJitter(
+                5,
+                Duration.ofMillis(100),
+                Duration.ofMillis(1_000),
+                2
+        );
+
+        assertThat(policy.delay(1)).isEqualTo(Duration.ofMillis(100));
+        assertThat(policy.delay(2)).isBetween(Duration.ofMillis(100), Duration.ofMillis(200));
+        assertThat(policy.delay(3)).isBetween(Duration.ofMillis(100), Duration.ofMillis(400));
+        assertThat(policy.delay(4)).isBetween(Duration.ofMillis(100), Duration.ofMillis(800));
+        assertThat(policy.delay(5)).isBetween(Duration.ofMillis(100), Duration.ofMillis(1_000));
+    }
+
+    @Test
     void policies_reject_invalid_values() {
         assertThatThrownBy(() -> RetryPolicy.fixed(0, Duration.ofMillis(100)))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -55,10 +72,10 @@ class RetryPolicyTest {
         assertThatThrownBy(() -> RetryPolicy.fixed(1, Duration.ZERO))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("delay");
-        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(50), 2))
+        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(50), 2, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("maxDelay");
-        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(100), 1))
+        assertThatThrownBy(() -> RetryPolicy.exponential(1, Duration.ofMillis(100), Duration.ofMillis(100), 1, false))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("multiplier");
         assertThatThrownBy(() -> RetryPolicy.fixed(1, Duration.ofMillis(100)).delay(0))

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
@@ -25,12 +25,14 @@ package org.traffichunter.titan.core.test.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.*;
@@ -54,11 +56,12 @@ public class ClientToServerTest {
 
     private final DispatcherQueue rq = DispatcherQueue.create(Destination.create("/route/test"), 1001);
     private InetServer server;
+    private int port;
 
     private static final Logger log = LoggerFactory.getLogger(ClientToServerTest.class);
 
     @BeforeEach
-    void setUp() throws InterruptedException {
+    void setUp() throws Exception {
         server = InetServer.open(EventLoopGroups.group(1))
                 .option(InetServerOption.builder().build())
                 .onChannel(ctx -> ctx.chain()
@@ -67,13 +70,10 @@ public class ClientToServerTest {
 
         server.start();
 
-        server.listen("localhost", 7777).addListener(future -> {
-            if(future.isSuccess()) {
-                log.info("Server started successfully");
-            }
-        });
-
-        Thread.sleep(100);
+        server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+        InetSocketAddress localAddress = (InetSocketAddress) server.localAddress();
+        port = localAddress.getPort();
+        log.info("Server started successfully. port={}", port);
     }
 
     @AfterEach
@@ -90,7 +90,7 @@ public class ClientToServerTest {
                 .onChannel(channel -> channel.chain());
 
         client.start();
-        client.connect("localhost", 7777).get();
+        client.connect("localhost", port).get();
 
         client.send(Buffer.alloc("hello\n".getBytes(StandardCharsets.UTF_8))).addListener(future -> {
             if(future.isSuccess()) {
@@ -115,7 +115,7 @@ public class ClientToServerTest {
                 .onChannel(channel -> channel.chain());
 
         client.start();
-        client.connect("localhost", 7777).get();
+        client.connect("localhost", port).get();
 
         for (int i = 0; i < count; i++) {
             es.execute(() -> {

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -253,6 +253,8 @@ public final class TitanProperties {
 
         private int multiplier = 2;
 
+        private boolean jitter = false;
+
         public boolean isEnabled() {
             return enabled;
         }
@@ -301,10 +303,18 @@ public final class TitanProperties {
             this.multiplier = multiplier;
         }
 
+        public boolean isJitter() {
+            return jitter;
+        }
+
+        public void setJitter(boolean jitter) {
+            this.jitter = jitter;
+        }
+
         public RetryPolicy toPolicy() {
             return switch (type) {
                 case FIX -> RetryPolicy.fixed(maxAttempts, delay);
-                case EXP -> RetryPolicy.exponential(maxAttempts, delay, maxDelay, multiplier);
+                case EXP -> RetryPolicy.exponential(maxAttempts, delay, maxDelay, multiplier, jitter);
             };
         }
 


### PR DESCRIPTION
## Motivation:

Retry policies need a way to spread repeated retry attempts so callers do not all retry on the exact same schedule. While preparing this, the core client/server integration test also exposed a fixed-port assumption that can fail when a local Titan server is already running.

## Modification:

Add jitter support to the exponential retry policy and expose an exponential-with-jitter factory. Extend retry policy tests to cover jitter bounds. Make the core client/server integration test bind to an available port, and let server bind failures propagate instead of being swallowed.

## Result:

Core retry policy can now opt into jittered exponential delays. The core client/server test no longer collides with a local process on port 7777.

Validation: ./gradlew :core:test --no-configuration-cache