### PR TITLE
Isolate channel failures in the I/O event loop

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * @author yun gkdbssla97
+ * @author yun, gkdbssla97
  */
 @Slf4j
 public final class ChannelInBoundHandlerChainImpl implements ChannelInBoundHandlerChain {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
@@ -70,9 +70,9 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
             NetChannel channel = (NetChannel) key.attachment();
             ChannelHandlerChain chain = channel.chain();
 
-            if (key.isConnectable()) {
-                chain.processChannelConnecting(channel);
-                try {
+            try {
+                if (key.isConnectable()) {
+                    chain.processChannelConnecting(channel);
                     if(channel.finishConnect()) {
                         if (channel instanceof NewIONetChannel nioNetChannel) {
                             nioNetChannel.completeConnect();
@@ -86,20 +86,41 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
 
                         ((AbstractChannel) channel).accept(channel);
                     }
-                } catch (Exception e) {
-                    log.error("Failed connect", e);
+                } else if (key.isReadable()) {
+                    processRead(channel, chain);
+                } else if (key.isWritable()) {
+                    channel.flush();
                 }
-            } else if (key.isReadable()) {
-                Buffer buffer = Buffer.alloc(BufferUtils.DEFAULT_INITIAL_CAPACITY, BufferUtils.DEFAULT_MAX_CAPACITY);
-                int read = channel.read(buffer);
-                if (read > 0) {
-                    chain.processChannelRead(channel, buffer);
+            } catch (Exception e) {
+                if (channel.isClosed()) {
+                    log.debug("Ignoring I/O event for closed channel. channelId={}", channel.id());
                 } else {
-                    buffer.release();
+                    log.error("Failed to process I/O event. channelId={}", channel.id(), e);
                 }
-            } else if (key.isWritable()) {
-                channel.flush();
+                key.cancel();
+                try {
+                    channel.close();
+                } catch (Exception closeError) {
+                    log.error("Failed to close channel after I/O error. channelId={}", channel.id(), closeError);
+                }
             }
+        }
+    }
+
+    private void processRead(NetChannel channel, ChannelHandlerChain chain) {
+        Buffer buffer = Buffer.alloc(BufferUtils.DEFAULT_INITIAL_CAPACITY, BufferUtils.DEFAULT_MAX_CAPACITY);
+        final int read;
+        try {
+            read = channel.read(buffer);
+        } catch (Exception e) {
+            buffer.release();
+            throw e;
+        }
+
+        if (read > 0) {
+            chain.processChannelRead(channel, buffer);
+        } else {
+            buffer.release();
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
  * {@link IOEventLoop}, while {@link ChannelWriteBuffer} keeps partially written buffers until
  * the socket becomes writable again.</p>
  *
- * @author yun gkdbssla97
+ * @author yun, gkdbssla97
  */
 @Slf4j
 public class NewIONetChannel extends AbstractChannel implements NetChannel {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -72,7 +72,8 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
             throw new ChannelException("Channel is closed");
         }
 
-        connectPromise = eventLoop().newPromise(this);
+        ChannelPromise promise = eventLoop().newPromise(this);
+        connectPromise = promise;
 
         if(connect0(remoteAddress)) {
             chain().processChannelConnecting(this);
@@ -86,14 +87,14 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         if(timeOut > 0) {
             ScheduledPromise<?> timeoutPromise = eventLoop().schedule(
                 () -> {
-                    if (connectPromise.isDone()) {
+                    if (promise.isDone()) {
                         return;
                     }
-                    connectPromise.fail(new ChannelException("Connect timeout"));
+                    promise.fail(new ChannelException("Connect timeout"));
                     close();
                 }, timeOut, timeUnit);
 
-            connectPromise.addListener(f -> timeoutPromise.cancel());
+            promise.addListener(f -> timeoutPromise.cancel());
         }
     }
 

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 /**
  * Verifies that ChannelInBoundHandlerChainImpl releases the buffer when no next handler exists.
  *
- * @author yun gkdbssla97
+ * @author yun, gkdbssla97
  */
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class ChannelInBoundHandlerChainImplTest {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -38,7 +38,7 @@ import java.util.List;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 
 /**
- * @author yun gkdbssla97
+ * @author yun, gkdbssla97
  */
 @Slf4j
 public class StompChannelDecoder extends ChannelDecoder {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -172,7 +172,11 @@ public final class StompServer {
             task.cancel();
             inactiveConnectionCleanupTask = null;
         }
-        inetServer.shutdown(timeout, unit);
+        try {
+            serverConnection.close();
+        } finally {
+            inetServer.shutdown(timeout, unit);
+        }
     }
 
     public boolean isShutdown() {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DisplayNameGenerator.*;
 
 /**
- * @author yun gkdbssla97
+ * @author yun, gkdbssla97
  */
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class StompChannelDecoderTest {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
@@ -26,7 +26,6 @@ package org.traffichunter.titan.core.transport.stomp;
 import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -52,8 +51,6 @@ import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.Priority;
-import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
-import org.traffichunter.titan.core.transport.stomp.client.StompConnection;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
@@ -87,36 +84,6 @@ class StompIntegrationTest {
             assertThat(client.channel().isConnected()).isTrue();
             assertThat(client.channel().session()).isNotNull();
             assertThat(client.remoteAddress()).isNotNull();
-        } finally {
-            client.shutdown();
-        }
-    }
-
-    @Test
-    void stomp_client_reconnects_after_unexpected_connection_close(StompTestServer testServer) throws Exception {
-        StompClientOption option = StompClientOption.builder()
-                .host(testServer.host())
-                .port(testServer.port())
-                .reconnectPolicy(RetryPolicy.fixed(
-                        RetryPolicy.UNLIMITED_ATTEMPTS,
-                        Duration.ofMillis(10)
-                ))
-                .build();
-        TitanStompClient client = TitanStompClient.open(clientGroups(), option);
-
-        try {
-            client.start();
-            StompConnection initialOperations = client.connect().get(3, TimeUnit.SECONDS);
-
-            client.channel().close();
-
-            // Reconnect drives a full TCP teardown + reconnect cycle on a background
-            // event loop, so allow generous slack for slower/loaded CI runners.
-            await().atMost(10, TimeUnit.SECONDS)
-                    .untilAsserted(() -> {
-                        assertThat(client.connection()).isNotSameAs(initialOperations);
-                        assertThat(client.connection().isConnected()).isTrue();
-                    });
         } finally {
             client.shutdown();
         }

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompReconnectIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompReconnectIntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
+import org.traffichunter.titan.core.transport.option.InetServerOption;
+import org.traffichunter.titan.core.transport.stomp.client.StompConnection;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class StompReconnectIntegrationTest {
+
+    private static final String HOST = "127.0.0.1";
+
+    @Test
+    void client_reconnects_after_server_restart() throws Exception {
+        StompServer server = startServer(0);
+        int port = localPort(server);
+        TitanStompClient client = startClient(port);
+
+        try {
+            StompConnection initialConnection = client.connect().get(3, SECONDS);
+            StompServer initialServer = server;
+            await().atMost(3, SECONDS)
+                    .untilAsserted(() -> assertThat(initialServer.connection().connections()).hasSize(1));
+
+            server.shutdown();
+            await().atMost(3, SECONDS)
+                    .untilAsserted(() -> assertThat(initialConnection.isConnected()).isFalse());
+
+            server = startServer(port);
+
+            StompServer restartedServer = server;
+            await().atMost(10, SECONDS)
+                    .untilAsserted(() -> {
+                        assertThat(restartedServer.connection().connections()).hasSize(1);
+                        assertThat(client.connection()).isNotSameAs(initialConnection);
+                        assertThat(client.connection().isConnected()).isTrue();
+                    });
+        } finally {
+            client.shutdown();
+            if (!server.isShutdown()) {
+                server.shutdown();
+            }
+        }
+    }
+
+    private static StompServer startServer(int port) throws Exception {
+        InetServerOption inetOption = InetServerOption.builder()
+                .reuseAddress(true)
+                .childReuseAddress(true)
+                .build();
+        StompServerOption option = StompServerOption.builder()
+                .inetServerOption(inetOption)
+                .build();
+        StompServer server = StompServer.open(EventLoopGroups.singleGroup(), option);
+        server.start();
+        server.listen(HOST, port).get(3, SECONDS);
+        return server;
+    }
+
+    private static TitanStompClient startClient(int port) {
+        StompClientOption option = StompClientOption.builder()
+                .host(HOST)
+                .port(port)
+                .reconnectPolicy(RetryPolicy.fixed(
+                        RetryPolicy.UNLIMITED_ATTEMPTS,
+                        Duration.ofMillis(10)
+                ))
+                .build();
+        TitanStompClient client = TitanStompClient.open(EventLoopGroups.singleGroup(), option);
+        client.start();
+        return client;
+    }
+
+    private static int localPort(StompServer server) {
+        SocketAddress address = server.connection().channel().localAddress();
+        if (address instanceof InetSocketAddress inetAddress) {
+            return inetAddress.getPort();
+        }
+        throw new IllegalStateException("STOMP server has no local address");
+    }
+}


### PR DESCRIPTION
## Motivation:

A channel read or write failure could escape the secondary I/O processing loop and terminate the shared event-loop thread that owns the channel. Other event-loop instances remained active, but every channel assigned to the affected loop could no longer process I/O. The reconnect test also simulated failure by directly closing the client channel, which did not represent an actual remote server outage.

## Modification:

- Isolate connect, read, and write failures per selected channel and keep processing remaining I/O events on the same event-loop thread.
- Release allocated read buffers when channel reads fail and isolate errors raised while closing failed channels.
- Keep the connect timeout promise in a non-null local reference for asynchronous callbacks.
- Close active STOMP server connections during shutdown.
- Replace the direct client-channel close test with an isolated server shutdown and restart reconnect test.
- Normalize joint author attribution.

## Result:

A single channel failure now closes only the affected channel instead of terminating its owning event-loop thread. Reconnect behavior is also verified against a realistic server restart.

Validation:
- `./gradlew :core:test :titan-stomp:test --no-configuration-cache`