### PR TITLE
Add monitor queue management

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ go run . --addr http://localhost:7777
 go run . --addr http://localhost:7777 --view queues
 go run . --addr http://localhost:7777 --view jvm --interval 1s --timeout 3s
 go run . --addr http://localhost:7777 --no-color --once
+
+# queue management
+export TITAN_MONITOR_TOKEN=<monitor-token>
+go run . --addr http://localhost:7777 queue list
+go run . --addr http://localhost:7777 queue create /queue/orders --capacity 100
+go run . --addr http://localhost:7777 queue delete /queue/orders
+go run . --addr http://localhost:7777 queue delete /queue/orders --force
 ```
 
 The monitor HTTP API is served under `/titan`.
@@ -134,6 +141,7 @@ The monitor HTTP API is served under `/titan`.
 ```bash
 curl http://localhost:7777/titan/monitor/health
 curl http://localhost:7777/titan/monitor/snapshot
+curl http://localhost:7777/titan/monitor/queues
 ```
 
 ## Examples

--- a/bootstrap/src/main/resources/logback.xml
+++ b/bootstrap/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="TITAN_LOG_LEVEL" value="${TITAN_LOG_LEVEL:-INFO}"/>
+    <property name="TITAN_JETTY_LOG_LEVEL" value="${TITAN_JETTY_LOG_LEVEL:-INFO}"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty" level="${TITAN_JETTY_LOG_LEVEL}"/>
+
+    <root level="${TITAN_LOG_LEVEL}">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/Dispatcher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/Dispatcher.java
@@ -56,6 +56,15 @@ public interface Dispatcher {
     @CanIgnoreReturnValue
     DispatcherQueue getOrPut(Destination destination);
 
+    /**
+     * Returns the existing queue or creates one with the requested capacity.
+     *
+     * <p>If the queue already exists, implementations should return it without
+     * changing its capacity.</p>
+     */
+    @CanIgnoreReturnValue
+    DispatcherQueue getOrPut(Destination destination, int capacity);
+
     boolean exists(Destination destination);
 
     void remove(Destination destination);

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueue.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueue.java
@@ -45,6 +45,8 @@ import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
  */
 public interface DispatcherQueue extends Pausable, Iterator<Message>, DispatcherQueueMbean {
 
+    int DEFAULT_CAPACITY = 11;
+
     static DispatcherQueue create(Destination key) {
         DispatcherQueue queue = new MessageDispatcherQueue(key);
         DispatcherQueueMbeans.register(queue);
@@ -84,7 +86,13 @@ public interface DispatcherQueue extends Pausable, Iterator<Message>, Dispatcher
      */
     Message dispatch() throws InterruptedException;
 
-    Message dispatch(long timeout, TimeUnit unit) throws InterruptedException;
+    /**
+     * Waits for a message until the timeout expires.
+     *
+     * @return a message, or {@code null} when no message is available before
+     * the timeout
+     */
+    @Nullable Message dispatch(long timeout, TimeUnit unit) throws InterruptedException;
 
     void remove(Message message);
 

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueDeleteResult.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueDeleteResult.java
@@ -1,0 +1,40 @@
+package org.traffichunter.titan.core.message.dispatcher;
+
+/**
+ * Result of an operational dispatcher queue deletion request.
+ *
+ * @param status deletion outcome
+ * @param size queue size observed when the deletion request was evaluated
+ * @author yungwang-o
+ */
+public record DispatcherQueueDeleteResult(
+        Status status,
+        int size
+) {
+
+    /**
+     * Deletion status values used by management APIs to map domain outcomes to
+     * transport-specific responses.
+     */
+    public enum Status {
+        /**
+         * The queue was removed.
+         */
+        DELETED,
+        /**
+         * No queue exists for the requested destination.
+         */
+        NOT_FOUND,
+        /**
+         * The queue still contains messages and force deletion was not allowed.
+         */
+        NOT_EMPTY
+    }
+
+    /**
+     * Returns whether the deletion request removed a queue.
+     */
+    public boolean isDeleted() {
+        return status == Status.DELETED;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueManager.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueManager.java
@@ -1,0 +1,43 @@
+package org.traffichunter.titan.core.message.dispatcher;
+
+import org.traffichunter.titan.core.util.Destination;
+
+/**
+ * Management boundary for dispatcher queues owned by a running transport or
+ * fanout component.
+ *
+ * <p>This interface is intentionally narrower than {@link Dispatcher}. It is
+ * used by operational surfaces, such as the monitor HTTP API, when they need to
+ * create or remove queues without depending on the concrete fanout
+ * implementation.</p>
+ *
+ * @author yungwang-o
+ */
+public interface DispatcherQueueManager {
+
+    /**
+     * Creates the queue for the destination if it does not exist.
+     *
+     * <p>Implementations should be idempotent. When the queue already exists,
+     * they should return the existing queue and leave its original capacity
+     * unchanged.</p>
+     *
+     * @param destination destination to register
+     * @param capacity requested capacity for a newly created queue
+     * @return existing or newly created queue
+     */
+    DispatcherQueue createQueue(Destination destination, int capacity);
+
+    /**
+     * Deletes the queue for the destination.
+     *
+     * <p>When {@code force} is {@code false}, implementations should reject
+     * deletion of non-empty queues. When {@code force} is {@code true}, queued
+     * messages may be dropped before the queue is removed.</p>
+     *
+     * @param destination destination to remove
+     * @param force whether queued messages may be dropped
+     * @return deletion outcome
+     */
+    DispatcherQueueDeleteResult deleteQueue(Destination destination, boolean force);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueManagers.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/DispatcherQueueManagers.java
@@ -1,0 +1,65 @@
+package org.traffichunter.titan.core.message.dispatcher;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Process-local registry of dispatcher queue managers.
+ *
+ * <p>Fanout adapters register their running gateway under the managed server
+ * name. Runtime extensions, such as the monitor module, can then resolve a
+ * manager without taking a compile-time dependency on the fanout module.</p>
+ *
+ * @author yungwang-o
+ */
+public final class DispatcherQueueManagers {
+
+    private static final Map<String, DispatcherQueueManager> MANAGERS = new ConcurrentHashMap<>();
+
+    /**
+     * Registers or replaces the queue manager for a managed server name.
+     */
+    public static void register(String name, DispatcherQueueManager manager) {
+        MANAGERS.put(name, manager);
+    }
+
+    /**
+     * Removes the queue manager for a managed server name.
+     */
+    public static void unregister(String name) {
+        MANAGERS.remove(name);
+    }
+
+    /**
+     * Returns the queue manager for a managed server name, or {@code null} when
+     * no manager has been registered.
+     */
+    public static @Nullable DispatcherQueueManager get(String name) {
+        return MANAGERS.get(name);
+    }
+
+    /**
+     * Returns the only registered queue manager.
+     *
+     * <p>When zero or multiple managers exist, callers must provide an explicit
+     * server name and this method returns {@code null}.</p>
+     */
+    public static @Nullable DispatcherQueueManager getDefault() {
+        if (MANAGERS.size() != 1) {
+            return null;
+        }
+        return MANAGERS.values().iterator().next();
+    }
+
+    /**
+     * Returns registered managed server names in stable order.
+     */
+    public static List<String> names() {
+        return MANAGERS.keySet().stream().sorted().toList();
+    }
+
+    private DispatcherQueueManagers() {
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MapDispatcher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MapDispatcher.java
@@ -26,14 +26,10 @@ package org.traffichunter.titan.core.message.dispatcher;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.traffichunter.titan.core.channel.NetChannel;
-import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
  * Hash-map dispatcher implementation.
@@ -64,7 +60,12 @@ public class MapDispatcher implements Dispatcher {
 
     @Override
     public DispatcherQueue getOrPut(final Destination destination) {
-        return map.putIfAbsent(destination, DispatcherQueue.create(destination));
+        return map.computeIfAbsent(destination, DispatcherQueue::create);
+    }
+
+    @Override
+    public DispatcherQueue getOrPut(final Destination destination, int capacity) {
+        return map.computeIfAbsent(destination, key -> DispatcherQueue.create(key, capacity));
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueue.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueue.java
@@ -58,7 +58,7 @@ class MessageDispatcherQueue implements DispatcherQueue {
      * {@link PriorityBlockingQueue} default capacity 11
      */
     MessageDispatcherQueue(final Destination destination) {
-        this(destination, 11);
+        this(destination, DEFAULT_CAPACITY);
     }
 
     MessageDispatcherQueue(final Destination destination, final int capacity) {

--- a/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/TrieDispatcher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/dispatcher/TrieDispatcher.java
@@ -48,10 +48,15 @@ public class TrieDispatcher implements Dispatcher {
     }
 
     @Override
-    public @Nullable DispatcherQueue getOrPut(final Destination destination) {
+    public DispatcherQueue getOrPut(final Destination destination) {
+        return getOrPut(destination, DispatcherQueue.DEFAULT_CAPACITY);
+    }
+
+    @Override
+    public DispatcherQueue getOrPut(final Destination destination, int capacity) {
         DispatcherQueue v = trie.get(destination.path());
         if (v == null) {
-            v = trie.insert(destination.path(), DispatcherQueue.create(destination));
+            v = trie.insert(destination.path(), DispatcherQueue.create(destination, capacity));
             log.info("Created new dispatcher for path {}", destination.path());
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbeans.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/mbeans/DispatcherQueueMbeans.java
@@ -6,6 +6,16 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.StandardMBean;
 
+/**
+ * Utility for exposing dispatcher queues through the platform MBean server.
+ *
+ * <p>Queue object names are derived from the destination path and use
+ * {@link ObjectName#quote(String)} so STOMP-style paths can be represented
+ * safely in JMX. Registration replaces an existing queue MBean for the same
+ * destination, while unregistration is tolerant when no MBean is present.</p>
+ *
+ * @author yun
+ */
 public final class DispatcherQueueMbeans {
 
     public static final String DOMAIN = "org.traffichunter.titan";
@@ -34,6 +44,21 @@ public final class DispatcherQueueMbeans {
             return name;
         } catch (JMException e) {
             throw new IllegalStateException("Failed to register dispatcher queue MBean: " + name, e);
+        }
+    }
+
+    public static void unregister(String destination) {
+        unregister(ManagementFactory.getPlatformMBeanServer(), destination);
+    }
+
+    public static void unregister(MBeanServer server, String destination) {
+        ObjectName name = objectName(destination);
+        try {
+            if (server.isRegistered(name)) {
+                server.unregisterMBean(name);
+            }
+        } catch (JMException e) {
+            throw new IllegalStateException("Failed to unregister dispatcher queue MBean: " + name, e);
         }
     }
 

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/DispatcherQueueManagementTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/DispatcherQueueManagementTest.java
@@ -1,0 +1,53 @@
+package org.traffichunter.titan.core.test.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
+import org.traffichunter.titan.core.message.dispatcher.MapDispatcher;
+import org.traffichunter.titan.core.message.dispatcher.TrieDispatcher;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
+
+class DispatcherQueueManagementTest {
+
+    @Test
+    void map_dispatcher_returns_created_queue_with_requested_capacity() {
+        Dispatcher dispatcher = new MapDispatcher(1);
+        Destination destination = Destination.create("/queue/orders");
+
+        DispatcherQueue queue = dispatcher.getOrPut(destination, 32);
+
+        assertThat(queue).isNotNull();
+        assertThat(queue.capacity()).isEqualTo(32);
+        assertThat(dispatcher.get(destination)).isSameAs(queue);
+    }
+
+    @Test
+    void trie_dispatcher_returns_created_queue_with_requested_capacity() {
+        Dispatcher dispatcher = new TrieDispatcher();
+        Destination destination = Destination.create("/queue/payments");
+
+        DispatcherQueue queue = dispatcher.getOrPut(destination, 64);
+
+        assertThat(queue).isNotNull();
+        assertThat(queue.capacity()).isEqualTo(64);
+        assertThat(dispatcher.get(destination)).isSameAs(queue);
+    }
+
+    @Test
+    void dispatcher_queue_mbean_can_be_unregistered() throws Exception {
+        Destination destination = Destination.create("/queue/mbean-test");
+        DispatcherQueue queue = DispatcherQueue.create(destination, 10);
+        ObjectName name = DispatcherQueueMbeans.objectName(destination.path());
+
+        assertThat(ManagementFactory.getPlatformMBeanServer().isRegistered(name)).isTrue();
+
+        DispatcherQueueMbeans.unregister(queue.getDestination());
+
+        assertThat(ManagementFactory.getPlatformMBeanServer().isRegistered(name)).isFalse();
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
@@ -29,19 +29,23 @@ import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueDeleteResult;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.concurrent.Damper;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.concurrent.NoopDamper;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -71,12 +75,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * <p>The optional {@link Damper} is a small back-pressure hook for executor
  * implementations that can create many concurrent tasks. The virtual-thread
  * gateway uses it to cap active fanout dispatch work.</p>
+ *
+ * @author yun
  */
 abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractExecutorFanoutGateway.class);
 
     private final Map<Destination, Future<?>> consumers = new ConcurrentHashMap<>();
+    private final Set<DispatcherQueue> deletedQueues = ConcurrentHashMap.newKeySet();
 
     private final ExecutorService executor;
     private final FanoutExporter exporter;
@@ -98,14 +105,14 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
             Dispatcher dispatcher,
             Damper damper
     ) {
-        this.executor = Assert.checkNotNull(executor, "executor");
-        this.exporter = Assert.checkNotNull(exporter, "exporter");
-        this.dispatcher = Assert.checkNotNull(dispatcher, "dispatcher");
-        this.damper = Assert.checkNotNull(damper, "damper");
+        this.executor = executor;
+        this.exporter = exporter;
+        this.dispatcher = dispatcher;
+        this.damper = damper;
     }
 
     @Override
-    public List<Future<Void>> fanout(Collection<Destination> destinations) {
+    public List<Future<@Nullable Void>> fanout(Collection<Destination> destinations) {
         Assert.checkNotNull(destinations, "destinations");
 
         if (isClosed.get()) {
@@ -119,18 +126,18 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Future<Void> fanout(Destination destination) {
+    public Future<@Nullable Void> fanout(Destination destination) {
         Assert.checkNotNull(destination, "destination");
 
         if (isClosed.get()) {
             throw new IllegalStateException("FanoutGateway is closed");
         }
 
-        return (Future<Void>) consumers.computeIfAbsent(destination, this::consume);
+        return (Future<@Nullable Void>) consumers.computeIfAbsent(destination, this::consume);
     }
 
     @Override
-    public List<Future<Void>> publish(Collection<Message> messages) {
+    public List<Future<@Nullable Void>> publish(Collection<Message> messages) {
         Assert.checkNotNull(messages, "messages");
 
         if (isClosed.get()) {
@@ -143,7 +150,7 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
     }
 
     @Override
-    public Future<Void> publish(Message message) {
+    public Future<@Nullable Void> publish(Message message) {
         Assert.checkNotNull(message, "message");
 
         if (isClosed.get()) {
@@ -177,16 +184,77 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
         }
     }
 
-    protected CompletableFuture<Void> consume(Destination destination) {
+    /**
+     * Creates a dispatcher queue through the gateway-owned dispatcher.
+     *
+     * <p>Queue creation is idempotent. If the queue already exists, the
+     * existing instance is returned and the supplied capacity is ignored.</p>
+     */
+    @Override
+    public DispatcherQueue createQueue(Destination destination, int capacity) {
+        if (isClosed.get()) {
+            throw new IllegalStateException("FanoutGateway is closed");
+        }
+
+        return dispatcher.getOrPut(destination, capacity);
+    }
+
+    /**
+     * Deletes a dispatcher queue and detaches its consumer.
+     *
+     * <p>Deletion removes the queue from the dispatcher, unregisters its JMX
+     * MBean, and marks the current queue instance as deleted so a running
+     * consumer can exit. Non-empty queues are rejected unless force deletion is
+     * requested.</p>
+     */
+    @Override
+    public DispatcherQueueDeleteResult deleteQueue(Destination destination, boolean force) {
+        DispatcherQueue queue = dispatcher.get(destination);
+        if (queue == null) {
+            return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.NOT_FOUND, 0);
+        }
+        int size = queue.size();
+        if (size > 0 && !force) {
+            return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.NOT_EMPTY, size);
+        }
+        if (force) {
+            queue.clear();
+        }
+
+        deletedQueues.add(queue);
+        Future<?> consumer = consumers.remove(destination);
+        if (consumer != null) {
+            consumer.cancel(true);
+        }
+        dispatcher.remove(destination);
+        DispatcherQueueMbeans.unregister(queue.getDestination());
+        return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.DELETED, size);
+    }
+
+    /**
+     * Runs one destination consumer.
+     *
+     * <p>The loop polls with a timeout instead of blocking indefinitely so it
+     * can observe queue deletion and shutdown state. The returned future uses
+     * {@code @Nullable Void} because successful completion is represented by a
+     * {@code null} value.</p>
+     */
+    protected CompletableFuture<@Nullable Void> consume(Destination destination) {
         DispatcherQueue dispatcherQueue = dispatcher.getOrPut(destination);
         log.info("Starting fanout consumer for destination={}", destination.path());
 
-        return CompletableFuture.runAsync(() -> {
+        CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
+        executor.execute(() -> {
             try {
-                while (!isClosed() && !Thread.currentThread().isInterrupted()) {
+                while (!isClosed()
+                        && !Thread.currentThread().isInterrupted()
+                        && !deletedQueues.contains(dispatcherQueue)) {
                     damper.acquire();
                     try {
-                        Message message = dispatcherQueue.dispatch();
+                        Message message = dispatcherQueue.dispatch(1, TimeUnit.SECONDS);
+                        if (message == null) {
+                            continue;
+                        }
 
                         exporter.export(destination, message);
                     } catch (InterruptedException e) {
@@ -202,10 +270,15 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
                         damper.release();
                     }
                 }
+                result.complete(null);
+            } catch (Exception e) {
+                result.completeExceptionally(e);
             } finally {
-                consumers.remove(destination);
+                deletedQueues.remove(dispatcherQueue);
+                consumers.remove(destination, result);
             }
-        }, executor);
+        });
+        return result;
     }
 
     protected @Nullable Message route(Message message) {

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
@@ -31,6 +31,8 @@ import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManager;
 
 /**
  * Asynchronous ingress and routing facade for fanout delivery.
@@ -48,8 +50,10 @@ import java.util.concurrent.Future;
  * matching destination consumer exists. The returned futures represent gateway
  * task submission, not necessarily remote protocol acknowledgement for every
  * subscribed client.</p>
+ *
+ * @author yungwang-o
  */
-public interface FanoutGateway extends Closeable {
+public interface FanoutGateway extends Closeable, DispatcherQueueManager {
 
     static FanoutGateway ofThread(FanoutExporter exporter) {
         return new ThreadPoolExecutorFanoutGateway(exporter);
@@ -59,13 +63,37 @@ public interface FanoutGateway extends Closeable {
         return new VirtualThreadExecutorFanoutGateway(exporter);
     }
 
-    List<Future<Void>> fanout(Collection<Destination> destinations);
+    /**
+     * Starts consumers for the destinations if they are not already running.
+     *
+     * <p>The returned futures complete with {@code null}; the value is only a
+     * completion signal.</p>
+     */
+    List<Future<@Nullable Void>> fanout(Collection<Destination> destinations);
 
-    Future<Void> fanout(Destination destination);
+    /**
+     * Starts the consumer for a destination if it is not already running.
+     *
+     * <p>The returned future completes with {@code null}; the value is only a
+     * completion signal.</p>
+     */
+    Future<@Nullable Void> fanout(Destination destination);
 
-    List<Future<Void>> publish(Collection<Message> messages);
+    /**
+     * Publishes messages into destination queues.
+     *
+     * <p>The returned futures represent enqueue and consumer-start submission,
+     * not delivery acknowledgement from subscribed clients.</p>
+     */
+    List<Future<@Nullable Void>> publish(Collection<Message> messages);
 
-    Future<Void> publish(Message message);
+    /**
+     * Publishes one message into its destination queue.
+     *
+     * <p>The returned future completes with {@code null}; the value is only a
+     * completion signal.</p>
+     */
+    Future<@Nullable Void> publish(Message message);
 
     boolean isOpen();
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ThreadFactory;
  *
  * <p>This mode is useful when fanout work should be bounded by a small number
  * of OS threads. It limits executor parallelism directly through the pool size.</p>
+ *
+ * @author yun
  */
 class ThreadPoolExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.fanout;
 import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.StompManagedServer;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManagers;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 import org.traffichunter.titan.fanout.exporter.StompFanoutExporter;
 
@@ -34,6 +35,8 @@ import java.util.function.Function;
 
 /**
  * Fanout adapter for Titan's own STOMP managed server.
+ *
+ * @author yun
  */
 @Slf4j
 public final class TitanStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
@@ -61,6 +64,7 @@ public final class TitanStompManagedServerFanoutAdapter implements ManagedServer
         FanoutGateway fanoutGateway = gatewayFactory.apply(
                 new StompFanoutExporter(stompManagedServer.server().connection())
         );
+        DispatcherQueueManagers.register(managedServer.name(), fanoutGateway);
 
         stompManagedServer.server().onStomp(handler ->
                 handler.sendHandler(new StompSendToFanoutHandler(fanoutGateway))

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManagers;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.vertx.VertxStompManagedServer;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
@@ -34,6 +35,8 @@ import java.util.function.Function;
 
 /**
  * Fanout adapter for Vert.x's native STOMP managed server.
+ *
+ * @author yun
  */
 @Slf4j
 public final class VertxStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
@@ -62,6 +65,7 @@ public final class VertxStompManagedServerFanoutAdapter implements ManagedServer
         FanoutGateway fanoutGateway = gatewayFactory.apply(
                 new VertxStompFanoutExporter(vertxStompManagedServer.server())
         );
+        DispatcherQueueManagers.register(managedServer.name(), fanoutGateway);
 
         vertxStompManagedServer.server().stompHandler()
                 .sendHandler(new VertxStompSendToFanoutHandler(fanoutGateway));

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ThreadFactory;
  * waiting for dispatcher queues. Virtual threads make that blocking cheap, while
  * the internal damper still caps active dispatch sections so exporter work does
  * not grow without a limit.</p>
+ *
+ * @author yun
  */
 class VirtualThreadExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
 

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/FanoutGatewayQueueManagementTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/FanoutGatewayQueueManagementTest.java
@@ -1,0 +1,84 @@
+package org.traffichunter.titan.fanout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueDeleteResult;
+import org.traffichunter.titan.core.message.dispatcher.TrieDispatcher;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
+
+class FanoutGatewayQueueManagementTest {
+
+    @Test
+    void delete_queue_rejects_non_empty_queue_without_force() {
+        TrieDispatcher dispatcher = new TrieDispatcher();
+        ThreadPoolExecutorFanoutGateway gateway = new ThreadPoolExecutorFanoutGateway(
+                noopExporter(),
+                dispatcher
+        );
+        Destination destination = Destination.create("/queue/delete-safe");
+        gateway.createQueue(destination, 10).enqueue(message(destination));
+
+        DispatcherQueueDeleteResult result = gateway.deleteQueue(destination, false);
+
+        assertThat(result.status()).isEqualTo(DispatcherQueueDeleteResult.Status.NOT_EMPTY);
+        assertThat(dispatcher.get(destination)).isNotNull();
+
+        gateway.close();
+    }
+
+    @Test
+    void delete_queue_with_force_removes_queue_and_allows_auto_create_later() throws Exception {
+        TrieDispatcher dispatcher = new TrieDispatcher();
+        ThreadPoolExecutorFanoutGateway gateway = new ThreadPoolExecutorFanoutGateway(
+                noopExporter(),
+                dispatcher
+        );
+        Destination destination = Destination.create("/queue/delete-force");
+        DispatcherQueue first = gateway.createQueue(destination, 10);
+        first.enqueue(message(destination));
+
+        DispatcherQueueDeleteResult result = gateway.deleteQueue(destination, true);
+
+        assertThat(result.isDeleted()).isTrue();
+        assertThat(dispatcher.get(destination)).isNull();
+
+        gateway.publish(message(destination)).get();
+
+        assertThat(dispatcher.get(destination)).isNotNull();
+        assertThat(dispatcher.get(destination)).isNotSameAs(first);
+
+        gateway.close();
+    }
+
+    private static FanoutExporter noopExporter() {
+        return new FanoutExporter() {
+            @Override
+            public String name() {
+                return "noop";
+            }
+
+            @Override
+            public AggregationResult export(Destination destination, Buffer payload) {
+                return AggregationResult.completed(List.of(destination), 0, 0, 0);
+            }
+        };
+    }
+
+    private static Message message(Destination destination) {
+        return Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(destination)
+                .createdAt(Instant.now())
+                .producerId("test")
+                .body(Buffer.alloc("test".getBytes()))
+                .build();
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringAuthorization.java
@@ -2,6 +2,9 @@ package org.traffichunter.titan.monitor.http;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+/**
+ * @author yun
+ */
 public final class MonitoringAuthorization {
 
     private final String token;
@@ -11,10 +14,10 @@ public final class MonitoringAuthorization {
     }
 
     public boolean required() {
-        return token != null && !token.isBlank();
+        return !token.isBlank();
     }
 
-    public boolean allows(HttpServletRequest request) {
+    public boolean permit(HttpServletRequest request) {
         if (!required()) {
             return true;
         }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHealthServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHealthServlet.java
@@ -6,6 +6,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.traffichunter.titan.core.httpserver.ContentType;
 
+/**
+ * @author yun
+ */
 public final class MonitoringHealthServlet extends HttpServlet {
 
     private final MonitoringAuthorization authorization;
@@ -16,7 +19,7 @@ public final class MonitoringHealthServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        if (!authorization.allows(request)) {
+        if (!authorization.permit(request)) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringHttpServer.java
@@ -8,10 +8,14 @@ import org.traffichunter.titan.core.httpserver.jetty.EmbeddedJettyHttpServer;
 import org.traffichunter.titan.core.httpserver.threadpool.JettyThreadPool;
 import org.traffichunter.titan.monitor.MonitoringSnapshotService;
 
+/**
+ * @author yun
+ */
 public final class MonitoringHttpServer implements HttpServer {
 
     public static final String SNAPSHOT_PATH = "/monitor/snapshot";
     public static final String HEALTH_PATH = "/monitor/health";
+    public static final String QUEUES_PATH = "/monitor/queues";
     public static final String DEFAULT_HOST = "127.0.0.1";
     public static final int DEFAULT_PORT = 7777;
 
@@ -32,6 +36,7 @@ public final class MonitoringHttpServer implements HttpServer {
                 .contextHandler(0)
                 .addContextServlet(servlet(new MonitoringSnapshotServlet(builder.service, authorization), SNAPSHOT_PATH))
                 .addContextServlet(servlet(new MonitoringHealthServlet(authorization), HEALTH_PATH))
+                .addContextServlet(servlet(new MonitoringQueueServlet(builder.service, authorization), QUEUES_PATH))
                 .gracefulShutdown(true)
                 .build();
     }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringQueueServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringQueueServlet.java
@@ -1,0 +1,188 @@
+package org.traffichunter.titan.monitor.http;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.codec.json.Json;
+import org.traffichunter.titan.core.httpserver.ContentType;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueDeleteResult;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManager;
+import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManagers;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.monitor.MonitoringSnapshotService;
+import org.traffichunter.titan.monitor.model.QueueSnapshot;
+
+/**
+ * HTTP endpoint for dispatcher queue inspection and management.
+ *
+ * <p>Read operations follow the monitor authorization policy. Mutating
+ * operations are stricter: they require a configured monitor token and a valid
+ * bearer token on the request. This prevents queue deletion from being exposed
+ * accidentally when the monitor server is started without authentication for
+ * local development.</p>
+ *
+ * @author yungwang-o
+ */
+public final class MonitoringQueueServlet extends HttpServlet {
+
+    private final MonitoringSnapshotService service;
+    private final MonitoringAuthorization authorization;
+
+    public MonitoringQueueServlet(MonitoringSnapshotService service, MonitoringAuthorization authorization) {
+        this.service = service;
+        this.authorization = authorization;
+    }
+
+    /**
+     * Returns queue snapshots collected from JMX.
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!authorization.permit(request)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        writeJson(response, HttpServletResponse.SC_OK, service.snapshot().queues());
+    }
+
+    /**
+     * Creates a queue through the registered runtime queue manager.
+     *
+     * <p>Creation is idempotent. If the destination is already registered, the
+     * existing queue is returned.</p>
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!allowsManagement(request, response)) {
+            return;
+        }
+
+        DispatcherQueueManager manager = manager(request, response);
+        if (manager == null) {
+            return;
+        }
+        Destination destination = destination(request, response);
+        if (destination == null) {
+            return;
+        }
+        int capacity = capacity(request, response);
+        if (capacity <= 0) {
+            return;
+        }
+
+        DispatcherQueue queue = manager.createQueue(destination, capacity);
+        writeJson(response, HttpServletResponse.SC_OK, snapshot(queue));
+    }
+
+    /**
+     * Deletes a queue through the registered runtime queue manager.
+     *
+     * <p>Non-empty queues return {@code 409 Conflict} unless the request uses
+     * {@code force=true}.</p>
+     */
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (!allowsManagement(request, response)) {
+            return;
+        }
+
+        DispatcherQueueManager manager = manager(request, response);
+        if (manager == null) {
+            return;
+        }
+        Destination destination = destination(request, response);
+        if (destination == null) {
+            return;
+        }
+
+        DispatcherQueueDeleteResult result = manager.deleteQueue(destination, force(request));
+        switch (result.status()) {
+            case DELETED -> writeJson(response, HttpServletResponse.SC_OK, new DeleteResponse("deleted", result.size()));
+            case NOT_FOUND -> writeJson(response, HttpServletResponse.SC_NOT_FOUND, new ErrorResponse("queue not found"));
+            case NOT_EMPTY -> writeJson(response, HttpServletResponse.SC_CONFLICT, new ErrorResponse("queue is not empty"));
+        }
+    }
+
+    private boolean allowsManagement(HttpServletRequest request, HttpServletResponse response) {
+        if (!authorization.required()) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return false;
+        }
+        if (!authorization.permit(request)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return false;
+        }
+        return true;
+    }
+
+    private @Nullable DispatcherQueueManager manager(HttpServletRequest request, HttpServletResponse response) {
+        String server = request.getParameter("server");
+        DispatcherQueueManager manager = server == null || server.isBlank()
+                ? DispatcherQueueManagers.getDefault()
+                : DispatcherQueueManagers.get(server);
+        if (manager == null) {
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            return null;
+        }
+        return manager;
+    }
+
+    private @Nullable Destination destination(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String raw = request.getParameter("destination");
+        if (raw == null || raw.isBlank()) {
+            writeJson(response, HttpServletResponse.SC_BAD_REQUEST, new ErrorResponse("destination is required"));
+            return null;
+        }
+        try {
+            return Destination.create(raw);
+        } catch (IllegalArgumentException e) {
+            writeJson(response, HttpServletResponse.SC_BAD_REQUEST, new ErrorResponse(e.getMessage()));
+            return null;
+        }
+    }
+
+    private int capacity(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String raw = request.getParameter("capacity");
+        if (raw == null || raw.isBlank()) {
+            return DispatcherQueue.DEFAULT_CAPACITY;
+        }
+        try {
+            int capacity = Integer.parseInt(raw);
+            if (capacity > 0) {
+                return capacity;
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        writeJson(response, HttpServletResponse.SC_BAD_REQUEST, new ErrorResponse("capacity must be greater than zero"));
+        return -1;
+    }
+
+    private static boolean force(HttpServletRequest request) {
+        return Boolean.parseBoolean(request.getParameter("force"));
+    }
+
+    private static QueueSnapshot snapshot(DispatcherQueue queue) {
+        return new QueueSnapshot(queue.getDestination(), queue.size(), queue.capacity(), queue.isPaused());
+    }
+
+    private static void writeJson(HttpServletResponse response, int status, Object body) throws IOException {
+        String json = Json.serialize(body);
+        if (json == null) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+        response.setStatus(status);
+        response.setContentType(ContentType.APPLICATION_JSON);
+        response.getWriter().write(json);
+    }
+
+    private record DeleteResponse(String status, int size) {
+    }
+
+    private record ErrorResponse(String error) {
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringSnapshotServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringSnapshotServlet.java
@@ -8,6 +8,9 @@ import org.traffichunter.titan.core.codec.json.Json;
 import org.traffichunter.titan.core.httpserver.ContentType;
 import org.traffichunter.titan.monitor.MonitoringSnapshotService;
 
+/**
+ * @author yun
+ */
 public final class MonitoringSnapshotServlet extends HttpServlet {
 
     private final MonitoringSnapshotService service;
@@ -20,7 +23,7 @@ public final class MonitoringSnapshotServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        if (!authorization.allows(request)) {
+        if (!authorization.permit(request)) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
@@ -6,11 +6,21 @@ import static org.awaitility.Awaitility.await;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+
+import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.message.dispatcher.*;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.mbeans.DispatcherQueueMbeans;
 import org.traffichunter.titan.monitor.MonitoringSnapshotService;
 
 class MonitoringHttpServerTest {
@@ -101,6 +111,168 @@ class MonitoringHttpServerTest {
         }
     }
 
+    @Test
+    void rejects_queue_mutation_when_token_is_not_configured() throws Exception {
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-queue-no-token-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> response = client.send(
+                        postQueue(port, "/queue/no-token", null),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(response.statusCode()).isEqualTo(403);
+            });
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void rejects_queue_mutation_without_bearer_token() throws Exception {
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-queue-auth-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> response = client.send(
+                        postQueue(port, "/queue/missing-token", null),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(response.statusCode()).isEqualTo(401);
+            });
+        } finally {
+            server.close();
+        }
+    }
+
+    @Test
+    void creates_and_deletes_queue_with_configured_bearer_token() throws Exception {
+        DispatcherQueueManagers.register("test", new TestQueueManager());
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-queue-success-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> created = client.send(
+                        postQueue(port, "/queue/orders", "secret"),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(created.statusCode()).isEqualTo(200);
+                assertThat(created.body()).contains("/queue/orders");
+            });
+
+            HttpResponse<String> deleted = client.send(
+                    deleteQueue(port, "/queue/orders", false, "secret"),
+                    HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(deleted.statusCode()).isEqualTo(200);
+            assertThat(deleted.body()).contains("deleted");
+        } finally {
+            DispatcherQueueManagers.unregister("test");
+            server.close();
+        }
+    }
+
+    @Test
+    void rejects_non_empty_queue_delete_until_force_is_used() throws Exception {
+        TestQueueManager manager = new TestQueueManager();
+        DispatcherQueue queue = manager.createQueue(Destination.create("/queue/non-empty"), 10);
+        queue.enqueue(Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(Destination.create("/queue/non-empty"))
+                .createdAt(java.time.Instant.now())
+                .producerId("test")
+                .body(Buffer.alloc("test".getBytes()))
+                .build());
+        DispatcherQueueManagers.register("test", manager);
+
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-queue-conflict-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> conflict = client.send(
+                        deleteQueue(port, "/queue/non-empty", false, "secret"),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(conflict.statusCode()).isEqualTo(409);
+            });
+
+            HttpResponse<String> deleted = client.send(
+                    deleteQueue(port, "/queue/non-empty", true, "secret"),
+                    HttpResponse.BodyHandlers.ofString()
+            );
+
+            assertThat(deleted.statusCode()).isEqualTo(200);
+        } finally {
+            DispatcherQueueManagers.unregister("test");
+            server.close();
+        }
+    }
+
+    @Test
+    void returns_not_found_when_deleting_missing_queue() throws Exception {
+        DispatcherQueueManagers.register("test", new TestQueueManager());
+
+        int port = availablePort();
+        MonitoringHttpServer server = MonitoringHttpServer.builder(new MonitoringSnapshotService("test"))
+                .host("127.0.0.1")
+                .port(port)
+                .token("secret")
+                .build();
+        Thread thread = new Thread(server::start, "monitor-http-queue-missing-test");
+        thread.setDaemon(true);
+        thread.start();
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+                HttpResponse<String> missing = client.send(
+                        deleteQueue(port, "/queue/missing", false, "secret"),
+                        HttpResponse.BodyHandlers.ofString()
+                );
+                assertThat(missing.statusCode()).isEqualTo(404);
+            });
+        } finally {
+            DispatcherQueueManagers.unregister("test");
+            server.close();
+        }
+    }
+
     private static HttpRequest request(int port, String path) {
         return HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + port + "/titan" + path)).GET().build();
     }
@@ -112,9 +284,65 @@ class MonitoringHttpServerTest {
                 .build();
     }
 
+    private static HttpRequest postQueue(int port, String destination, String token) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(queueUri(port, destination, false))
+                .POST(HttpRequest.BodyPublishers.noBody());
+        if (token != null) {
+            builder.header("Authorization", "Bearer " + token);
+        }
+        return builder.build();
+    }
+
+    private static HttpRequest deleteQueue(int port, String destination, boolean force, String token) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(queueUri(port, destination, force))
+                .DELETE();
+        if (token != null) {
+            builder.header("Authorization", "Bearer " + token);
+        }
+        return builder.build();
+    }
+
+    private static URI queueUri(int port, String destination, boolean force) {
+        String encoded = URLEncoder.encode(destination, StandardCharsets.UTF_8);
+        return URI.create("http://127.0.0.1:" + port + "/titan"
+                + MonitoringHttpServer.QUEUES_PATH
+                + "?destination=" + encoded
+                + "&capacity=10"
+                + "&force=" + force);
+    }
+
     private static int availablePort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();
+        }
+    }
+
+    @NullMarked
+    private static final class TestQueueManager implements DispatcherQueueManager {
+
+        private final Dispatcher dispatcher = new TrieDispatcher();
+
+        @Override
+        public DispatcherQueue createQueue(Destination destination, int capacity) {
+            return dispatcher.getOrPut(destination, capacity);
+        }
+
+        @Override
+        public DispatcherQueueDeleteResult deleteQueue(Destination destination, boolean force) {
+            DispatcherQueue queue = dispatcher.get(destination);
+            if (queue == null) {
+                return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.NOT_FOUND, 0);
+            }
+            int size = queue.size();
+            if (size > 0 && !force) {
+                return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.NOT_EMPTY, size);
+            }
+            if (force) {
+                queue.clear();
+            }
+            dispatcher.remove(destination);
+            DispatcherQueueMbeans.unregister(queue.getDestination());
+            return new DispatcherQueueDeleteResult(DispatcherQueueDeleteResult.Status.DELETED, size);
         }
     }
 }

--- a/titan-cli/internal/cli/cli.go
+++ b/titan-cli/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,15 @@ type viewOptions struct {
 	noClear  bool
 	noColor  bool
 	once     bool
+}
+
+type queueOptions struct {
+	addr     string
+	token    string
+	timeout  time.Duration
+	noColor  bool
+	capacity int
+	force    bool
 }
 
 func Run(args []string, stdout io.Writer, stderr io.Writer, version string) int {
@@ -65,15 +75,99 @@ func newRootCommand(stdout io.Writer, stderr io.Writer, version string) *cobra.C
 	}
 	command.SetOut(stdout)
 	command.SetErr(stderr)
-	command.Flags().StringVar(&options.addr, "addr", defaultAddr, "Titan monitor HTTP address")
-	command.Flags().StringVar(&options.token, "token", "", "Titan monitor bearer token")
+	command.PersistentFlags().StringVar(&options.addr, "addr", defaultAddr, "Titan monitor HTTP address")
+	command.PersistentFlags().StringVar(&options.token, "token", "", "Titan monitor bearer token")
+	command.PersistentFlags().DurationVar(&options.timeout, "timeout", 5*time.Second, "HTTP request timeout")
+	command.PersistentFlags().BoolVar(&options.noColor, "no-color", false, "Render without ANSI colors")
 	command.Flags().DurationVar(&options.interval, "interval", time.Second, "Polling interval")
-	command.Flags().DurationVar(&options.timeout, "timeout", 5*time.Second, "HTTP request timeout")
 	command.Flags().StringVar(&options.view, "view", "overview", "Initial view: overview, queues, or jvm")
 	command.Flags().BoolVar(&options.noClear, "no-clear", false, "Render without clearing the terminal")
-	command.Flags().BoolVar(&options.noColor, "no-color", false, "Render without ANSI colors")
 	command.Flags().BoolVar(&options.once, "once", false, "Render one frame and exit")
+	command.AddCommand(queueCommand(stdout, options))
 	command.AddCommand(versionCommand(stdout, version))
+	return command
+}
+
+func queueCommand(stdout io.Writer, rootOptions *viewOptions) *cobra.Command {
+	options := &queueOptions{}
+	command := &cobra.Command{
+		Use:           "queue",
+		Short:         "Manage dispatcher queues",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			options.addr = rootOptions.addr
+			options.token = token(rootOptions.token)
+			options.timeout = rootOptions.timeout
+			options.noColor = rootOptions.noColor
+		},
+	}
+	command.AddCommand(queueListCommand(stdout, options))
+	command.AddCommand(queueCreateCommand(stdout, options))
+	command.AddCommand(queueDeleteCommand(stdout, options))
+	return command
+}
+
+func queueListCommand(stdout io.Writer, options *queueOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:           "list",
+		Short:         "List dispatcher queues",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := monitor.NewClientWithTimeout(options.addr, options.token, options.timeout)
+			queues, err := client.Queues(cmd.Context())
+			if err != nil {
+				return queueError(err)
+			}
+			render.Queues(stdout, queues, render.Options{Color: !options.noColor})
+			return nil
+		},
+	}
+}
+
+func queueCreateCommand(stdout io.Writer, options *queueOptions) *cobra.Command {
+	command := &cobra.Command{
+		Use:           "create <destination>",
+		Short:         "Create a dispatcher queue",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.capacity <= 0 {
+				return exitError{code: 2, err: fmt.Errorf("capacity must be greater than 0")}
+			}
+			client := monitor.NewClientWithTimeout(options.addr, options.token, options.timeout)
+			queue, err := client.CreateQueue(cmd.Context(), args[0], options.capacity)
+			if err != nil {
+				return queueError(err)
+			}
+			fmt.Fprintf(stdout, "created %s size=%d capacity=%d\n", queue.Destination, queue.Size, queue.Capacity)
+			return nil
+		},
+	}
+	command.Flags().IntVar(&options.capacity, "capacity", 11, "Queue capacity")
+	return command
+}
+
+func queueDeleteCommand(stdout io.Writer, options *queueOptions) *cobra.Command {
+	command := &cobra.Command{
+		Use:           "delete <destination>",
+		Short:         "Delete a dispatcher queue",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client := monitor.NewClientWithTimeout(options.addr, options.token, options.timeout)
+			err := client.DeleteQueue(cmd.Context(), args[0], options.force)
+			if err != nil {
+				return queueError(err)
+			}
+			fmt.Fprintf(stdout, "deleted %s\n", args[0])
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&options.force, "force", false, "Drop queued messages before deleting")
 	return command
 }
 
@@ -94,7 +188,7 @@ func runView(ctx context.Context, stdout io.Writer, options *viewOptions) error 
 		return exitError{code: 2, err: err}
 	}
 
-	client := monitor.NewClientWithTimeout(options.addr, options.token, options.timeout)
+	client := monitor.NewClientWithTimeout(options.addr, token(options.token), options.timeout)
 	for {
 		snapshot, err := client.Snapshot(ctx)
 		if !options.noClear {
@@ -118,6 +212,21 @@ func runView(ctx context.Context, stdout io.Writer, options *viewOptions) error 
 		case <-time.After(options.interval):
 		}
 	}
+}
+
+func token(value string) string {
+	if value != "" {
+		return value
+	}
+	return os.Getenv("TITAN_MONITOR_TOKEN")
+}
+
+func queueError(err error) error {
+	var httpErr monitor.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == 409 {
+		return exitError{code: 1, err: fmt.Errorf("%w; retry with --force to drop queued messages", err)}
+	}
+	return exitError{code: 1, err: err}
 }
 
 func renderOptions(options *viewOptions) render.Options {

--- a/titan-cli/internal/cli/cli_test.go
+++ b/titan-cli/internal/cli/cli_test.go
@@ -92,6 +92,60 @@ func TestRunRendersQueueViewOnce(t *testing.T) {
 	}
 }
 
+func TestQueueListRendersQueues(t *testing.T) {
+	server := queueServer(t, http.StatusOK)
+	defer server.Close()
+	var stdout bytes.Buffer
+
+	code := Run([]string{"--addr", server.URL, "--no-color", "queue", "list"}, &stdout, &bytes.Buffer{}, "test")
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(stdout.String(), "/queue/orders") {
+		t.Fatalf("expected queue output, got %q", stdout.String())
+	}
+}
+
+func TestQueueCreateUsesTokenFromEnvironment(t *testing.T) {
+	t.Setenv("TITAN_MONITOR_TOKEN", "env-secret")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer env-secret" {
+			t.Fatalf("missing env bearer token")
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		_, _ = w.Write([]byte(`{"destination":"/queue/orders","size":0,"capacity":30,"paused":false}`))
+	}))
+	defer server.Close()
+	var stdout bytes.Buffer
+
+	code := Run([]string{"--addr", server.URL, "queue", "create", "/queue/orders", "--capacity", "30"}, &stdout, &bytes.Buffer{}, "test")
+
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(stdout.String(), "created /queue/orders") {
+		t.Fatalf("expected create output, got %q", stdout.String())
+	}
+}
+
+func TestQueueDeleteConflictSuggestsForce(t *testing.T) {
+	server := queueServer(t, http.StatusConflict)
+	defer server.Close()
+	var stderr bytes.Buffer
+
+	code := Run([]string{"--addr", server.URL, "queue", "delete", "/queue/orders"}, &bytes.Buffer{}, &stderr, "test")
+
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "--force") {
+		t.Fatalf("expected force suggestion, got %q", stderr.String())
+	}
+}
+
 func snapshotServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -107,5 +161,18 @@ func snapshotServer(t *testing.T) *httptest.Server {
 			},
 			"queues":[{"destination":"/queue/orders","size":5,"capacity":10,"paused":false}]
 		}`))
