### PR TITLE
Refine file handle API

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.core.util.buffer.BufferUtils;
+import org.traffichunter.titan.core.util.buffer.Buffers;
 import org.traffichunter.titan.core.util.event.EventLoopConstants;
 
 /**
@@ -108,7 +108,7 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
     }
 
     private void processRead(NetChannel channel, ChannelHandlerChain chain) {
-        Buffer buffer = Buffer.alloc(BufferUtils.DEFAULT_INITIAL_CAPACITY, BufferUtils.DEFAULT_MAX_CAPACITY);
+        Buffer buffer = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, Buffers.DEFAULT_MAX_CAPACITY);
         final int read;
         try {
             read = channel.read(buffer);

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
@@ -37,18 +37,19 @@ import org.traffichunter.titan.core.util.Clearable;
  * @author yun
  */
 @NullMarked
+@Deprecated(since = "0.7.2")
 public final class BufferAccumulator implements Clearable {
 
     private @Nullable Buffer accumulator;
     private final int maxAccumulatedSize;
 
     public BufferAccumulator() {
-        this(BufferUtils.DEFAULT_MAX_CAPACITY);
+        this(Buffers.DEFAULT_MAX_CAPACITY);
     }
 
     public BufferAccumulator(int maxAccumulatedSize) {
         this.maxAccumulatedSize = maxAccumulatedSize;
-        this.accumulator = Buffer.alloc(BufferUtils.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
+        this.accumulator = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
     }
 
     /**
@@ -161,7 +162,7 @@ public final class BufferAccumulator implements Clearable {
         if (accumulator != null) {
             accumulator.release();
         }
-        accumulator = Buffer.alloc(BufferUtils.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
+        accumulator = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
     }
 
     /**

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffers.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffers.java
@@ -1,0 +1,58 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+import io.netty.buffer.ByteBuf;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Shared buffer sizing defaults.
+ *
+ * @author yun
+ */
+public final class Buffers {
+
+    public static final int DEFAULT_INITIAL_CAPACITY = 4096;
+    public static final int DEFAULT_MAX_CAPACITY = 65536;
+
+    public static ByteBuffer readableByteBuffer(Buffer source) {
+        ByteBuf byteBuf = source.byteBuf();
+        return byteBuf.nioBuffer(byteBuf.readerIndex(), byteBuf.readableBytes());
+    }
+
+    public static ByteBuffer writableByteBuffer(Buffer destination) {
+        ByteBuf byteBuf = destination.byteBuf();
+        return byteBuf.nioBuffer(byteBuf.writerIndex(), byteBuf.writableBytes());
+    }
+
+    public static void updateWriterIndex(Buffer destination, int read) {
+        if (read > 0) {
+            ByteBuf byteBuf = destination.byteBuf();
+            byteBuf.writerIndex(byteBuf.writerIndex() + read);
+        }
+    }
+
+    private Buffers() {}
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
@@ -1,0 +1,91 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.file;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.nio.channels.FileLock;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * Opened file resource backed by a file channel.
+ *
+ * @author yun
+ */
+public interface FileHandle extends AutoCloseable {
+
+    static FileHandle open(Path path) {
+        FileUtils.createParentDirectories(path);
+        return new LocalFileHandle(path, CREATE, READ, WRITE);
+    }
+
+    static FileHandle openReadOnly(Path path) {
+        FileUtils.createParentDirectories(path);
+        return new LocalFileHandle(path, READ);
+    }
+
+    static FileHandle newOpen(Path path) {
+        FileUtils.createParentDirectories(path);
+        return new LocalFileHandle(path, CREATE_NEW, READ, WRITE);
+    }
+
+    static FileHandle open(Path path, OpenOption... options) {
+        FileUtils.createParentDirectories(path);
+        return new LocalFileHandle(path, options);
+    }
+
+    Path path();
+
+    Buffer readAll();
+
+    Buffer read(long position, int length);
+
+    Instant lastModified();
+
+    long size();
+
+    void write(Buffer source);
+
+    void write(long position, Buffer source);
+
+    long append(Buffer source);
+
+    void truncate(long size);
+
+    void force(boolean metadata);
+
+    FileLock lock();
+
+    @Nullable FileLock tryLock();
+
+    @Override
+    void close();
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
@@ -36,7 +36,12 @@ import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * Opened file resource backed by a file channel.
+ * High-level handle for a single opened file.
+ *
+ * <p>The handle exposes Titan {@link Buffer} based read and write operations instead of leaking
+ * {@code FileChannel} position management to callers. Methods that receive a {@code Buffer} never
+ * release it. Methods that return a {@code Buffer} allocate a new buffer and transfer release
+ * ownership to the caller.</p>
  *
  * @author yun
  */
@@ -64,18 +69,45 @@ public interface FileHandle extends AutoCloseable {
 
     Path path();
 
+    /**
+     * Reads the whole file into a newly allocated buffer.
+     *
+     * @return buffer owned by the caller
+     */
     Buffer readAll();
 
+    /**
+     * Reads up to {@code length} bytes from {@code position} into a newly allocated buffer.
+     *
+     * @return buffer owned by the caller
+     */
     Buffer read(long position, int length);
 
     Instant lastModified();
 
     long size();
 
+    /**
+     * Writes the readable bytes of {@code source} at the handle's current file position.
+     *
+     * <p>The source buffer remains owned by the caller and is not released.</p>
+     */
     void write(Buffer source);
 
+    /**
+     * Writes the readable bytes of {@code source} starting at {@code position}.
+     *
+     * <p>The source buffer remains owned by the caller and is not released.</p>
+     */
     void write(long position, Buffer source);
 
+    /**
+     * Appends the readable bytes of {@code source} to the end of the file.
+     *
+     * <p>The source buffer remains owned by the caller and is not released.</p>
+     *
+     * @return start offset where the bytes were appended
+     */
     long append(Buffer source);
 
     void truncate(long size);

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileIOException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileIOException.java
@@ -21,17 +21,18 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-package org.traffichunter.titan.core.util.buffer;
+package org.traffichunter.titan.core.util.file;
 
 /**
- * Shared buffer sizing defaults.
- *
  * @author yun
  */
-public final class BufferUtils {
+public class FileIOException extends RuntimeException {
 
-    public static final int DEFAULT_INITIAL_CAPACITY = 4096;
-    public static final int DEFAULT_MAX_CAPACITY = 65536;
+    public FileIOException(String message) {
+        super(message);
+    }
 
-    private BufferUtils() {}
+    public FileIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileUtils.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileUtils.java
@@ -41,6 +41,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 /**
  * File-system utilities used by backup and persistence code.
  *
+ * <p>Methods that receive a {@link Buffer} never release it. Methods that return a
+ * {@code Buffer} allocate a new buffer and transfer release ownership to the caller.</p>
+ *
  * @author yun
  */
 public final class FileUtils {
@@ -128,18 +131,33 @@ public final class FileUtils {
         }
     }
 
+    /**
+     * Reads the whole file into a newly allocated buffer.
+     *
+     * @return buffer owned by the caller
+     */
     public static Buffer read(Path path) {
         try (FileHandle file = FileHandle.openReadOnly(path)) {
             return file.readAll();
         }
     }
 
+    /**
+     * Reads up to {@code length} bytes from {@code position} into a newly allocated buffer.
+     *
+     * @return buffer owned by the caller
+     */
     public static Buffer read(Path path, long position, int length) {
         try (FileHandle file = FileHandle.openReadOnly(path)) {
             return file.read(position, length);
         }
     }
 
+    /**
+     * Replaces the file content with the readable bytes of {@code content}.
+     *
+     * <p>The content buffer remains owned by the caller and is not released.</p>
+     */
     public static void write(Path path, Buffer content) {
         try (FileHandle file = FileHandle.open(path, CREATE, WRITE, TRUNCATE_EXISTING)) {
             file.write(content);
@@ -147,6 +165,13 @@ public final class FileUtils {
         }
     }
 
+    /**
+     * Appends the readable bytes of {@code content} to the file.
+     *
+     * <p>The content buffer remains owned by the caller and is not released.</p>
+     *
+     * @return start offset where the bytes were appended
+     */
     public static long append(Path path, Buffer content) {
         try (FileHandle file = FileHandle.open(path, CREATE, READ, WRITE)) {
             long offset = file.append(content);
@@ -155,6 +180,12 @@ public final class FileUtils {
         }
     }
 
+    /**
+     * Atomically replaces the file content with the readable bytes of {@code content}.
+     *
+     * <p>The content buffer remains owned by the caller and is not released. Temporary files are
+     * cleaned up when the replace step is not reached.</p>
+     */
     public static void atomicWrite(Path path, Buffer content) {
         Path directory = parentOrCurrent(path);
         Path temp = createTempFile(directory, "." + path.getFileName(), ".tmp");

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileUtils.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileUtils.java
@@ -1,0 +1,185 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.file;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.IOException;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * File-system utilities used by backup and persistence code.
+ *
+ * @author yun
+ */
+public final class FileUtils {
+
+    public static void createParentDirectories(Path path) {
+        Path parent = path.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new FileIOException("Failed to create parent directories: " + path, e);
+            }
+        }
+    }
+
+    public static Path parentOrCurrent(Path path) {
+        Path parent = path.getParent();
+        return parent == null ? Path.of(".") : parent;
+    }
+
+    public static void createDirectories(Path directory) {
+        try {
+            Files.createDirectories(directory);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to create directories: " + directory, e);
+        }
+    }
+
+    public static boolean exists(Path path) {
+        return Files.exists(path);
+    }
+
+    public static boolean isFile(Path path) {
+        return Files.isRegularFile(path);
+    }
+
+    public static boolean isDirectory(Path path) {
+        return Files.isDirectory(path);
+    }
+
+    public static void delete(Path path) {
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to delete file: " + path, e);
+        }
+    }
+
+    public static void deleteIfExists(Path path) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to delete file: " + path, e);
+        }
+    }
+
+    public static void move(Path source, Path target, CopyOption... options) {
+        createParentDirectories(target);
+        try {
+            Files.move(source, target, options);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to move file: " + source + " -> " + target, e);
+        }
+    }
+
+    public static void copy(Path source, Path target, CopyOption... options) {
+        createParentDirectories(target);
+        try {
+            Files.copy(source, target, options);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to copy file: " + source + " -> " + target, e);
+        }
+    }
+
+    public static void atomicReplace(Path target, Path replacement) {
+        move(replacement, target, ATOMIC_MOVE, REPLACE_EXISTING);
+    }
+
+    public static Path createTempFile(Path directory, String prefix, String suffix) {
+        createDirectories(directory);
+        try {
+            return Files.createTempFile(directory, prefix, suffix);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to create temp file: " + directory, e);
+        }
+    }
+
+    public static Buffer read(Path path) {
+        try (FileHandle file = FileHandle.openReadOnly(path)) {
+            return file.readAll();
+        }
+    }
+
+    public static Buffer read(Path path, long position, int length) {
+        try (FileHandle file = FileHandle.openReadOnly(path)) {
+            return file.read(position, length);
+        }
+    }
+
+    public static void write(Path path, Buffer content) {
+        try (FileHandle file = FileHandle.open(path, CREATE, WRITE, TRUNCATE_EXISTING)) {
+            file.write(content);
+            file.force(true);
+        }
+    }
+
+    public static long append(Path path, Buffer content) {
+        try (FileHandle file = FileHandle.open(path, CREATE, READ, WRITE)) {
+            long offset = file.append(content);
+            file.force(true);
+            return offset;
+        }
+    }
+
+    public static void atomicWrite(Path path, Buffer content) {
+        Path directory = parentOrCurrent(path);
+        Path temp = createTempFile(directory, "." + path.getFileName(), ".tmp");
+        boolean moved = false;
+        try {
+            try (FileHandle file = FileHandle.open(temp, WRITE, TRUNCATE_EXISTING)) {
+                file.write(content);
+                file.force(true);
+            }
+            atomicReplace(path, temp);
+            moved = true;
+        } finally {
+            if (!moved) {
+                deleteIfExists(temp);
+            }
+        }
+    }
+
+    public static List<Path> list(Path directory) {
+        try (Stream<Path> paths = Files.list(directory)) {
+            return paths.toList();
+        } catch (IOException e) {
+            throw new FileIOException("Failed to list directory: " + directory, e);
+        }
+    }
+
+    private FileUtils() { }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/LocalFileHandle.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/LocalFileHandle.java
@@ -1,0 +1,200 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.file;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.time.Instant;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.buffer.Buffers;
+
+/**
+ * Local {@link FileHandle} implementation backed by {@link FileChannel}.
+ *
+ * @author yun
+ */
+final class LocalFileHandle implements FileHandle {
+
+    private final Path path;
+    private final FileChannel fileChannel;
+
+    LocalFileHandle(Path path, OpenOption... options) {
+        this.path = path;
+        try {
+            this.fileChannel = FileChannel.open(path, options);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to open file channel: " + path, e);
+        }
+    }
+
+    @Override
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public Buffer readAll() {
+        long size = size();
+        if (size > Integer.MAX_VALUE) {
+            throw new FileIOException("File is too large to read into a Buffer: " + path);
+        }
+        return read(0, (int) size);
+    }
+
+    @Override
+    public Buffer read(long position, int length) {
+        Assert.checkArgument(position >= 0, "position must be greater than or equal to zero");
+        Assert.checkArgument(length >= 0, "length must be greater than or equal to zero");
+
+        Buffer destination = Buffer.alloc(length);
+        try {
+            ByteBuffer buffer = Buffers.writableByteBuffer(destination);
+            long nextPosition = position;
+            while (buffer.hasRemaining()) {
+                int read = fileChannel.read(buffer, nextPosition);
+                if (read < 0) {
+                    break;
+                }
+                Buffers.updateWriterIndex(destination, read);
+                nextPosition += read;
+            }
+            return destination;
+        } catch (IOException e) {
+            destination.release();
+            throw new FileIOException("Failed to read file: " + path, e);
+        }
+    }
+
+    @Override
+    public Instant lastModified() {
+        try {
+            return Instant.ofEpochMilli(Files.getLastModifiedTime(path).toMillis());
+        } catch (IOException e) {
+            throw new FileIOException("Failed to get last modified time: " + path, e);
+        }
+    }
+
+    @Override
+    public long size() {
+        try {
+            return fileChannel.size();
+        } catch (IOException e) {
+            throw new FileIOException("Failed to get file channel size: " + path, e);
+        }
+    }
+
+    @Override
+    public void write(Buffer source) {
+        ByteBuffer buffer = Buffers.readableByteBuffer(source);
+        while (buffer.hasRemaining()) {
+            write(buffer);
+        }
+    }
+
+    @Override
+    public void write(long position, Buffer source) {
+        Assert.checkArgument(position >= 0, "position must be greater than or equal to zero");
+
+        ByteBuffer buffer = Buffers.readableByteBuffer(source);
+        long nextPosition = position;
+        while (buffer.hasRemaining()) {
+            nextPosition += write(buffer, nextPosition);
+        }
+    }
+
+    @Override
+    public synchronized long append(Buffer source) {
+        long offset = size();
+        write(offset, source);
+        return offset;
+    }
+
+    @Override
+    public void truncate(long size) {
+        try {
+            fileChannel.truncate(size);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to truncate file: " + path, e);
+        }
+    }
+
+    @Override
+    public void force(boolean metadata) {
+        try {
+            fileChannel.force(metadata);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to force file: " + path, e);
+        }
+    }
+
+    @Override
+    public FileLock lock() {
+        try {
+            return fileChannel.lock();
+        } catch (IOException e) {
+            throw new FileIOException("Failed to lock file: " + path, e);
+        }
+    }
+
+    @Override
+    public @Nullable FileLock tryLock() {
+        try {
+            return fileChannel.tryLock();
+        } catch (IOException e) {
+            throw new FileIOException("Failed to try lock file: " + path, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            fileChannel.close();
+        } catch (IOException e) {
+            throw new FileIOException("Failed to close file channel: " + path, e);
+        }
+    }
+
+    private int write(ByteBuffer source) {
+        try {
+            return fileChannel.write(source);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to write file: " + path, e);
+        }
+    }
+
+    private int write(ByteBuffer source, long position) {
+        try {
+            return fileChannel.write(source, position);
+        } catch (IOException e) {
+            throw new FileIOException("Failed to write file: " + path, e);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.util.file;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileUtilsTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileUtilsTest.java
@@ -1,0 +1,185 @@
+package org.traffichunter.titan.core.test.implementation;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.file.FileHandle;
+import org.traffichunter.titan.core.util.file.FileUtils;
+
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * Verifies local file management operations used by backup and persistence.
+ *
+ * @author yun
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class FileUtilsTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void create_directories_and_open_create_file() {
+        Path file = tempDir.resolve("data/queue.log");
+        Buffer content = Buffer.alloc("hello", UTF_8);
+
+        try (FileHandle resource = FileHandle.open(file, CREATE, WRITE)) {
+            resource.write(content);
+        } finally {
+            content.release();
+        }
+
+        assertThat(FileUtils.exists(file)).isTrue();
+        assertThat(FileUtils.isFile(file)).isTrue();
+    }
+
+    @Test
+    void append_returns_start_offset_and_read_reads_positioned_bytes() {
+        Path file = tempDir.resolve("queue.log");
+        Buffer first = Buffer.alloc("hello", UTF_8);
+        Buffer second = Buffer.alloc(" titan", UTF_8);
+        Buffer buffer = null;
+
+        try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE)) {
+            long firstOffset = resource.append(first);
+            long secondOffset = resource.append(second);
+
+            buffer = resource.read(0, 11);
+
+            assertThat(firstOffset).isZero();
+            assertThat(secondOffset).isEqualTo(5);
+            assertThat(resource.lastModified()).isNotNull();
+            assertThat(buffer.toString(UTF_8)).isEqualTo("hello titan");
+        } finally {
+            first.release();
+            second.release();
+            if (buffer != null) {
+                buffer.release();
+            }
+        }
+    }
+
+    @Test
+    void positioned_write_replaces_content_at_offset() throws Exception {
+        Path file = tempDir.resolve("queue.log");
+        Buffer content = Buffer.alloc("hello", UTF_8);
+        Buffer replacement = Buffer.alloc("y", UTF_8);
+
+        try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE, TRUNCATE_EXISTING)) {
+            resource.write(content);
+            resource.write(0, replacement);
+        } finally {
+            content.release();
+            replacement.release();
+        }
+
+        assertThat(Files.readString(file)).isEqualTo("yello");
+    }
+
+    @Test
+    void truncate_reduces_file_size() {
+        Path file = tempDir.resolve("queue.log");
+        Buffer content = Buffer.alloc("hello", UTF_8);
+
+        try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE, TRUNCATE_EXISTING)) {
+            resource.write(content);
+            resource.truncate(2);
+
+            assertThat(resource.size()).isEqualTo(2);
+        } finally {
+            content.release();
+        }
+    }
+
+    @Test
+    void move_copy_delete_and_list_files() throws Exception {
+        Path source = tempDir.resolve("source.log");
+        Path copied = tempDir.resolve("copy.log");
+        Path moved = tempDir.resolve("nested/moved.log");
+        Files.writeString(source, "data");
+
+        FileUtils.copy(source, copied);
+        FileUtils.move(copied, moved);
+        List<Path> files = FileUtils.list(tempDir);
+        FileUtils.deleteIfExists(source);
+
+        assertThat(FileUtils.exists(moved)).isTrue();
+        assertThat(FileUtils.exists(source)).isFalse();
+        assertThat(files).contains(source);
+    }
+
+    @Test
+    void create_temp_file_creates_file_under_directory() {
+        Path directory = tempDir.resolve("tmp");
+
+        Path temp = FileUtils.createTempFile(directory, "backup-", ".tmp");
+
+        assertThat(temp).hasParent(directory);
+        assertThat(FileUtils.exists(temp)).isTrue();
+    }
+
+    @Test
+    void atomic_write_replaces_file_content() throws Exception {
+        Path file = tempDir.resolve("manifest.json");
+        Files.writeString(file, "old");
+        Buffer content = Buffer.alloc("new", UTF_8);
+
+        try {
+            FileUtils.atomicWrite(file, content);
+        } finally {
+            content.release();
+        }
+
+        assertThat(Files.readString(file)).isEqualTo("new");
+        assertThat(FileUtils.list(tempDir))
+                .noneMatch(fileItem -> fileItem.getFileName().toString().startsWith(".manifest.json")
+                        && fileItem.getFileName().toString().endsWith(".tmp"));
+    }
+
+    @Test
+    void utility_read_write_and_append_handle_whole_file_buffers() {
+        Path file = tempDir.resolve("data.log");
+        Buffer first = Buffer.alloc("hello", UTF_8);
+        Buffer second = Buffer.alloc(" titan", UTF_8);
+        Buffer read = null;
+
+        try {
+            FileUtils.write(file, first);
+            long offset = FileUtils.append(file, second);
+            read = FileUtils.read(file);
+
+            assertThat(offset).isEqualTo(5);
+            assertThat(read.toString(UTF_8)).isEqualTo("hello titan");
+        } finally {
+            first.release();
+            second.release();
+            if (read != null) {
+                read.release();
+            }
+        }
+    }
+
+    @Test
+    void lock_acquires_file_lock() throws Exception {
+        Path file = tempDir.resolve("queue.log");
+
+        try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE);
+             FileLock lock = resource.lock()) {
+            assertThat(lock.isValid()).isTrue();
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation:

The backup and persistence work needs a file abstraction that is slightly higher level than direct FileChannel-style operations. The previous FileManager shape mixed file-system utilities with opened-file state, and ByteBuffer-based APIs made Titan buffer ownership less explicit.

## Modification:

- Replace the FileManager shape with FileHandle and FileUtils.
- Add Buffer-based read, write, append, and atomic write APIs.
- Add Buffers helpers for readable and writable NIO views over Titan Buffer.
- Document Buffer ownership rules: input buffers are not released by file APIs, returned buffers are owned by callers.
- Add FileUtilsTest coverage for file operations and Buffer release expectations.

## Result:

Introduces a higher-level file handling surface for backup and persistence code while keeping Titan Buffer ownership explicit.

Validation:
- ./gradlew test --no-configuration-cache
- ./gradlew :core:test --no-configuration-cache