### PR TITLE
Prepare release 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,32 @@ repositories {
 Spring client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.1")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.2")
 ```
 
 STOMP client/server:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.1")
+implementation("org.traffichunter.titan:titan-stomp:0.7.2")
 ```
 
 Fanout support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-fanout:0.7.1")
+implementation("org.traffichunter.titan:titan-fanout:0.7.2")
 ```
 
 Monitoring support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-monitor:0.7.1")
+implementation("org.traffichunter.titan:titan-monitor:0.7.2")
 ```
 
 Bootstrap/runtime support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.1")
-implementation("org.traffichunter.titan:titan-core:0.7.1")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.2")
+implementation("org.traffichunter.titan:titan-core:0.7.2")
 ```
 
 ## Standalone Server
@@ -70,15 +70,15 @@ Download the executable server jar from GitHub Releases.
 Using `curl`:
 
 ```bash
-curl -L -o titan-server-0.7.1.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.1/titan-server-0.7.1.jar
+curl -L -o titan-server-0.7.2.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.2/titan-server-0.7.2.jar
 ```
 
 Using `wget`:
 
 ```bash
-wget -O titan-server-0.7.1.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.1/titan-server-0.7.1.jar
+wget -O titan-server-0.7.2.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.2/titan-server-0.7.2.jar
 ```
 
 Create `titan-env.yml`.
@@ -109,7 +109,7 @@ titan:
 Run Titan.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.1.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.2.jar
 ```
 
 Inspect the running server from a terminal. The release page provides
@@ -118,7 +118,7 @@ CLI from source while developing.
 
 ```bash
 # prebuilt archive example
-tar -xzf titan-cli-0.7.1-linux-amd64.tar.gz
+tar -xzf titan-cli-0.7.2-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 
 # source checkout example

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.1")
+implementation("org.traffichunter.titan:titan-stomp:0.7.2")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.1")
-implementation("org.traffichunter.titan:titan-core:0.7.1")
-implementation("org.traffichunter.titan:titan-stomp:0.7.1")
-implementation("org.traffichunter.titan:titan-fanout:0.7.1")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.2")
+implementation("org.traffichunter.titan:titan-core:0.7.2")
+implementation("org.traffichunter.titan:titan-stomp:0.7.2")
+implementation("org.traffichunter.titan:titan-fanout:0.7.2")
 ```
 
 ### `titan-env.yml`

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.1")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.2")
 ```
 
 ## Enable Titan


### PR DESCRIPTION
## Motivation:

Prepare the project documentation for the 0.7.2 stability release after the event-loop isolation and reconnect fixes were merged.

## Modification:

- Update Maven dependency examples from 0.7.1 to 0.7.2.
- Update standalone server download and execution examples.
- Update the prebuilt Titan CLI archive example.

## Result:

README and documentation examples now reference the artifacts that will be published by the 0.7.2 release.

Validation:
- `./gradlew --no-daemon -PversionName=0.7.2 clean build --no-configuration-cache`
- `cd titan-cli && go test ./...`