+	}))
+}
+
+func queueServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/titan/monitor/queues" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			_, _ = w.Write([]byte(`[{"destination":"/queue/orders","size":5,"capacity":10,"paused":false}]`))
+		}
 	}))
 }

--- a/titan-cli/internal/monitor/client.go
+++ b/titan-cli/internal/monitor/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -13,6 +14,15 @@ type Client struct {
 	baseURL    string
 	token      string
 	httpClient *http.Client
+}
+
+type HTTPError struct {
+	StatusCode int
+	Status     string
+}
+
+func (e HTTPError) Error() string {
+	return fmt.Sprintf("monitor endpoint returned %s", e.Status)
 }
 
 func NewClient(addr string, token string) Client {
@@ -33,12 +43,9 @@ func NewClientWithTimeout(addr string, token string, timeout time.Duration) Clie
 }
 
 func (c Client) Snapshot(ctx context.Context) (Snapshot, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/titan/monitor/snapshot", nil)
+	request, err := c.request(ctx, http.MethodGet, "/titan/monitor/snapshot")
 	if err != nil {
 		return Snapshot{}, err
-	}
-	if c.token != "" {
-		request.Header.Set("Authorization", "Bearer "+c.token)
 	}
 
 	response, err := c.httpClient.Do(request)
@@ -48,7 +55,7 @@ func (c Client) Snapshot(ctx context.Context) (Snapshot, error) {
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return Snapshot{}, fmt.Errorf("monitor endpoint returned %s", response.Status)
+		return Snapshot{}, HTTPError{StatusCode: response.StatusCode, Status: response.Status}
 	}
 
 	var snapshot Snapshot
@@ -56,4 +63,84 @@ func (c Client) Snapshot(ctx context.Context) (Snapshot, error) {
 		return Snapshot{}, err
 	}
 	return snapshot, nil
+}
+
+func (c Client) Queues(ctx context.Context) ([]QueueSnapshot, error) {
+	request, err := c.request(ctx, http.MethodGet, "/titan/monitor/queues")
+	if err != nil {
+		return nil, err
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, HTTPError{StatusCode: response.StatusCode, Status: response.Status}
+	}
+
+	var queues []QueueSnapshot
+	if err := json.NewDecoder(response.Body).Decode(&queues); err != nil {
+		return nil, err
+	}
+	return queues, nil
+}
+
+func (c Client) CreateQueue(ctx context.Context, destination string, capacity int) (QueueSnapshot, error) {
+	values := url.Values{}
+	values.Set("destination", destination)
+	if capacity > 0 {
+		values.Set("capacity", fmt.Sprintf("%d", capacity))
+	}
+	request, err := c.request(ctx, http.MethodPost, "/titan/monitor/queues?"+values.Encode())
+	if err != nil {
+		return QueueSnapshot{}, err
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return QueueSnapshot{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return QueueSnapshot{}, HTTPError{StatusCode: response.StatusCode, Status: response.Status}
+	}
+
+	var queue QueueSnapshot
+	if err := json.NewDecoder(response.Body).Decode(&queue); err != nil {
+		return QueueSnapshot{}, err
+	}
+	return queue, nil
+}
+
+func (c Client) DeleteQueue(ctx context.Context, destination string, force bool) error {
+	values := url.Values{}
+	values.Set("destination", destination)
+	values.Set("force", fmt.Sprintf("%t", force))
+	request, err := c.request(ctx, http.MethodDelete, "/titan/monitor/queues?"+values.Encode())
+	if err != nil {
+		return err
+	}
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return HTTPError{StatusCode: response.StatusCode, Status: response.Status}
+	}
+	return nil
+}
+
+func (c Client) request(ctx context.Context, method string, path string) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.token != "" {
+		request.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	return request, nil
 }

