### PR TITLE
fix: Netty DirectByteBuf 누수 3곳 수정

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * @author yun
+ * @author yun gkdbssla97
  */
 @Slf4j
 public final class ChannelInBoundHandlerChainImpl implements ChannelInBoundHandlerChain {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
@@ -64,6 +64,7 @@ public final class ChannelInBoundHandlerChainImpl implements ChannelInBoundHandl
     public void sparkChannelRead(NetChannel channel, Buffer buffer) {
         ChannelInBoundHandlerChainImpl chain = next;
         if(chain == null) {
+            buffer.release();
             return;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -170,7 +170,10 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
             byteBuf.readerIndex(byteBuf.readerIndex() + written);
 
             if(!byteBuf.isReadable()) {
-                channelWriteBuffer.poll();
+                Buffer consumed = channelWriteBuffer.poll();
+                if (consumed != null) {
+                    consumed.release();
+                }
             }
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
  * {@link IOEventLoop}, while {@link ChannelWriteBuffer} keeps partially written buffers until
  * the socket becomes writable again.</p>
  *
- * @author yun
+ * @author yun gkdbssla97
  */
 @Slf4j
 public class NewIONetChannel extends AbstractChannel implements NetChannel {

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
@@ -1,0 +1,78 @@
+package org.traffichunter.titan.core.channel;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * Verifies that ChannelInBoundHandlerChainImpl releases the buffer when no next handler exists.
+ *
+ * @author yun gkdbssla97
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ChannelInBoundHandlerChainImplTest {
+
+    @Test
+    void when_terminal_chain_then_buffer_refCnt_is_zero() {
+        Buffer buf = Buffer.alloc("data");
+        ChannelHandlerChain chain = new ChannelHandlerChain();
+
+        chain.processChannelRead(new InMemoryNetChannel(), buf);
+
+        assertThat(buf.byteBuf().refCnt())
+                .as("terminal chain must release buffer")
+                .isEqualTo(0);
+    }
+
+    @Test
+    void when_pass_through_handler_then_buffer_released_at_chain_end() {
+        Buffer buf = Buffer.alloc("data");
+        ChannelHandlerChain chain = new ChannelHandlerChain();
+        chain.add(new PassThroughHandler());
+
+        chain.processChannelRead(new InMemoryNetChannel(), buf);
+
+        assertThat(buf.byteBuf().refCnt())
+                .as("buffer must be released after passing through all handlers")
+                .isEqualTo(0);
+    }
+
+    @Test
+    void when_handler_retains_buffer_then_refCnt_reflects_retain() {
+        Buffer buf = Buffer.alloc("data");
+        ChannelHandlerChain chain = new ChannelHandlerChain();
+        chain.add(new RetainingHandler());
+
+        chain.processChannelRead(new InMemoryNetChannel(), buf);
+
+        // RetainingHandler called retain() → refCnt should be 1 after chain releases its ref
+        assertThat(buf.byteBuf().refCnt())
+                .as("explicit retain keeps buffer alive beyond chain release")
+                .isEqualTo(1);
+
+        buf.release();
+    }
+
+    private static class PassThroughHandler implements ChannelInBoundHandler {
+        @Override
+        public void sparkChannelRead(@NonNull NetChannel channel,
+                                     @NonNull Buffer buffer,
+                                     @NonNull ChannelInBoundHandlerChain chain) {
+            chain.sparkChannelRead(channel, buffer);
+        }
+    }
+
+    private static class RetainingHandler implements ChannelInBoundHandler {
+        @Override
+        public void sparkChannelRead(@NonNull NetChannel channel,
+                                     @NonNull Buffer buffer,
+                                     @NonNull ChannelInBoundHandlerChain chain) {
+            buffer.retain();
+            chain.sparkChannelRead(channel, buffer);
+        }
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -38,7 +38,7 @@ import java.util.List;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 
 /**
- * @author yun
+ * @author yun gkdbssla97
  */
 @Slf4j
 public class StompChannelDecoder extends ChannelDecoder {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -121,38 +121,42 @@ public class StompChannelDecoder extends ChannelDecoder {
                     .accumulateByte(StompDelimiter.LF.getHex());
 
             List<Buffer> frames = lineFrameDecoder.decodes(channel, stompFrame);
+            try {
+                StompCommand stompCommand = StompCommand.valueOf(frames.getFirst().toString());
 
-            StompCommand stompCommand = StompCommand.valueOf(frames.getFirst().toString());
+                int bodyLength = -1;
+                StompHeaders headers = new StompHeaders(StompVersion.STOMP_1_2);
+                for(int i = 1; i < frames.size(); i++) {
+                    String header = frames.get(i).toString();
+                    if(header.isBlank()) {
+                        break;
+                    } else {
+                        String[] keyValue = header.split(COLON, 2);
+                        if (keyValue.length != 2) {
+                            return StompFrame.ERR_STOMP_FRAME;
+                        }
 
-            int bodyLength = -1;
-            StompHeaders headers = new StompHeaders(StompVersion.STOMP_1_2);
-            for(int i = 1; i < frames.size(); i++) {
-                String header = frames.get(i).toString();
-                if(header.isBlank()) {
-                    break;
-                } else {
-                    String[] keyValue = header.split(COLON, 2);
-                    if (keyValue.length != 2) {
-                        return StompFrame.ERR_STOMP_FRAME;
+                        String key = keyValue[0].trim();
+                        String value = keyValue[1].trim();
+                        if(key.equals(CONTENT_LENGTH)) {
+                            bodyLength = Integer.parseInt(value);
+                        }
+
+                        headers.put(Elements.convertToElements(key), value);
                     }
-
-                    String key = keyValue[0].trim();
-                    String value = keyValue[1].trim();
-                    if(key.equals(CONTENT_LENGTH)) {
-                        bodyLength = Integer.parseInt(value);
-                    }
-
-                    headers.put(Elements.convertToElements(key), value);
                 }
-            }
 
-            Buffer bodyBuffer = frames.getLast();
-            byte[] body = bodyBuffer.getBytes();
-            if(bodyLength > -1 && bodyLength != body.length) {
-                return StompFrame.ERR_STOMP_FRAME;
-            }
+                Buffer bodyBuffer = frames.getLast();
+                byte[] body = bodyBuffer.getBytes();
+                if(bodyLength > -1 && bodyLength != body.length) {
+                    return StompFrame.ERR_STOMP_FRAME;
+                }
 
-            return StompFrame.create(headers, stompCommand, body);
+                return StompFrame.create(headers, stompCommand, body);
+            } finally {
+                stompFrame.release();
+                frames.forEach(Buffer::release);
+            }
         }
 
         private int findEol(Buffer buffer) {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DisplayNameGenerator.*;
 
 /**
- * @author yun
+ * @author yun gkdbssla97
  */
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class StompChannelDecoderTest {
@@ -172,6 +172,73 @@ class StompChannelDecoderTest {
             total.release();
             chain.releaseAll();
         }
+    }
+
+    // ── refCnt leak regression tests ──────────────────────────────────────────
+
+    @Test
+    void decode_result_refCnt_is_zero_when_no_downstream_handler() {
+        // Leak 2 regression: ChannelInBoundHandlerChainImpl must release the buffer
+        // returned by decode() when it reaches the end of the chain (next == null).
+        StompHeaders headers = StompHeaders.create();
+        headers.put(StompHeaders.Elements.ID, IdGenerator.uuid());
+        StompFrame frame = StompFrame.create(headers, StompCommand.CONNECT, Buffer.alloc("hello"));
+        Buffer buf = frame.toBuffer();
+
+        TerminalChain terminal = new TerminalChain();
+        TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, ((sf, sc) -> {}));
+
+        try {
+            decoder.sparkChannelRead(new InMemoryNetChannel(), buf, terminal);
+            assertThat(terminal.received)
+                    .as("terminal chain must have received the decoded buffer")
+                    .isNotNull();
+            assertThat(terminal.received.byteBuf().refCnt())
+                    .as("buffer refCnt must be 0 after terminal chain releases it")
+                    .isEqualTo(0);
+        } finally {
+            // buf itself is consumed by keepingBuffer inside ChannelDecoder
+            // and released when keepingBuffer is drained — no manual release needed here
+        }
+    }
+
+    @Test
+    void when_content_length_mismatch_then_parse_buffers_released() {
+        // Leak 3 regression: stompFrame and frames list inside StompParser.parse()
+        // must be released even when ERR_STOMP_FRAME is returned early.
+        StompHeaders headers = StompHeaders.create();
+        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "999");
+        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        Buffer buf = frame.toBuffer();
+
+        TerminalChain terminal = new TerminalChain();
+        TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, ((sf, sc) -> {}));
+        decoder.sparkChannelRead(new InMemoryNetChannel(), buf, terminal);
+
+        // If stompFrame/frames buffers were not released, ResourceLeakDetector (PARANOID)
+        // would report a leak. Here we verify the decode completes without error
+        // and the output buffer is properly handled.
+        assertThat(terminal.received).isNotNull();
+        assertThat(terminal.received.byteBuf().refCnt()).isEqualTo(0);
+    }
+
+    private static class TerminalChain implements ChannelInBoundHandlerChain {
+        Buffer received;
+
+        @Override
+        public void sparkChannelConnecting(@NonNull NetChannel channel) {}
+
+        @Override
+        public void sparkChannelAfterConnected(@NonNull NetChannel channel) {}
+
+        @Override
+        public void sparkChannelRead(@NonNull NetChannel channel, @NonNull Buffer buffer) {
+            received = buffer;
+            buffer.release();
+        }
+
+        @Override
+        public void sparkExceptionCaught(@NonNull Throwable error) {}
     }
 
     private static class TestStompChannelDecoder extends StompChannelDecoder {


### PR DESCRIPTION
## Description

Netty `PooledByteBufAllocator`로 할당된 `DirectBuffer`가 사용 후 `release()` 없이 GC에 의해 수거되는 메모리 누수 버그.
`ResourceLeakDetector`가 두 가지 코드 경로에서 동일 패턴의 누수를 감지하고 있음.

## Reason.

- `StompFrame.toBuffer()`가 `Buffer.alloc()` → `InternalBuffer` → `PooledByteBufAllocator.newDirectBuffer()`를 통해 `DirectByteBuf`를 할당하지만, 호출부에서 전송/디코딩 완료 후 `ByteBuf.release()`를 호출하지 않음
- Netty의 `PooledByteBuf`는 JVM GC 대상이 아닌 레퍼런스 카운팅 방식으로 생명주기를 관리하므로, `release()` 누락 시 네이티브 메모리(off-heap)가 반환되지 않음
- 누수 경로가 3곳으로 확인됨 (아래 Trouble shooting 참조)

## Trouble shooting.

**[Leak 1] `NewIONetChannel.flush()`**
- 버퍼를 소켓에 완전히 쓴 후 `channelWriteBuffer.poll()`만 하고 `release()`를 호출하지 않음
- 수정: `poll()` 반환값에 `release()` 추가

**[Leak 2] `ChannelInBoundHandlerChainImpl.sparkChannelRead()`**
- 체인 끝(`next == null`)에서 전달받은 `Buffer`를 release 없이 그냥 드롭
- `StompClientChannelImpl`(구 `StompClientConnectionImpl`)가 체인의 마지막 핸들러일 때 `frame.toBuffer()`로 생성한 Buffer가 GC될 때까지 반환되지 않았음
- 수정: `next == null`일 때 `buffer.release()` 호출 후 return

**[Leak 3] `StompChannelDecoder.StompParser.parse()`**
- 임시 `stompFrame` Buffer와 `lineFrameDecoder.decodes()`가 `readRetainedSlice()`로 반환한 `frames` 목록이 조기 return(`ERR_STOMP_FRAME`) 포함 모든 경로에서 release되지 않음
- 수정: `try-finally`로 `stompFrame.release()` 및 `frames.forEach(Buffer::release)` 보장

## Opinion.

`StompFrame.toBuffer()`가 매 호출마다 새 `DirectBuffer`를 할당하는 구조 자체를 재검토할 필요가 있음. STOMP 프레임 인코딩 시 버퍼를 재사용(pooling)하거나, `CompositeByteBuf` 기반으로 전환하면 할당/해제 사이클 자체를 줄일 수 있음. 단기적으로는 이번 패치로 누수를 막고, 중기적으로는 `Buffer` 소유권 이전 컨벤션을 명시적으로 문서화하는 것을 권장.