### PR TITLE
Expose CompletableFuture for STOMP operations

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/concurrent/Promise.java
+++ b/core/src/main/java/org/traffichunter/titan/core/concurrent/Promise.java
@@ -24,10 +24,12 @@
 package org.traffichunter.titan.core.concurrent;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -122,7 +124,7 @@ public interface Promise<C> extends RunnableFuture<C>, Completable<C> {
      * <p>Do not run blocking code in the callback.</p>
      */
     @CanIgnoreReturnValue
-    Promise<C> onSuccess(Consumer<? super C> success);
+    Promise<C> onSuccess(Consumer<? super @Nullable C> success);
 
     /**
      * Registers a callback for failed completion.
@@ -133,6 +135,26 @@ public interface Promise<C> extends RunnableFuture<C>, Completable<C> {
     Promise<C> onFailure(Consumer<? super Throwable> failure);
 
     Future<C> future();
+
+    /**
+     * Convert to CompletableFuture
+     * @return CompletableFuture
+     */
+    default CompletableFuture<@Nullable C> toCompletableFuture() {
+        CompletableFuture<@Nullable C> completableFuture = new CompletableFuture<>();
+        addListener(future -> {
+            if (future.isSuccess()) {
+                completableFuture.complete(future.getNow());
+            } else {
+                Throwable error = future.error();
+                completableFuture.completeExceptionally(
+                        error != null ? error : new PromiseException("Promise failed without error")
+                );
+            }
+        });
+
+        return completableFuture;
+    }
 
     boolean isDone();
 

--- a/core/src/main/java/org/traffichunter/titan/core/concurrent/PromiseImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/concurrent/PromiseImpl.java
@@ -26,17 +26,10 @@ package org.traffichunter.titan.core.concurrent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.EventLoop;
@@ -115,16 +108,23 @@ public class PromiseImpl<C> implements Promise<C> {
     }
 
     @Override
-    public <R> Promise<R> map(Function<? super @Nullable C, ? extends R> mapper) {
+    public <R> Promise<R> map(Function<? super C, ? extends R> mapper) {
         Promise<R> next = Promise.newPromise(eventLoop);
         addListener(promise -> {
             if (!promise.isSuccess()) {
-                next.fail(error != null ? error : new PromiseException("Promise failed without error"));
+                Throwable failure = promise.error();
+                next.fail(failure != null ? failure : new PromiseException("Promise failed without error"));
                 return;
             }
 
             try {
-                next.success(mapper.apply(promise.getNow()));
+                C get = promise.getNow();
+                if (get == null) {
+                    next.fail(new PromiseException("Cannot map a promise without a result"));
+                    return;
+                }
+
+                next.success(mapper.apply(get));
             } catch (Exception e) {
                 next.fail(e);
             }
@@ -133,22 +133,24 @@ public class PromiseImpl<C> implements Promise<C> {
     }
 
     @Override
-    public <R> Promise<R> thenCompose(Function<? super @Nullable C, ? extends @Nullable Promise<R>> mapper) {
+    public <R> Promise<R> thenCompose(Function<? super C, ? extends Promise<R>> mapper) {
         Promise<R> next = Promise.newPromise(eventLoop);
 
         addListener(promise -> {
             if (!promise.isSuccess()) {
-                next.fail(error != null ? error : new PromiseException("Promise failed without error"));
+                Throwable failure = promise.error();
+                next.fail(failure != null ? failure : new PromiseException("Promise failed without error"));
                 return;
             }
 
             try {
-                Promise<R> mapped = mapper.apply(promise.getNow());
-                if (mapped == null) {
-                    next.fail(new PromiseException("Composed promise cannot be null"));
+                C get = promise.getNow();
+                if (get == null) {
+                    next.fail(new PromiseException("Cannot compose a promise without a result"));
                     return;
                 }
 
+                Promise<R> mapped = mapper.apply(get);
                 mapped.addListener(result -> {
                     if (result.isSuccess()) {
                         next.success(result.getNow());
@@ -167,7 +169,7 @@ public class PromiseImpl<C> implements Promise<C> {
     }
 
     @Override
-    public Promise<C> onSuccess(Consumer<? super C> success) {
+    public Promise<C> onSuccess(Consumer<? super @Nullable C> success) {
         addListener(promise -> {
             if (promise.isSuccess()) {
                 success.accept(promise.getNow());

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/PromiseTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/PromiseTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.Timeout;
 import org.traffichunter.titan.core.channel.EventLoop;
 import org.traffichunter.titan.core.concurrent.AsyncListener;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.concurrent.PromiseException;
 import org.traffichunter.titan.core.concurrent.PromiseImpl;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -143,6 +145,42 @@ class PromiseTest {
     }
 
     @Test
+    void map_should_fail_without_result() {
+        Promise<String> promise = new TestPromiseImpl<>(eventLoop, NOOP);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        Promise<Integer> mapped = promise.map(value -> {
+            invoked.set(true);
+            return value.length();
+        });
+        promise.success();
+
+        assertThatThrownBy(mapped::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(PromiseException.class)
+                .hasRootCauseMessage("Cannot map a promise without a result");
+        assertThat(invoked).isFalse();
+    }
+
+    @Test
+    void map_should_propagate_failure_without_invoking_mapper() {
+        Promise<String> promise = new TestPromiseImpl<>(eventLoop, NOOP);
+        AtomicBoolean invoked = new AtomicBoolean();
+        IllegalStateException failure = new IllegalStateException("boom");
+
+        Promise<Integer> mapped = promise.map(value -> {
+            invoked.set(true);
+            return value.length();
+        });
+        promise.fail(failure);
+
+        assertThatThrownBy(mapped::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCause(failure);
+        assertThat(invoked).isFalse();
+    }
+
+    @Test
     void thenCompose_should_chain_result_test() throws Exception {
         Promise<String> promise = new TestPromiseImpl<>(eventLoop, NOOP);
 
@@ -155,6 +193,24 @@ class PromiseTest {
         promise.success("test");
 
         assertThat(chained.get()).isEqualTo(4);
+    }
+
+    @Test
+    void thenCompose_should_fail_without_result() {
+        Promise<String> promise = new TestPromiseImpl<>(eventLoop, NOOP);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        Promise<Integer> chained = promise.thenCompose(value -> {
+            invoked.set(true);
+            return Promise.newPromise(eventLoop, () -> value.length());
+        });
+        promise.success();
+
+        assertThatThrownBy(chained::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(PromiseException.class)
+                .hasRootCauseMessage("Cannot compose a promise without a result");
+        assertThat(invoked).isFalse();
     }
 
     @Test

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/StompOperations.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/StompOperations.java
@@ -1,7 +1,7 @@
 package org.traffichunter.titan.springframework.stomp.core;
 
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.util.Handler;
@@ -16,21 +16,21 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
  */
 public interface StompOperations {
 
-    Future<StompFrames> send(String destination, Buffer payload);
+    CompletableFuture<StompFrames> send(String destination, Buffer payload);
 
-    Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers);
+    CompletableFuture<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers);
 
-    Future<String> subscribe(String destination, Handler<StompFrames> handler);
+    CompletableFuture<String> subscribe(String destination, Handler<StompFrames> handler);
 
-    Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler);
+    CompletableFuture<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler);
 
-    Future<StompFrames> unsubscribe(String subscriptionId);
+    CompletableFuture<StompFrames> unsubscribe(String subscriptionId);
 
-    Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers);
+    CompletableFuture<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers);
 
-    Future<StompFrames> ack(String messageId);
+    CompletableFuture<StompFrames> ack(String messageId);
 
-    Future<StompFrames> nack(String messageId);
+    CompletableFuture<StompFrames> nack(String messageId);
 
-    Future<StompFrames> disconnect();
+    CompletableFuture<StompFrames> disconnect();
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
@@ -3,7 +3,7 @@ package org.traffichunter.titan.springframework.stomp.core;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
@@ -16,7 +16,7 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  * Delegates every operation to the active {@link StompConnection} resolved through
  * {@link TitanClientManager}, connecting on demand when no connection exists yet.
  *
- * <p>The {@link StompOperations} contract is asynchronous and returns {@link Future}
+ * <p>The {@link StompOperations} contract is asynchronous and returns {@link CompletableFuture}
  * results. Blocking convenience overloads are provided for the common send and
  * subscribe calls and wait up to {@link TitanClientManager#connectTimeoutMillis()}.
  *
@@ -33,47 +33,47 @@ public final class TitanTemplate implements StompOperations {
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload) {
         return connection().send(destination, payload);
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
         return connection().send(destination, payload, headers);
     }
 
     @Override
-    public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(String destination, Handler<StompFrames> handler) {
         return connection().subscribe(destination, handler);
     }
 
     @Override
-    public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
         return connection().subscribe(destination, headers, handler);
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId) {
         return connection().unsubscribe(subscriptionId);
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
         return connection().unsubscribe(subscriptionId, headers);
     }
 
     @Override
-    public Future<StompFrames> ack(String messageId) {
+    public CompletableFuture<StompFrames> ack(String messageId) {
         return connection().ack(messageId);
     }
 
     @Override
-    public Future<StompFrames> nack(String messageId) {
+    public CompletableFuture<StompFrames> nack(String messageId) {
         return connection().nack(messageId);
     }
 
     @Override
-    public Future<StompFrames> disconnect() {
+    public CompletableFuture<StompFrames> disconnect() {
         return connection().disconnect();
     }
 
@@ -96,7 +96,7 @@ public final class TitanTemplate implements StompOperations {
         return await(subscribe(destination, NOOP_HANDLER));
     }
 
-    private <T> T await(Future<T> future) throws Exception {
+    private <T> T await(CompletableFuture<T> future) throws Exception {
         return future.get(clientManager.connectTimeoutMillis(), TimeUnit.MILLISECONDS);
     }
 

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplateTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplateTest.java
@@ -13,7 +13,6 @@ import org.traffichunter.titan.springframework.stomp.TitanProperties;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -86,11 +85,11 @@ class TitanTemplateTest {
 
     @Test
     void async_send_buffer_returns_connection_future() {
-        Future<StompFrames> expected = CompletableFuture.completedFuture(frame);
+        CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
         Buffer payload = Buffer.alloc("hello".getBytes(StandardCharsets.UTF_8));
         when(connection.send("/topic/test", payload)).thenReturn(expected);
 
-        Future<StompFrames> result = template.send("/topic/test", payload);
+        CompletableFuture<StompFrames> result = template.send("/topic/test", payload);
 
         assertThat(result).isSameAs(expected);
     }
@@ -122,21 +121,21 @@ class TitanTemplateTest {
     @Test
     @SuppressWarnings("unchecked")
     void async_subscribe_returns_connection_future() {
-        Future<String> expected = CompletableFuture.completedFuture("sub-1");
+        CompletableFuture<String> expected = CompletableFuture.completedFuture("sub-1");
         Handler<StompFrames> handler = frame -> { };
         when(connection.subscribe("/topic/test", handler)).thenReturn(expected);
 
-        Future<String> result = template.subscribe("/topic/test", handler);
+        CompletableFuture<String> result = template.subscribe("/topic/test", handler);
 
         assertThat(result).isSameAs(expected);
     }
 
     @Test
     void unsubscribe_uses_subscription_id() {
-        Future<StompFrames> expected = CompletableFuture.completedFuture(frame);
+        CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
         when(connection.unsubscribe("sub-1")).thenReturn(expected);
 
-        Future<StompFrames> result = template.unsubscribe("sub-1");
+        CompletableFuture<StompFrames> result = template.unsubscribe("sub-1");
 
         assertThat(result).isSameAs(expected);
         verify(connection).unsubscribe("sub-1");
@@ -144,7 +143,7 @@ class TitanTemplateTest {
 
     @Test
     void ack_delegates_to_connection() {
-        Future<StompFrames> expected = CompletableFuture.completedFuture(frame);
+        CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
         when(connection.ack("msg-1")).thenReturn(expected);
 
         assertThat(template.ack("msg-1")).isSameAs(expected);
@@ -152,7 +151,7 @@ class TitanTemplateTest {
 
     @Test
     void nack_delegates_to_connection() {
-        Future<StompFrames> expected = CompletableFuture.completedFuture(frame);
+        CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
         when(connection.nack("msg-1")).thenReturn(expected);
 
         assertThat(template.nack("msg-1")).isSameAs(expected);
@@ -160,10 +159,10 @@ class TitanTemplateTest {
 
     @Test
     void disconnect_delegates_to_connection() {
-        Future<StompFrames> expected = CompletableFuture.completedFuture(frame);
+        CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
         when(connection.disconnect()).thenReturn(expected);
 
-        Future<StompFrames> result = template.disconnect();
+        CompletableFuture<StompFrames> result = template.disconnect();
 
         verify(connection).disconnect();
         assertThat(result).isSameAs(expected);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrames.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrames.java
@@ -24,6 +24,8 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.codec.stomp;
 
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.codec.stomp.vertx.VertxStompFrame;
+import org.traffichunter.titan.core.util.inet.Frame;
 
 import java.util.Map;
 
@@ -33,6 +35,14 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
  * @author yun
  */
 public interface StompFrames {
+
+    static StompFrames from(StompFrame frame) {
+        return frame;
+    }
+
+    static StompFrames from(VertxStompFrame frame) {
+        return frame;
+    }
 
     StompCommand command();
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompConnection.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/StompConnection.java
@@ -29,7 +29,7 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 
@@ -40,23 +40,23 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
  */
 public interface StompConnection {
 
-    Future<StompFrames> send(String destination, Buffer payload);
+    CompletableFuture<StompFrames> send(String destination, Buffer payload);
 
-    Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers);
+    CompletableFuture<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers);
 
-    Future<String> subscribe(String destination, Handler<StompFrames> handler);
+    CompletableFuture<String> subscribe(String destination, Handler<StompFrames> handler);
 
-    Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler);
+    CompletableFuture<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler);
 
-    Future<StompFrames> unsubscribe(String subscriptionId);
+    CompletableFuture<StompFrames> unsubscribe(String subscriptionId);
 
-    Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers);
+    CompletableFuture<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers);
 
-    Future<StompFrames> ack(String messageId);
+    CompletableFuture<StompFrames> ack(String messageId);
 
-    Future<StompFrames> nack(String messageId);
+    CompletableFuture<StompFrames> nack(String messageId);
 
-    Future<StompFrames> disconnect();
+    CompletableFuture<StompFrames> disconnect();
 
     @CanIgnoreReturnValue
     StompConnection errorHandler(Handler<StompFrames> handler);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompConnection.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/TitanStompConnection.java
@@ -33,7 +33,7 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * @author yun
@@ -73,70 +73,74 @@ public final class TitanStompConnection implements StompConnection {
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload) {
         validateDestination(destination);
         return connection.send(destination, payload)
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
         validateDestination(destination);
         return connection.send(destination, payload, toHeaders(headers))
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(String destination, Handler<StompFrames> handler) {
         return subscribe(destination, Map.of(), handler);
     }
 
     @Override
-    public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(
+            String destination,
+            Map<Elements, String> headers,
+            Handler<StompFrames> handler
+    ) {
         validateDestination(destination);
         StompHeaders stompHeaders = toHeaders(headers);
         String subscriptionId = stompHeaders.getOrDefault(Elements.ID, destination);
         return connection.subscribe(destination, stompHeaders, handler::handle)
                 .map(frame -> subscriptionId)
-                .future();
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId) {
         return unsubscribe(subscriptionId, Map.of());
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
         StompHeaders stompHeaders = toHeaders(headers);
         stompHeaders.put(Elements.ID, subscriptionId);
         return connection.unsubscribe(subscriptionId, stompHeaders)
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> ack(String messageId) {
+    public CompletableFuture<StompFrames> ack(String messageId) {
         return connection.ack(messageId)
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> nack(String messageId) {
+    public CompletableFuture<StompFrames> nack(String messageId) {
         return connection.nack(messageId)
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> disconnect() {
+    public CompletableFuture<StompFrames> disconnect() {
         beforeDisconnect.run();
         return connection.disconnect()
-                .map(f -> (StompFrames) f)
-                .future();
+                .map(StompFrames::from)
+                .toCompletableFuture();
     }
 
     @Override

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompConnection.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/client/VertxStompConnection.java
@@ -24,7 +24,6 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.transport.stomp.client;
 
 import io.vertx.ext.stomp.StompClientConnection;
-import org.jspecify.annotations.NullMarked;
 import org.traffichunter.titan.core.codec.stomp.StompFrames;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 import org.traffichunter.titan.core.codec.stomp.vertx.VertxStompFrame;
@@ -35,10 +34,6 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * @author yun
@@ -78,58 +73,62 @@ public final class VertxStompConnection implements StompConnection {
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload) {
         validateDestination(destination);
         return toFuture(connection.send(destination, toVertxBuffer(payload)));
     }
 
     @Override
-    public Future<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> send(String destination, Buffer payload, Map<Elements, String> headers) {
         validateDestination(destination);
         return toFuture(connection.send(destination, toVertxHeaders(headers), toVertxBuffer(payload)));
     }
 
     @Override
-    public Future<String> subscribe(String destination, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(String destination, Handler<StompFrames> handler) {
         validateDestination(destination);
-        return VertxFutureWrapper.wrap(connection.subscribe(
+        return connection.subscribe(
                 destination,
                 frame -> handler.handle(VertxStompFrame.wrap(frame))
-        ));
+        ).toCompletionStage().toCompletableFuture();
     }
 
     @Override
-    public Future<String> subscribe(String destination, Map<Elements, String> headers, Handler<StompFrames> handler) {
+    public CompletableFuture<String> subscribe(
+            String destination,
+            Map<Elements, String> headers,
+            Handler<StompFrames> handler
+    ) {
         validateDestination(destination);
-        return VertxFutureWrapper.wrap(connection.subscribe(
+        return connection.subscribe(
                 destination,
                 toVertxHeaders(headers),
                 frame -> handler.handle(VertxStompFrame.wrap(frame))
-        ));
+        ).toCompletionStage().toCompletableFuture();
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId) {
         return toFuture(connection.unsubscribe(subscriptionId));
     }
 
     @Override
-    public Future<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
+    public CompletableFuture<StompFrames> unsubscribe(String subscriptionId, Map<Elements, String> headers) {
         return toFuture(connection.unsubscribe(subscriptionId, toVertxHeaders(headers)));
     }
 
     @Override
-    public Future<StompFrames> ack(String messageId) {
+    public CompletableFuture<StompFrames> ack(String messageId) {
         return toFuture(connection.ack(messageId));
     }
 
     @Override
-    public Future<StompFrames> nack(String messageId) {
+    public CompletableFuture<StompFrames> nack(String messageId) {
         return toFuture(connection.nack(messageId));
     }
 
     @Override
-    public Future<StompFrames> disconnect() {
+    public CompletableFuture<StompFrames> disconnect() {
         beforeDisconnect.run();
         return toFuture(connection.disconnect());
     }
@@ -169,45 +168,12 @@ public final class VertxStompConnection implements StompConnection {
         return connection.isConnected();
     }
 
-    @NullMarked
-    private record VertxFutureWrapper<V>(CompletableFuture<V> future) implements Future<V> {
-
-        private VertxFutureWrapper(io.vertx.core.Future<V> future) {
-            this(future.toCompletionStage().toCompletableFuture());
-        }
-
-        static <V> Future<V> wrap(io.vertx.core.Future<V> future) {
-            return new VertxFutureWrapper<>(future);
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            return future.cancel(mayInterruptIfRunning);
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return future.isCancelled();
-        }
-
-        @Override
-        public boolean isDone() {
-            return future.isDone();
-        }
-
-        @Override
-        public V get() throws InterruptedException, ExecutionException {
-            return future.get();
-        }
-
-        @Override
-        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            return future.get(timeout, unit);
-        }
-    }
-
-    private static Future<StompFrames> toFuture(io.vertx.core.Future<io.vertx.ext.stomp.Frame> future) {
-        return VertxFutureWrapper.wrap(future.map(VertxStompFrame::wrap));
+    private static CompletableFuture<StompFrames> toFuture(
+            io.vertx.core.Future<io.vertx.ext.stomp.Frame> future
+    ) {
+        return future.map(frame -> (StompFrames) VertxStompFrame.wrap(frame))
+                .toCompletionStage()
+                .toCompletableFuture();
     }
 
     private static io.vertx.core.buffer.Buffer toVertxBuffer(Buffer buffer) {


### PR DESCRIPTION
## Motivation:

The STOMP client APIs returned the generic JDK `Future`, which limited asynchronous composition and required transport-specific wrappers. Promise mapping also allowed nullable results to reach mappers despite the mapper contract being non-null.

## Modification:

- Added a `CompletableFuture` bridge to Titan `Promise` and made `map` and `thenCompose` fail explicitly when no result is available.
- Changed transport-neutral STOMP connection APIs to return `CompletableFuture`.
- Adapted Titan and Vert.x STOMP connections without exposing transport-specific future types.
- Updated Spring `StompOperations`, `TitanTemplate`, and their tests to use `CompletableFuture`.
- Added Promise tests for null results and failure propagation.

## Result:

STOMP operations can now be composed through standard `CompletableFuture` APIs while preserving transport-neutral contracts and explicit null handling.

Validated with:

`./gradlew :core:test :titan-stomp:test :titan-spring-client:test --no-configuration-cache`