--- a/titan-cli/internal/monitor/client_test.go
+++ b/titan-cli/internal/monitor/client_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,7 +35,59 @@ func TestSnapshotReturnsHTTPError(t *testing.T) {
 
 	_, err := NewClient(server.URL, "").Snapshot(context.Background())
 
-	if err == nil {
+	var httpErr HTTPError
+	if !errors.As(err, &httpErr) {
 		t.Fatalf("expected error")
+	}
+	if httpErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", httpErr.StatusCode)
+	}
+}
+
+func TestCreateAndDeleteQueueUseManagementEndpoint(t *testing.T) {
+	var sawCreate bool
+	var sawDelete bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" {
+			t.Fatalf("missing bearer token")
+		}
+		if r.URL.Path != "/titan/monitor/queues" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		switch r.Method {
+		case http.MethodPost:
+			sawCreate = true
+			if r.URL.Query().Get("destination") != "/queue/orders" {
+				t.Fatalf("unexpected destination %q", r.URL.Query().Get("destination"))
+			}
+			if r.URL.Query().Get("capacity") != "20" {
+				t.Fatalf("unexpected capacity %q", r.URL.Query().Get("capacity"))
+			}
+			_, _ = w.Write([]byte(`{"destination":"/queue/orders","size":0,"capacity":20,"paused":false}`))
+		case http.MethodDelete:
+			sawDelete = true
+			if r.URL.Query().Get("force") != "true" {
+				t.Fatalf("unexpected force %q", r.URL.Query().Get("force"))
+			}
+			_, _ = w.Write([]byte(`{"status":"deleted","size":0}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "secret")
+	queue, err := client.CreateQueue(context.Background(), "/queue/orders", 20)
+	if err != nil {
+		t.Fatalf("unexpected create error: %v", err)
+	}
+	if queue.Capacity != 20 {
+		t.Fatalf("expected capacity 20, got %d", queue.Capacity)
+	}
+	if err := client.DeleteQueue(context.Background(), "/queue/orders", true); err != nil {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+	if !sawCreate || !sawDelete {
+		t.Fatalf("expected create and delete calls")
 	}
 }


### PR DESCRIPTION
## Motivation:

Titan can expose queue and JVM status through the monitor endpoint, but operators cannot manage dispatcher queues from the CLI. This PR adds a small management surface for creating and deleting queues safely while keeping destructive operations behind the monitor bearer token.

## Modification:

- Add dispatcher queue management contracts, deletion results, manager registry, capacity-aware creation, and MBean unregister support.
- Connect fanout gateways to the queue management lifecycle, including consumer shutdown, JMX cleanup, and auto-create recovery after deletion.
- Add monitor HTTP queue endpoints for list/create/delete with stricter authorization for mutating operations.
- Add titan-cli queue list/create/delete commands and token environment fallback.
- Add standalone logback defaults so production logs default to INFO while Jetty can be controlled separately.

## Result:

Introduces monitor-backed queue management for Titan standalone and CLI users.

Validation:
- ./gradlew clean build --no-configuration-cache
- go test ./...
- ./gradlew :bootstrap:processResources :bootstrap:shadowJar --no-configuration-cache