### PR TITLE
Stabilize client smoke tests

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/util/Destination.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/Destination.java
@@ -59,7 +59,7 @@ public record Destination(String path) {
         return path.contains(prefix.path);
     }
 
-    private boolean matchKey(final String key) {
+    public static boolean matchKey(final String key) {
         return ROUTING_KEY_PATTERN.matcher(key).matches();
     }
 

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/SmokeTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/SmokeTest.java
@@ -23,18 +23,22 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.smoke.springframework.smoke.junit;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.test.annotation.DirtiesContext;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 
+/**
+ * @author yun
+ */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@SmokeTest
-@SpringBootTest(properties = "spring.titan.client=vertx")
-public @interface VertxSmokeTest {
+@TitanBootstrapper
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public @interface SmokeTest {
 }

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/TitanSmokeTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/junit/TitanSmokeTest.java
@@ -34,9 +34,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@TitanBootstrapper
+@SmokeTest
 @SpringBootTest(properties = "spring.titan.client=titan")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public @interface TitanSmokeTest {
 }

--- a/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/AbstractTitanSmokeLocalTest.java
+++ b/smoke-test/smoke-spring/src/test/java/org/traffichunter/titan/smoke/springframework/smoke/local/AbstractTitanSmokeLocalTest.java
@@ -6,13 +6,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompOperations;
 import org.traffichunter.titan.springframework.stomp.TitanClientManager;
 import org.traffichunter.titan.springframework.stomp.TitanTemplate;
+import org.traffichunter.titan.springframework.stomp.listener.TitanListenerEndpointRegistry;
 
 public abstract class AbstractTitanSmokeLocalTest {
 
@@ -30,6 +37,9 @@ public abstract class AbstractTitanSmokeLocalTest {
     @Autowired
     private SmokeListener smokeListener;
 
+    @Autowired
+    private TitanListenerEndpointRegistry listenerRegistry;
+
     protected abstract Class<? extends StompClient> clientType();
 
     protected abstract Class<? extends StompOperations> operationsType();
@@ -43,8 +53,19 @@ public abstract class AbstractTitanSmokeLocalTest {
     @Test
     void sync_subscribe_and_send_smoke() throws Exception {
         String destination = destination("sync");
-        subscribeEventually(destination);
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
         sendEventually(destination, PAYLOAD);
+        assertReceived(received, PAYLOAD);
+    }
+
+    @RepeatedTest(5)
+    void subscribe_send_receive_contract_is_stable() throws Exception {
+        String destination = destination("stable");
+        String payload = PAYLOAD + "-stable-" + UUID.randomUUID();
+
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
+        sendEventually(destination, payload);
+        assertReceived(received, payload);
     }
 
     @Test
@@ -52,21 +73,24 @@ public abstract class AbstractTitanSmokeLocalTest {
         String destination = destination("bytes");
         byte[] payload = PAYLOAD.getBytes();
 
-        subscribeEventually(destination);
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(10))
                 .ignoreExceptions()
                 .untilAsserted(() -> assertThat(titanTemplate.send(destination, payload)).isNotNull());
+        assertReceived(received, PAYLOAD);
     }
 
     @Test
     void repeated_send_smoke() throws Exception {
         String destination = destination("repeat");
-        subscribeEventually(destination);
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
 
         sendEventually(destination, PAYLOAD + "-1");
         sendEventually(destination, PAYLOAD + "-2");
+        assertReceived(received, PAYLOAD + "-1");
+        assertReceived(received, PAYLOAD + "-2");
     }
 
     @Test
@@ -74,27 +98,30 @@ public abstract class AbstractTitanSmokeLocalTest {
         String destinationA = destination("multi-a");
         String destinationB = destination("multi-b");
 
-        subscribeEventually(destinationA);
-        subscribeEventually(destinationB);
+        BlockingQueue<String> receivedA = subscribeReceivingEventually(destinationA);
+        BlockingQueue<String> receivedB = subscribeReceivingEventually(destinationB);
 
         sendEventually(destinationA, PAYLOAD + "-a");
         sendEventually(destinationB, PAYLOAD + "-b");
+        assertReceived(receivedA, PAYLOAD + "-a");
+        assertReceived(receivedB, PAYLOAD + "-b");
     }
 
     @Test
     void unsubscribe_and_resubscribe_smoke() throws Exception {
         String destination = destination("unsubscribe");
 
-        subscribeEventually(destination);
+        subscribeReceivingEventually(destination);
         unsubscribeEventually(destination);
-        subscribeEventually(destination);
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
         sendEventually(destination, PAYLOAD + "-after-unsubscribe");
+        assertReceived(received, PAYLOAD + "-after-unsubscribe");
     }
 
     @Test
     void byte_buffer_send_smoke() throws Exception {
         String destination = destination("byte-buffer");
-        subscribeEventually(destination);
+        BlockingQueue<String> received = subscribeReceivingEventually(destination);
 
         ByteBuffer wrapped = ByteBuffer.wrap((PAYLOAD + "-wrapped").getBytes(StandardCharsets.UTF_8));
         ByteBuffer direct = ByteBuffer.allocateDirect((PAYLOAD + "-direct").getBytes(StandardCharsets.UTF_8).length);
@@ -110,6 +137,8 @@ public abstract class AbstractTitanSmokeLocalTest {
                 .atMost(Duration.ofSeconds(10))
                 .ignoreExceptions()
                 .untilAsserted(() -> assertThat(titanTemplate.send(destination, direct)).isNotNull());
+        assertReceived(received, PAYLOAD + "-wrapped");
+        assertReceived(received, PAYLOAD + "-direct");
     }
 
     @Test
@@ -117,6 +146,7 @@ public abstract class AbstractTitanSmokeLocalTest {
         String payload = PAYLOAD + "-listener";
 
         smokeListener.clear();
+        awaitListenerReady();
         sendEventually(SmokeListener.DESTINATION, payload);
 
         Awaitility.await()
@@ -132,14 +162,23 @@ public abstract class AbstractTitanSmokeLocalTest {
     }
 
     private static String destination(String suffix) {
-        return "/queue/smoke-local/" + suffix;
+        return "/queue/smoke-local/" + suffix + "/" + UUID.randomUUID();
     }
 
-    private void subscribeEventually(String destination) {
+    private BlockingQueue<String> subscribeReceivingEventually(String destination) {
+        BlockingQueue<String> received = new LinkedBlockingQueue<>();
         Awaitility.await()
                 .atMost(Duration.ofSeconds(10))
                 .ignoreExceptions()
-                .untilAsserted(() -> assertThat(titanTemplate.subscribe(destination)).isNotNull());
+                .untilAsserted(() -> assertThat(clientManager.operations()
+                        .subscribe(destination, frame -> received.add(body(frame)))
+                        .get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS)
+                ).isNotNull());
+        String probe = PAYLOAD + "-probe-" + UUID.randomUUID();
+        sendEventually(destination, probe);
+        assertReceived(received, probe);
+        received.clear();
+        return received;
     }
 
     private void sendEventually(String destination, String payload) {
@@ -154,5 +193,26 @@ public abstract class AbstractTitanSmokeLocalTest {
                 .atMost(Duration.ofSeconds(10))
                 .ignoreExceptions()
                 .untilAsserted(() -> assertThat(titanTemplate.unsubscribe(destination)).isNotNull());
+    }
+
+    private static void assertReceived(BlockingQueue<String> received, String payload) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(received).contains(payload));
+    }
+
+    private void awaitListenerReady() {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(listenerRegistry.isRunning()).isTrue());
+
+        String probe = PAYLOAD + "-listener-probe-" + UUID.randomUUID();
+        sendEventually(SmokeListener.DESTINATION, probe);
+        assertReceived(smokeListener.received(), probe);
+        smokeListener.clear();
+    }
+
+    private static String body(StompFrames frame) {
+        return new String(frame.body(), StandardCharsets.UTF_8);
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientConnectionImpl.java
@@ -424,6 +424,11 @@ public class StompClientConnectionImpl implements StompClientConnection {
     }
 
     private void send(StompFrame frame, Completable<StompFrame> receiptPromise) {
+        if (!eventLoop().inEventLoop()) {
+            eventLoop().register(() -> send(frame, receiptPromise));
+            return;
+        }
+
         if (!netChannel.isActive() || !netChannel.isConnected()) {
             close();
             receiptPromise.fail(new StompNetChannelException("Channel is closed"));


### PR DESCRIPTION
## Motivation:

Client smoke tests were still vulnerable to timing issues and did not always prove that Titan and Vert.x clients actually received delivered messages. While strengthening the smoke tests, a cross-thread STOMP write issue surfaced when fanout delivered `MESSAGE` frames from a non-event-loop thread.

## Modification:

- Add a shared smoke test annotation for Titan and Vert.x client smoke tests.
- Use unique queue destinations per smoke test.
- Verify real subscription delivery with probe messages before the main assertion.
- Wait for `@TitanListener` containers to receive a probe message before listener smoke assertions.
- Expose destination key matching for shared validation.
- Route STOMP client writes back onto the owning event loop when invoked from another thread.

## Result:

Titan and Vert.x smoke tests now validate actual message receipt more reliably, and STOMP client writes preserve event-loop thread affinity.

Validation:
- `./gradlew :smoke-test:smoke-spring:cleanTest :smoke-test:smoke-spring:test --no-configuration-cache`
- `./gradlew test --no-configuration-cache`
