### PR TITLE
Fix Vertx fanout message delivery

### DIFF
--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/VertxStompFanoutExporter.java
@@ -28,6 +28,7 @@ import io.vertx.ext.stomp.Frame;
 import io.vertx.ext.stomp.StompServer;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.fanout.AggregationResult;
 
@@ -65,9 +66,11 @@ public final class VertxStompFanoutExporter implements FanoutExporter {
 
         try {
             Frame frame = new Frame()
-                    .setCommand(Command.SEND)
+                    .setCommand(Command.MESSAGE)
                     .setDestination(destination.path())
                     .setBody(io.vertx.core.buffer.Buffer.buffer(payload.getBytes()));
+            frame.addHeader(Frame.DESTINATION, destination.path());
+            frame.addHeader(Frame.MESSAGE_ID, IdGenerator.uuid());
             frame.addHeader(Frame.CONTENT_LENGTH, Integer.toString(payload.length()));
             stompDestination.dispatch(null, frame);
             succeeded = attempted;

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/FanoutExporterTest.java
@@ -25,14 +25,21 @@ package org.traffichunter.titan.fanout.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.vertx.ext.stomp.Command;
+import io.vertx.ext.stomp.Frame;
+import io.vertx.ext.stomp.StompServer;
+import io.vertx.ext.stomp.StompServerHandler;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.traffichunter.titan.core.channel.IOEventLoop;
@@ -61,6 +68,15 @@ class FanoutExporterTest {
 
     @Mock
     private InetServer inetServer;
+
+    @Mock
+    private StompServer vertxServer;
+
+    @Mock
+    private StompServerHandler vertxServerHandler;
+
+    @Mock
+    private io.vertx.ext.stomp.Destination vertxDestination;
 
     @Test
     void aggregationResult_completes_when_done_reaches_attempted() {
@@ -122,6 +138,50 @@ class FanoutExporterTest {
         assertThat(result.done()).isEqualTo(2);
         assertThat(result.succeeded()).isEqualTo(1);
         assertThat(result.failed()).isEqualTo(1);
+    }
+
+    @Test
+    void vertxStompFanoutExporter_dispatches_message_frame_to_subscribers() {
+        Destination destination = Destination.create("/topic/orders");
+        Buffer payload = Buffer.alloc("hello".getBytes());
+
+        when(vertxServer.isListening()).thenReturn(true);
+        when(vertxServer.stompHandler()).thenReturn(vertxServerHandler);
+        when(vertxServerHandler.getDestination(destination.path())).thenReturn(vertxDestination);
+        when(vertxDestination.numberOfSubscriptions()).thenReturn(1);
+
+        VertxStompFanoutExporter exporter = new VertxStompFanoutExporter(vertxServer);
+        AggregationResult result = exporter.export(destination, payload);
+
+        ArgumentCaptor<Frame> frameCaptor = ArgumentCaptor.forClass(Frame.class);
+        verify(vertxDestination).dispatch(isNull(), frameCaptor.capture());
+        Frame frame = frameCaptor.getValue();
+
+        assertThat(frame.getCommand()).isEqualTo(Command.MESSAGE);
+        assertThat(frame.getDestination()).isEqualTo(destination.path());
+        assertThat(frame.getHeader(Frame.DESTINATION)).isEqualTo(destination.path());
+        assertThat(frame.getHeader(Frame.MESSAGE_ID)).isNotBlank();
+        assertThat(frame.getHeader(Frame.CONTENT_LENGTH)).isEqualTo(Integer.toString(payload.length()));
+        assertThat(frame.getBodyAsString()).isEqualTo("hello");
+        assertThat(result.totalAttempted()).isEqualTo(1);
+        assertThat(result.succeeded()).isEqualTo(1);
+        assertThat(result.failed()).isZero();
+    }
+
+    @Test
+    void vertxStompFanoutExporter_completes_without_dispatch_when_destination_is_missing() {
+        Destination destination = Destination.create("/topic/missing");
+
+        when(vertxServer.isListening()).thenReturn(true);
+        when(vertxServer.stompHandler()).thenReturn(vertxServerHandler);
+        when(vertxServerHandler.getDestination(destination.path())).thenReturn(null);
+
+        VertxStompFanoutExporter exporter = new VertxStompFanoutExporter(vertxServer);
+        AggregationResult result = exporter.export(destination, Buffer.alloc("hello".getBytes()));
+
+        assertThat(result.totalAttempted()).isZero();
+        assertThat(result.succeeded()).isZero();
+        assertThat(result.failed()).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Motivation:

Vert.x smoke tests can miss listener-delivered messages because `VertxStompFanoutExporter` dispatches fanout payloads as client `SEND` frames instead of server `MESSAGE` frames. Native STOMP fanout already sends `MESSAGE`, so the Vert.x transport should match the same delivery contract.

## Modification:

- Change `VertxStompFanoutExporter` to dispatch `Command.MESSAGE` frames.
- Add STOMP delivery headers for `destination`, `message-id`, and `content-length`.
- Add fanout tests that capture the dispatched Vert.x frame and verify the missing-destination path.

## Result:

Vert.x fanout delivery now matches the native STOMP exporter and gives Spring listener smoke tests a stable server-message frame shape.

Validation:
- `./gradlew :fanout:test :smoke-test:smoke-spring:test --tests '*VertxSmokeLocalTest' --no-configuration-cache`
- `./gradlew :smoke-test:smoke-spring:test --no-configuration-cache`
