### PR TITLE
Add append-only backup foundation

### DIFF
--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
@@ -24,7 +24,7 @@
 package org.traffichunter.titan.bootstrap;
 
 import java.util.List;
-import lombok.Builder;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Immutable runtime settings resolved from the bootstrap environment.
@@ -34,17 +34,20 @@ import lombok.Builder;
  * share a {@code Settings} instance without observing accidental caller-side
  * mutation.</p>
  */
-@Builder
 public record Settings(
         List<ServerSettings> servers,
-        MonitorSettings monitor
+        MonitorSettings monitor,
+        BackupSettings backup
 ) {
 
-    public Settings {
-        servers = servers == null ? List.of() : List.copyOf(servers);
-        if (monitor == null) {
-            monitor = MonitorSettings.disabled();
-        }
+    public Settings(
+            @Nullable List<ServerSettings> servers,
+            @Nullable MonitorSettings monitor,
+            @Nullable BackupSettings backup
+    ) {
+        this.servers = servers == null ? List.of() : List.copyOf(servers);
+        this.monitor = monitor == null ? MonitorSettings.disabled() : monitor;
+        this.backup = backup == null ? BackupSettings.disabled() : backup;
     }
 
     public record MonitorSettings(
@@ -59,19 +62,57 @@ public record Settings(
             return new MonitorSettings(false, "127.0.0.1", 7777, "", 8);
         }
 
-        public MonitorSettings {
-            if (host == null || host.isBlank()) {
-                host = "127.0.0.1";
-            }
-            if (port <= 0 || port > 65535) {
-                port = 7777;
-            }
-            if (token == null) {
-                token = "";
-            }
-            if (threadPoolSize <= 0) {
-                threadPoolSize = 8;
-            }
+        public MonitorSettings(
+                boolean enabled,
+                @Nullable String host,
+                int port,
+                @Nullable String token,
+                int threadPoolSize
+        ) {
+            this.enabled = enabled;
+            this.host = host == null || host.isBlank() ? "127.0.0.1" : host;
+            this.port = port <= 0 || port > 65535 ? 7777 : port;
+            this.token = token == null ? "" : token;
+            this.threadPoolSize = threadPoolSize <= 0 ? 8 : threadPoolSize;
+        }
+    }
+
+    public record BackupSettings(
+            boolean enabled,
+            String type,
+            String path,
+            String syncPolicy,
+            String recoveryPolicy
+    ) {
+
+        public static BackupSettings disabled() {
+            return new BackupSettings(false, "aof", "", "every_sec", "load_truncated_tail");
+        }
+
+        public static BackupSettings fromConfig(
+                boolean enabled,
+                @Nullable String type,
+                @Nullable String path,
+                @Nullable String syncPolicy,
+                @Nullable String recoveryPolicy
+        ) {
+            return new BackupSettings(enabled, type, path, syncPolicy, recoveryPolicy);
+        }
+
+        public BackupSettings(
+                boolean enabled,
+                @Nullable String type,
+                @Nullable String path,
+                @Nullable String syncPolicy,
+                @Nullable String recoveryPolicy
+        ) {
+            this.enabled = enabled;
+            this.type = type == null || type.isBlank() ? "aof" : type;
+            this.path = path == null || path.isBlank() ? "" : path;
+            this.syncPolicy = syncPolicy == null || syncPolicy.isBlank() ? "every_sec" : syncPolicy;
+            this.recoveryPolicy = recoveryPolicy == null || recoveryPolicy.isBlank()
+                    ? "load_truncated_tail"
+                    : recoveryPolicy;
         }
     }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
@@ -28,9 +28,11 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.bootstrap.Settings;
 import org.traffichunter.titan.bootstrap.environment.proprerty.RootYamlProperty;
+import org.traffichunter.titan.bootstrap.environment.proprerty.sub.BackupProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.MonitorProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.ServerProperty;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -109,13 +111,27 @@ final class YamlConfigurationInitializer implements ConfigurationInitializer {
                         .map(YamlConfigurationInitializer::mapServer)
                         .toList();
 
-        return Settings.builder()
-                .servers(servers)
-                .monitor(mapMonitor(root.getTitan() == null ? null : root.getTitan().getMonitor()))
-                .build();
+        return new Settings(
+                servers,
+                mapMonitor(root.getTitan() == null ? null : root.getTitan().getMonitor()),
+                mapBackup(root.getTitan() == null ? null : root.getTitan().getBackup())
+        );
     }
 
-    private static Settings.MonitorSettings mapMonitor(final MonitorProperty property) {
+    private static Settings.BackupSettings mapBackup(final @Nullable BackupProperty property) {
+        if (property == null) {
+            return Settings.BackupSettings.disabled();
+        }
+        return Settings.BackupSettings.fromConfig(
+                property.isEnabled(),
+                property.getType(),
+                property.getPath(),
+                property.getSyncPolicy(),
+                property.getRecoveryPolicy()
+        );
+    }
+
+    private static Settings.MonitorSettings mapMonitor(final @Nullable MonitorProperty property) {
         if (property == null) {
             return Settings.MonitorSettings.disabled();
         }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/TitanSubProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/TitanSubProperty.java
@@ -28,6 +28,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.traffichunter.titan.bootstrap.environment.proprerty.sub.BackupProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.HttpServerProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.MonitorProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.ServerProperty;
@@ -48,6 +49,8 @@ public class TitanSubProperty {
     private HttpServerProperty httpServer;
 
     private MonitorProperty monitor;
+
+    private BackupProperty backup;
 
     private ServiceDiscoveryProperty serviceDiscovery;
 

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/BackupProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/BackupProperty.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2025 traffic-hunter
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.traffichunter.titan.bootstrap.environment.proprerty.sub;
+
+/**
+ * YAML DTO for append-only backup settings.
+ */
+public class BackupProperty {
+
+    private boolean enabled;
+
+    private String type;
+
+    private String path;
+
+    private String syncPolicy;
+
+    private String recoveryPolicy;
+
+    public BackupProperty() {
+    }
+
+    public BackupProperty(
+            boolean enabled,
+            String type,
+            String path,
+            String syncPolicy,
+            String recoveryPolicy
+    ) {
+        this.enabled = enabled;
+        this.type = type;
+        this.path = path;
+        this.syncPolicy = syncPolicy;
+        this.recoveryPolicy = recoveryPolicy;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getSyncPolicy() {
+        return syncPolicy;
+    }
+
+    public void setSyncPolicy(String syncPolicy) {
+        this.syncPolicy = syncPolicy;
+    }
+
+    public String getRecoveryPolicy() {
+        return recoveryPolicy;
+    }
+
+    public void setRecoveryPolicy(String recoveryPolicy) {
+        this.recoveryPolicy = recoveryPolicy;
+    }
+}

--- a/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/environment/ConfigurationInitializerTest.java
+++ b/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/environment/ConfigurationInitializerTest.java
@@ -37,6 +37,28 @@ class ConfigurationInitializerTest {
     }
 
     @Test
+    void load_maps_backup_settings() {
+        String yaml = """
+                titan:
+                  backup:
+                    enabled: true
+                    type: all
+                    path: ./data/titan.aof
+                    sync-policy: every
+                    recovery-policy: fail-on-truncated-tail
+                """;
+
+        Settings settings = ConfigurationInitializer.getDefault("unused")
+                .load(new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(settings.backup().enabled()).isTrue();
+        assertThat(settings.backup().type()).isEqualTo("all");
+        assertThat(settings.backup().path()).isEqualTo("./data/titan.aof");
+        assertThat(settings.backup().syncPolicy()).isEqualTo("every");
+        assertThat(settings.backup().recoveryPolicy()).isEqualTo("fail-on-truncated-tail");
+    }
+
+    @Test
     void load_defaults_monitor_to_disabled_when_missing() {
         String yaml = """
                 titan:
@@ -53,15 +75,20 @@ class ConfigurationInitializerTest {
         assertThat(settings.monitor().enabled()).isFalse();
         assertThat(settings.monitor().host()).isEqualTo("127.0.0.1");
         assertThat(settings.monitor().port()).isEqualTo(7777);
+        assertThat(settings.backup().enabled()).isFalse();
+        assertThat(settings.backup().type()).isEqualTo("aof");
+        assertThat(settings.backup().syncPolicy()).isEqualTo("every_sec");
+        assertThat(settings.backup().recoveryPolicy()).isEqualTo("load_truncated_tail");
     }
 
     @Test
     void settings_builder_defaults_missing_sections() {
-        Settings settings = Settings.builder().build();
+        Settings settings = new Settings(null, null, null);
 
         assertThat(settings.servers()).isEmpty();
         assertThat(settings.monitor().enabled()).isFalse();
         assertThat(settings.monitor().host()).isEqualTo("127.0.0.1");
         assertThat(settings.monitor().port()).isEqualTo(7777);
+        assertThat(settings.backup().enabled()).isFalse();
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofRecoveryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofRecoveryPolicy.java
@@ -1,0 +1,45 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * AOF replay behavior when the file ends with a partially written record.
+ *
+ * @author yun
+ */
+public enum AofRecoveryPolicy {
+
+    /**
+     * Replay the valid prefix and stop at a truncated tail record.
+     *
+     * <p>This policy does not scan for the next magic value or jump over corrupted bytes. Middle
+     * corruption still fails replay because AOF ordering is part of the recovered state.</p>
+     */
+    LOAD_TRUNCATED_TAIL,
+
+    /**
+     * Fail replay when a truncated tail record is found.
+     */
+    FAIL_ON_TRUNCATED_TAIL
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofRecoveryPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofRecoveryPolicy.java
@@ -23,6 +23,9 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.resilience.backup;
 
+import java.util.Locale;
+import org.jspecify.annotations.Nullable;
+
 /**
  * AOF replay behavior when the file ends with a partially written record.
  *
@@ -41,5 +44,19 @@ public enum AofRecoveryPolicy {
     /**
      * Fail replay when a truncated tail record is found.
      */
-    FAIL_ON_TRUNCATED_TAIL
+    FAIL_ON_TRUNCATED_TAIL;
+
+    /**
+     * Maps external configuration values to the internal recovery policy.
+     */
+    public static AofRecoveryPolicy fromConfig(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return LOAD_TRUNCATED_TAIL;
+        }
+        return switch (value.toLowerCase(Locale.ROOT).replace('-', '_')) {
+            case "load_truncated_tail" -> LOAD_TRUNCATED_TAIL;
+            case "fail_on_truncated_tail" -> FAIL_ON_TRUNCATED_TAIL;
+            default -> throw new IllegalArgumentException("Unknown AOF recovery policy: " + value);
+        };
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofSyncPolicy.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofSyncPolicy.java
@@ -1,0 +1,67 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import java.util.Locale;
+
+/**
+ * Sync policy for Titan append-only backup writes.
+ *
+ * <p>Configuration strings are mapped through {@link #fromConfig(String)}.</p>
+ *
+ * @author yun
+ */
+public enum AofSyncPolicy {
+
+    /**
+     * Force the AOF file after every append.
+     */
+    EVERY,
+
+    /**
+     * Force the AOF file at most once per second during append.
+     */
+    EVERY_SEC,
+
+    /**
+     * Do not force during append; leave flushing to the operating system unless {@code sync()} is
+     * called explicitly.
+     */
+    NO;
+
+    /**
+     * Maps external configuration values to the internal policy names.
+     *
+     * @param value configuration value such as {@code every}, {@code every_sec}, or {@code no}
+     * @return matching AOF sync policy
+     */
+    public static AofSyncPolicy fromConfig(String value) {
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "every" -> EVERY;
+            case "every_sec" -> EVERY_SEC;
+            case "no" -> NO;
+            default -> throw new IllegalArgumentException("Unknown AOF sync policy: " + value);
+        };
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
@@ -40,14 +40,21 @@ public interface AppendOnlyFile extends AutoCloseable {
      * Opens an append-only file with default sync and recovery policies.
      */
     static AppendOnlyFile open(Path path) {
-        return open(path, AofSyncPolicy.EVERY_SEC, AofRecoveryPolicy.LOAD_TRUNCATED_TAIL);
+        return open(path, BackupOption.defaults());
+    }
+
+    /**
+     * Opens an append-only file with explicit backup options.
+     */
+    static AppendOnlyFile open(Path path, BackupOption option) {
+        return new FileAppendOnlyFile(path, option);
     }
 
     /**
      * Opens an append-only file with explicit sync and recovery policies.
      */
     static AppendOnlyFile open(Path path, AofSyncPolicy syncPolicy, AofRecoveryPolicy recoveryPolicy) {
-        return new FileAppendOnlyFile(path, syncPolicy, recoveryPolicy);
+        return open(path, new BackupOption(BackupType.AOF, syncPolicy, recoveryPolicy));
     }
 
     /**
@@ -57,6 +64,9 @@ public interface AppendOnlyFile extends AutoCloseable {
 
     /**
      * Replays valid records from the beginning of the file.
+     *
+     * <p>Truncated tail records follow the configured recovery policy. Invalid or corrupted
+     * records fail replay immediately.</p>
      */
     void replay(MetadataHandler handler);
 

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
@@ -1,0 +1,75 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import java.nio.file.Path;
+
+/**
+ * Append-only backup file for sequential durability records.
+ *
+ * <p>The file stores Titan backup metadata records sequentially and replays only the order encoded
+ * in the log. Implementations must not mutate or release buffers owned by the source
+ * {@link Metadata}.</p>
+ *
+ * @author yun
+ */
+public interface AppendOnlyFile extends AutoCloseable {
+
+    /**
+     * Opens an append-only file with default sync and recovery policies.
+     */
+    static AppendOnlyFile open(Path path) {
+        return open(path, AofSyncPolicy.EVERY_SEC, AofRecoveryPolicy.LOAD_TRUNCATED_TAIL);
+    }
+
+    /**
+     * Opens an append-only file with explicit sync and recovery policies.
+     */
+    static AppendOnlyFile open(Path path, AofSyncPolicy syncPolicy, AofRecoveryPolicy recoveryPolicy) {
+        return new FileAppendOnlyFile(path, syncPolicy, recoveryPolicy);
+    }
+
+    /**
+     * Appends one encoded metadata record and returns the starting file offset.
+     */
+    long append(Metadata metadata);
+
+    /**
+     * Replays valid records from the beginning of the file.
+     */
+    void replay(MetadataHandler handler);
+
+    /**
+     * Forces pending file writes to durable storage.
+     */
+    void fsync();
+
+    /**
+     * Returns the underlying file path.
+     */
+    Path path();
+
+    @Override
+    void close();
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupException.java
@@ -1,0 +1,46 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * Base unchecked exception for Titan backup and AOF failures.
+ *
+ * @author yun
+ */
+public class BackupException extends RuntimeException {
+
+    /**
+     * Creates a backup exception with a detail message.
+     */
+    public BackupException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a backup exception with a detail message and cause.
+     */
+    public BackupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupOption.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupOption.java
@@ -1,0 +1,74 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Options used when opening an append-only backup file.
+ *
+ * <p>The record keeps durability and recovery policy together so later backup settings can be
+ * added without expanding constructor parameter lists.</p>
+ *
+ * @author yun
+ */
+public record BackupOption(
+        BackupType type,
+        AofSyncPolicy syncPolicy,
+        AofRecoveryPolicy recoveryPolicy
+) {
+
+    /**
+     * Returns the default backup option.
+     */
+    public static BackupOption defaults() {
+        return new BackupOption(
+                BackupType.AOF,
+                AofSyncPolicy.EVERY_SEC,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL
+        );
+    }
+
+    /**
+     * Creates backup options from external configuration values.
+     */
+    public static BackupOption fromConfig(
+            @Nullable String type,
+            @Nullable String syncPolicy,
+            @Nullable String recoveryPolicy
+    ) {
+        return new BackupOption(
+                BackupType.fromConfig(type),
+                AofSyncPolicy.fromConfig(syncPolicy),
+                AofRecoveryPolicy.fromConfig(recoveryPolicy)
+        );
+    }
+
+    /**
+     * Creates append-log backup options from external configuration values.
+     */
+    public static BackupOption fromConfig(@Nullable String syncPolicy, @Nullable String recoveryPolicy) {
+        return fromConfig("aof", syncPolicy, recoveryPolicy);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupType.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupType.java
@@ -27,46 +27,42 @@ import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Sync policy for Titan append-only backup writes.
+ * Backup strategy selected by external configuration.
  *
- * <p>Configuration strings are mapped through {@link #fromConfig(String)}.</p>
+ * <p>{@link #RDB} is reserved for snapshot-based persistence and {@link #ALL} means both append
+ * log and snapshot persistence should be enabled when both implementations exist.</p>
  *
  * @author yun
  */
-public enum AofSyncPolicy {
+public enum BackupType {
 
     /**
-     * Force the AOF file after every append.
+     * Append-only log backup.
      */
-    EVERY,
+    AOF,
 
     /**
-     * Force the AOF file at most once per second during append.
+     * Snapshot backup.
      */
-    EVERY_SEC,
+    RDB,
 
     /**
-     * Do not force during append; leave flushing to the operating system unless {@code fsync()} is
-     * called explicitly.
+     * Enable all available backup strategies.
      */
-    NO;
+    ALL;
 
     /**
-     * Maps external configuration values to the internal policy names.
-     *
-     * @param value configuration value such as {@code every}, {@code every-sec}, {@code every_sec},
-     *              or {@code no}
-     * @return matching AOF sync policy
+     * Maps external configuration values to a backup type.
      */
-    public static AofSyncPolicy fromConfig(@Nullable String value) {
+    public static BackupType fromConfig(@Nullable String value) {
         if (value == null || value.isBlank()) {
-            return EVERY_SEC;
+            return AOF;
         }
-        return switch (value.toLowerCase(Locale.ROOT).replace('-', '_')) {
-            case "every" -> EVERY;
-            case "every_sec" -> EVERY_SEC;
-            case "no" -> NO;
-            default -> throw new IllegalArgumentException("Unknown AOF sync policy: " + value);
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "aof" -> AOF;
+            case "rdb" -> RDB;
+            case "all" -> ALL;
+            default -> throw new IllegalArgumentException("Unknown backup type: " + value);
         };
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/DecodedMetadata.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/DecodedMetadata.java
@@ -1,0 +1,35 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * Decoded metadata plus the number of bytes consumed from the AOF stream.
+ *
+ * <p>The consumed length lets replay advance through a concatenated append-only file without
+ * rescanning for record boundaries.</p>
+ *
+ * @author yun
+ */
+public record DecodedMetadata(Metadata metadata, int length) {
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
@@ -51,7 +51,14 @@ public final class FileAppendOnlyFile implements AppendOnlyFile {
      * Opens a file-backed append-only log using the given durability and recovery policies.
      */
     public FileAppendOnlyFile(Path path, AofSyncPolicy syncPolicy, AofRecoveryPolicy recoveryPolicy) {
-        this(FileHandle.open(path), syncPolicy, recoveryPolicy, System::currentTimeMillis);
+        this(path, new BackupOption(BackupType.AOF, syncPolicy, recoveryPolicy));
+    }
+
+    /**
+     * Opens a file-backed append-only log using explicit backup options.
+     */
+    public FileAppendOnlyFile(Path path, BackupOption option) {
+        this(FileHandle.open(path), option, System::currentTimeMillis);
     }
 
     /**
@@ -60,13 +67,12 @@ public final class FileAppendOnlyFile implements AppendOnlyFile {
      */
     FileAppendOnlyFile(
             FileHandle fileHandle,
-            AofSyncPolicy syncPolicy,
-            AofRecoveryPolicy recoveryPolicy,
+            BackupOption option,
             LongSupplier clock
     ) {
         this.fileHandle = fileHandle;
-        this.syncPolicy = syncPolicy;
-        this.recoveryPolicy = recoveryPolicy;
+        this.syncPolicy = option.syncPolicy();
+        this.recoveryPolicy = option.recoveryPolicy();
         this.clock = clock;
         this.lastSyncMillis = clock.getAsLong();
     }
@@ -136,7 +142,7 @@ public final class FileAppendOnlyFile implements AppendOnlyFile {
                 }
             }
             case NO -> {
-                // Depend on the OS unless sync() is called explicitly.
+                // Depend on the OS unless fsync() is called explicitly.
             }
         }
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
@@ -1,0 +1,143 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import java.nio.file.Path;
+import java.util.function.LongSupplier;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.file.FileHandle;
+
+/**
+ * File-backed {@link AppendOnlyFile} implementation.
+ *
+ * <p>The implementation writes encoded records at the file tail and replays from byte offset zero.
+ * It is intentionally simple for v1: no rewrite, no manifest, and no scan-forward repair. Those
+ * belong to a later rewrite/snapshot layer.</p>
+ *
+ * @author yun
+ */
+public final class FileAppendOnlyFile implements AppendOnlyFile {
+
+    private static final long EVERY_SEC_MILLIS = 1000;
+
+    private final FileHandle fileHandle;
+    private final AofSyncPolicy syncPolicy;
+    private final AofRecoveryPolicy recoveryPolicy;
+    private final LongSupplier clock;
+    private long lastSyncMillis;
+
+    /**
+     * Opens a file-backed append-only log using the given durability and recovery policies.
+     */
+    public FileAppendOnlyFile(Path path, AofSyncPolicy syncPolicy, AofRecoveryPolicy recoveryPolicy) {
+        this(FileHandle.open(path), syncPolicy, recoveryPolicy, System::currentTimeMillis);
+    }
+
+    /**
+     * Creates a file-backed append-only log with injected file and clock dependencies for
+     * deterministic tests.
+     */
+    FileAppendOnlyFile(
+            FileHandle fileHandle,
+            AofSyncPolicy syncPolicy,
+            AofRecoveryPolicy recoveryPolicy,
+            LongSupplier clock
+    ) {
+        this.fileHandle = fileHandle;
+        this.syncPolicy = syncPolicy;
+        this.recoveryPolicy = recoveryPolicy;
+        this.clock = clock;
+        this.lastSyncMillis = clock.getAsLong();
+    }
+
+    @Override
+    public long append(Metadata metadata) {
+        Buffer encoded = MetadataCodec.encode(metadata);
+        try {
+            long offset = fileHandle.append(encoded);
+            syncIfNeeded();
+            return offset;
+        } finally {
+            // The encoded buffer is created by this log. Source metadata payload ownership stays
+            // with the caller, but the transient encoded representation is released here.
+            encoded.release();
+        }
+    }
+
+    @Override
+    public void replay(MetadataHandler handler) {
+        Buffer content = fileHandle.readAll();
+        try {
+            byte[] bytes = content.getBytes();
+            int offset = 0;
+            while (offset < bytes.length) {
+                try {
+                    DecodedMetadata decoded = MetadataCodec.decode(bytes, offset);
+                    handler.handle(decoded.metadata());
+                    offset += decoded.length();
+                } catch (TruncatedBackupRecordException e) {
+                    // Tolerant loading only accepts a partial record at the file tail.
+                    // We stop at the valid prefix instead of scanning forward for another magic.
+                    if (recoveryPolicy == AofRecoveryPolicy.LOAD_TRUNCATED_TAIL) {
+                        return;
+                    }
+                    throw e;
+                }
+            }
+        } finally {
+            content.release();
+        }
+    }
+
+    @Override
+    public void fsync() {
+        fileHandle.force(true);
+        lastSyncMillis = clock.getAsLong();
+    }
+
+    @Override
+    public Path path() {
+        return fileHandle.path();
+    }
+
+    @Override
+    public void close() {
+        fileHandle.close();
+    }
+
+    private void syncIfNeeded() {
+        switch (syncPolicy) {
+            case EVERY -> fsync();
+            case EVERY_SEC -> {
+                long now = clock.getAsLong();
+                if (now - lastSyncMillis >= EVERY_SEC_MILLIS) {
+                    fsync();
+                }
+            }
+            case NO -> {
+                // Depend on the OS unless sync() is called explicitly.
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/InvalidBackupRecordException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/InvalidBackupRecordException.java
@@ -1,0 +1,42 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * Thrown when a backup record is complete but structurally invalid or corrupted.
+ *
+ * <p>Examples include invalid magic, unsupported version, unknown type, negative length, or CRC32
+ * mismatch.</p>
+ *
+ * @author yun
+ */
+public final class InvalidBackupRecordException extends BackupException {
+
+    /**
+     * Creates an invalid-record failure with a detail message.
+     */
+    public InvalidBackupRecordException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Metadata.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Metadata.java
@@ -1,0 +1,121 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.Arrays;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * Binary AOF record metadata and payload.
+ *
+ * <p>The record keeps byte arrays defensively copied so that callers cannot
+ *  invalidate length and checksum metadata after construction. The source {@link Buffer} passed to
+ * {@link #create(Type, long, String, Buffer)} remains owned by the caller.</p>
+ *
+ * @author yun
+ */
+public record Metadata(
+        int magic,
+        short version,
+        short type,
+        long timestamp,
+        int destinationLength,
+        int payloadLength,
+        int crc32,
+        byte[] destination,
+        byte[] payload
+) {
+
+    /**
+     * Defensively copies mutable byte arrays on construction.
+     */
+    public Metadata {
+        destination = destination.clone();
+        payload = payload.clone();
+    }
+
+    /**
+     * Creates metadata from a Titan buffer without releasing or retaining the source buffer.
+     */
+    public static Metadata create(Type type, long timestamp, String destination, Buffer payload) {
+        return create(type, timestamp, destination, payload.getBytes());
+    }
+
+    /**
+     * Creates metadata from raw bytes using UTF-8 for the destination path.
+     */
+    public static Metadata create(Type type, long timestamp, String destination, byte[] payload) {
+        byte[] destinationBytes = destination.getBytes(UTF_8);
+        return new Metadata(
+                MetadataCodec.MAGIC,
+                MetadataCodec.VERSION,
+                (short) type.getValue(),
+                timestamp,
+                destinationBytes.length,
+                payload.length,
+                0,
+                destinationBytes,
+                payload
+        );
+    }
+
+    /**
+     * Returns the typed AOF record operation.
+     */
+    public Type recordType() {
+        return Type.fromValue(type);
+    }
+
+    /**
+     * Returns the UTF-8 decoded destination path.
+     */
+    public String destinationPath() {
+        return new String(destination, UTF_8);
+    }
+
+    @Override
+    public byte[] destination() {
+        return destination.clone();
+    }
+
+    @Override
+    public byte[] payload() {
+        return payload.clone();
+    }
+
+    @Override
+    public String toString() {
+        return magic + ", " +
+                version + ", " +
+                type + ", " +
+                timestamp + ", " +
+                destinationLength + ", " +
+                payloadLength + ", " +
+                crc32 + ", " +
+                Arrays.toString(destination) + ", " +
+                Arrays.toString(payload);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/MetadataCodec.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/MetadataCodec.java
@@ -1,0 +1,220 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.zip.CRC32;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * Codec for Titan AOF metadata records.
+ *
+ * <p>The v1 layout is big-endian and intentionally self-delimiting:</p>
+ *
+ * <pre>
+ * int    magic
+ * short  version
+ * short  type
+ * long   timestamp
+ * int    destinationLength
+ * int    payloadLength
+ * int    crc32
+ * byte[] destination
+ * byte[] payload
+ * </pre>
+ *
+ * <p>The CRC32 covers version, type, timestamp, lengths, destination, and payload. Magic and crc32
+ * are verified separately and are not included in the checksum input.</p>
+ *
+ * @author yun
+ */
+public final class MetadataCodec {
+
+    /**
+     * ASCII {@code TAOF}; used as the sync marker for Titan append-only records.
+     */
+    public static final int MAGIC = 0x54414F46;
+
+    /**
+     * Binary metadata record format version.
+     */
+    public static final short VERSION = 1;
+
+    /**
+     * Fixed-size header length before destination and payload bytes.
+     */
+    public static final int HEADER_SIZE;
+
+    static {
+        HEADER_SIZE = combineSize(
+                Integer.BYTES,
+                Short.BYTES,
+                Short.BYTES,
+                Long.BYTES,
+                Integer.BYTES,
+                Integer.BYTES,
+                Integer.BYTES
+        );
+    }
+
+    /**
+     * Encodes metadata into a newly allocated Titan buffer.
+     *
+     * <p>The returned buffer is owned by the caller and must be released by the caller.</p>
+     */
+    public static Buffer encode(Metadata metadata) {
+        byte[] destination = metadata.destination();
+        byte[] payload = metadata.payload();
+        int crc32 = crc32(
+                metadata.version(),
+                metadata.type(),
+                metadata.timestamp(),
+                destination.length,
+                payload.length,
+                destination,
+                payload
+        );
+
+        ByteBuffer buffer = ByteBuffer.allocate(HEADER_SIZE + destination.length + payload.length);
+        buffer.putInt(MAGIC);
+        buffer.putShort(VERSION);
+        buffer.putShort(metadata.type());
+        buffer.putLong(metadata.timestamp());
+        buffer.putInt(destination.length);
+        buffer.putInt(payload.length);
+        buffer.putInt(crc32);
+        buffer.put(destination);
+        buffer.put(payload);
+        return Buffer.alloc(buffer.array());
+    }
+
+    /**
+     * Decodes one complete record from a buffer starting at offset zero.
+     */
+    public static DecodedMetadata decode(Buffer buffer) {
+        return decode(buffer.getBytes(), 0);
+    }
+
+    /**
+     * Decodes one record from {@code bytes} at {@code offset}.
+     *
+     * <p>The method returns the decoded record and the consumed byte count so replay can move to
+     * the next record without searching for magic bytes.</p>
+     */
+    public static DecodedMetadata decode(byte[] bytes, int offset) {
+        if (bytes.length - offset < HEADER_SIZE) {
+            throw new TruncatedBackupRecordException("Truncated backup record header", offset);
+        }
+
+        ByteBuffer buffer = ByteBuffer.wrap(bytes, offset, bytes.length - offset);
+        int magic = buffer.getInt();
+        short version = buffer.getShort();
+        short type = buffer.getShort();
+        long timestamp = buffer.getLong();
+        int destinationLength = buffer.getInt();
+        int payloadLength = buffer.getInt();
+        int crc32 = buffer.getInt();
+
+        if (magic != MAGIC) {
+            throw new InvalidBackupRecordException("Invalid backup record magic: " + magic);
+        }
+        if (version != VERSION) {
+            throw new InvalidBackupRecordException("Unsupported backup record version: " + version);
+        }
+        Type.fromValue(type);
+        if (destinationLength < 0) {
+            throw new InvalidBackupRecordException("Invalid destination length: " + destinationLength);
+        }
+        if (payloadLength < 0) {
+            throw new InvalidBackupRecordException("Invalid payload length: " + payloadLength);
+        }
+
+        int recordLength = HEADER_SIZE + destinationLength + payloadLength;
+        if (bytes.length - offset < recordLength) {
+            throw new TruncatedBackupRecordException("Truncated backup record body", offset);
+        }
+
+        byte[] destination = new byte[destinationLength];
+        byte[] payload = new byte[payloadLength];
+        buffer.get(destination);
+        buffer.get(payload);
+
+        int computedCrc32 = crc32(version, type, timestamp, destinationLength, payloadLength, destination, payload);
+        if (crc32 != computedCrc32) {
+            throw new InvalidBackupRecordException("Backup record crc32 mismatch");
+        }
+
+        return new DecodedMetadata(
+                new Metadata(
+                        magic,
+                        version,
+                        type,
+                        timestamp,
+                        destinationLength,
+                        payloadLength,
+                        crc32,
+                        destination,
+                        payload
+                ),
+                recordLength
+        );
+    }
+
+    private static int crc32(
+            short version,
+            short type,
+            long timestamp,
+            int destinationLength,
+            int payloadLength,
+            byte[] destination,
+            byte[] payload
+    ) {
+        // Keep the checksum input identical to the documented v1 format: magic and the crc field
+        // are excluded, while all replay-relevant metadata and payload bytes are included.
+        ByteBuffer header = ByteBuffer.allocate(
+                combineSize(Short.BYTES, Short.BYTES, Long.BYTES, Integer.BYTES, Integer.BYTES)
+        );
+        header.putShort(version);
+        header.putShort(type);
+        header.putLong(timestamp);
+        header.putInt(destinationLength);
+        header.putInt(payloadLength);
+
+        CRC32 crc32 = new CRC32();
+        crc32.update(header.array());
+        crc32.update(destination);
+        crc32.update(payload);
+        return (int) crc32.getValue();
+    }
+
+    private static int combineSize(int... numberByte) {
+        return Arrays.stream(numberByte).sum();
+    }
+
+    /**
+     * Utility class.
+     */
+    private MetadataCodec() { }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/MetadataHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/MetadataHandler.java
@@ -1,0 +1,44 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import org.traffichunter.titan.core.util.Handler;
+
+/**
+ * Callback invoked for each metadata record recovered from an AOF file.
+ *
+ * <p>The handler receives immutable byte-array metadata. If a later replay layer converts payload
+ * bytes back to Titan {@code Buffer}, that layer owns the created buffer and must release it.</p>
+ *
+ * @author yun
+ */
+@FunctionalInterface
+public interface MetadataHandler extends Handler<Metadata> {
+
+    /**
+     * Handles one decoded metadata record in append order.
+     */
+    @Override
+    void handle(Metadata metadata);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/TruncatedBackupRecordException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/TruncatedBackupRecordException.java
@@ -1,0 +1,53 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * Thrown when an AOF record header or body is incomplete.
+ *
+ * <p>A truncated record can be acceptable only at the end of the file and only when
+ * {@link AofRecoveryPolicy#LOAD_TRUNCATED_TAIL} is selected. The offset points to the start of the
+ * incomplete record.</p>
+ *
+ * @author yun
+ */
+public final class TruncatedBackupRecordException extends BackupException {
+
+    private final int offset;
+
+    /**
+     * Creates a truncated-record failure at a replay offset.
+     */
+    public TruncatedBackupRecordException(String message, int offset) {
+        super(message);
+        this.offset = offset;
+    }
+
+    /**
+     * Returns the byte offset where the truncated record starts.
+     */
+    public int offset() {
+        return offset;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Type.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Type.java
@@ -1,0 +1,76 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * Operation type persisted in the Titan AOF stream.
+ *
+ * <p>Each enum value has a stable numeric id because records are stored on disk. Do not reorder or
+ * reuse ids once a release writes them.</p>
+ *
+ * @author yun
+ */
+public enum Type {
+
+    /**
+     * A message was appended to a destination queue.
+     */
+    MESSAGE_APPEND(1),
+
+    /**
+     * A destination queue was explicitly created.
+     */
+    CREATE_QUEUE(2),
+
+    /**
+     * A destination queue was explicitly deleted.
+     */
+    DELETE_QUEUE(3),
+    ;
+
+    private final int value;
+
+    Type(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the stable on-disk numeric representation.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Resolves a persisted numeric value into a record type.
+     */
+    public static Type fromValue(short value) {
+        for (Type type : values()) {
+            if (type.value == value) {
+                return type;
+            }
+        }
+        throw new InvalidBackupRecordException("Unknown backup record type: " + value);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Append-only backup support for Titan durability.
+ *
+ * <p>The package contains the first backup log foundation: binary record metadata, record codec,
+ * append/replay file access, fsync policy, and truncated-tail recovery policy. Queue restore,
+ * rewrite, manifest, and snapshot integration are intentionally left to later layers.</p>
+ *
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.resilience.backup;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/test/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFileTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFileTest.java
@@ -1,0 +1,291 @@
+package org.traffichunter.titan.core.resilience.backup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.channels.FileLock;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.file.FileHandle;
+
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * @author yun
+ */
+@NullMarked
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class FileAppendOnlyFileTest {
+
+    @Test
+    void append_and_replay_records_in_order() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+        MutableClock clock = new MutableClock();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.NO,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                clock
+        )) {
+            Metadata first = metadata(Type.CREATE_QUEUE, "/queue/a", "first");
+            Metadata second = metadata(Type.MESSAGE_APPEND, "/queue/a", "second");
+
+            long firstOffset = file.append(first);
+            long secondOffset = file.append(second);
+
+            List<Metadata> replayed = new ArrayList<>();
+            file.replay(replayed::add);
+
+            assertThat(firstOffset).isZero();
+            assertThat(secondOffset).isPositive();
+            assertThat(replayed).hasSize(2);
+            assertThat(replayed.get(0).recordType()).isEqualTo(Type.CREATE_QUEUE);
+            assertThat(replayed.get(1).recordType()).isEqualTo(Type.MESSAGE_APPEND);
+            assertThat(new String(replayed.get(1).payload(), UTF_8)).isEqualTo("second");
+        }
+    }
+
+    @Test
+    void every_fsync_policy_forces_each_append() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.EVERY,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                new MutableClock()
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "two"));
+
+            assertThat(fileHandle.forceCount()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void every_sec_fsync_policy_forces_after_interval() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+        MutableClock clock = new MutableClock();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.EVERY_SEC,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                clock
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            clock.advanceMillis(999);
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "two"));
+            clock.advanceMillis(1);
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "three"));
+
+            assertThat(fileHandle.forceCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void no_sync_policy_does_not_force_on_append_but_explicit_fsync_does() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.NO,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                new MutableClock()
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            assertThat(fileHandle.forceCount()).isZero();
+
+            file.fsync();
+            assertThat(fileHandle.forceCount()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void truncated_tail_can_be_ignored() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.NO,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                new MutableClock()
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "two"));
+            fileHandle.truncateBytes(fileHandle.length() - 1);
+
+            List<Metadata> replayed = new ArrayList<>();
+            file.replay(replayed::add);
+
+            assertThat(replayed).hasSize(1);
+            assertThat(new String(replayed.getFirst().payload(), UTF_8)).isEqualTo("one");
+        }
+    }
+
+    @Test
+    void truncated_tail_can_fail_replay() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.NO,
+                AofRecoveryPolicy.FAIL_ON_TRUNCATED_TAIL,
+                new MutableClock()
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            fileHandle.truncateBytes(fileHandle.length() - 1);
+
+            assertThatThrownBy(() -> file.replay(metadata -> { }))
+                    .isInstanceOf(TruncatedBackupRecordException.class);
+        }
+    }
+
+    @Test
+    void crc_mismatch_fails_replay() {
+        FakeFileHandle fileHandle = new FakeFileHandle();
+
+        try (AppendOnlyFile file = new FileAppendOnlyFile(
+                fileHandle,
+                AofSyncPolicy.NO,
+                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                new MutableClock()
+        )) {
+            file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
+            fileHandle.flipLastByte();
+
+            assertThatThrownBy(() -> file.replay(metadata -> { }))
+                    .isInstanceOf(InvalidBackupRecordException.class);
+        }
+    }
+
+    private Metadata metadata(Type type, String destination, String payload) {
+        Buffer buffer = Buffer.alloc(payload, UTF_8);
+        try {
+            return Metadata.create(type, 100, destination, buffer);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static final class MutableClock implements LongSupplier {
+
+        private long now;
+
+        @Override
+        public long getAsLong() {
+            return now;
+        }
+
+        void advanceMillis(long millis) {
+            now += millis;
+        }
+    }
+
+    private static final class FakeFileHandle implements FileHandle {
+
+        private byte[] bytes = new byte[0];
+        private int forceCount;
+
+        @Override
+        public Path path() {
+            return Path.of("fake.aof");
+        }
+
+        @Override
+        public Buffer readAll() {
+            return Buffer.alloc(bytes);
+        }
+
+        @Override
+        public Buffer read(long position, int length) {
+            byte[] slice = Arrays.copyOfRange(bytes, (int) position, (int) position + length);
+            return Buffer.alloc(slice);
+        }
+
+        @Override
+        public Instant lastModified() {
+            return Instant.EPOCH;
+        }
+
+        @Override
+        public long size() {
+            return bytes.length;
+        }
+
+        @Override
+        public void write(Buffer source) {
+            bytes = source.getBytes();
+        }
+
+        @Override
+        public void write(long position, Buffer source) {
+            byte[] sourceBytes = source.getBytes();
+            byte[] next = Arrays.copyOf(bytes, Math.max(bytes.length, (int) position + sourceBytes.length));
+            System.arraycopy(sourceBytes, 0, next, (int) position, sourceBytes.length);
+            bytes = next;
+        }
+
+        @Override
+        public long append(Buffer source) {
+            long offset = bytes.length;
+            byte[] sourceBytes = source.getBytes();
+            byte[] next = Arrays.copyOf(bytes, bytes.length + sourceBytes.length);
+            System.arraycopy(sourceBytes, 0, next, bytes.length, sourceBytes.length);
+            bytes = next;
+            return offset;
+        }
+
+        @Override
+        public void truncate(long size) {
+            bytes = Arrays.copyOf(bytes, (int) size);
+        }
+
+        @Override
+        public void force(boolean metadata) {
+            forceCount++;
+        }
+
+        @Override
+        public FileLock lock() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public @Nullable FileLock tryLock() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        int forceCount() {
+            return forceCount;
+        }
+
+        int length() {
+            return bytes.length;
+        }
+
+        void truncateBytes(int length) {
+            bytes = Arrays.copyOf(bytes, length);
+        }
+
+        void flipLastByte() {
+            bytes[bytes.length - 1] = (byte) (bytes[bytes.length - 1] + 1);
+        }
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFileTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFileTest.java
@@ -29,14 +29,22 @@ import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 class FileAppendOnlyFileTest {
 
     @Test
+    void backup_option_can_be_created_from_config_values() {
+        BackupOption option = BackupOption.fromConfig("all", "no", "fail-on-truncated-tail");
+
+        assertThat(option.type()).isEqualTo(BackupType.ALL);
+        assertThat(option.syncPolicy()).isEqualTo(AofSyncPolicy.NO);
+        assertThat(option.recoveryPolicy()).isEqualTo(AofRecoveryPolicy.FAIL_ON_TRUNCATED_TAIL);
+    }
+
+    @Test
     void append_and_replay_records_in_order() {
         FakeFileHandle fileHandle = new FakeFileHandle();
         MutableClock clock = new MutableClock();
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.NO,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.fromConfig("no", null),
                 clock
         )) {
             Metadata first = metadata(Type.CREATE_QUEUE, "/queue/a", "first");
@@ -63,8 +71,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.EVERY,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.fromConfig("every", null),
                 new MutableClock()
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
@@ -81,8 +88,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.EVERY_SEC,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.defaults(),
                 clock
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
@@ -101,8 +107,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.NO,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.fromConfig("no", null),
                 new MutableClock()
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
@@ -119,8 +124,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.NO,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.fromConfig("no", null),
                 new MutableClock()
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
@@ -141,8 +145,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.NO,
-                AofRecoveryPolicy.FAIL_ON_TRUNCATED_TAIL,
+                BackupOption.fromConfig("no", "fail_on_truncated_tail"),
                 new MutableClock()
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));
@@ -159,8 +162,7 @@ class FileAppendOnlyFileTest {
 
         try (AppendOnlyFile file = new FileAppendOnlyFile(
                 fileHandle,
-                AofSyncPolicy.NO,
-                AofRecoveryPolicy.LOAD_TRUNCATED_TAIL,
+                BackupOption.fromConfig("no", null),
                 new MutableClock()
         )) {
             file.append(metadata(Type.MESSAGE_APPEND, "/queue/a", "one"));

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/backup/MetadataCodecTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/backup/MetadataCodecTest.java
@@ -1,0 +1,142 @@
+package org.traffichunter.titan.core.test.implementation.backup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.resilience.backup.DecodedMetadata;
+import org.traffichunter.titan.core.resilience.backup.InvalidBackupRecordException;
+import org.traffichunter.titan.core.resilience.backup.Metadata;
+import org.traffichunter.titan.core.resilience.backup.MetadataCodec;
+import org.traffichunter.titan.core.resilience.backup.TruncatedBackupRecordException;
+import org.traffichunter.titan.core.resilience.backup.Type;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * @author yun
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MetadataCodecTest {
+
+    @Test
+    void encode_and_decode_round_trip_binary_payload() {
+        byte[] payloadBytes = new byte[] { 'a', '\n', 0, (byte) 0xff };
+        Buffer payload = Buffer.alloc(payloadBytes);
+        Buffer encoded = null;
+
+        try {
+            Metadata metadata = Metadata.create(Type.MESSAGE_APPEND, 100, "/queue/orders", payload);
+
+            encoded = MetadataCodec.encode(metadata);
+            DecodedMetadata decoded = MetadataCodec.decode(encoded);
+
+            assertThat(decoded.length()).isEqualTo(encoded.length());
+            assertThat(decoded.metadata().magic()).isEqualTo(MetadataCodec.MAGIC);
+            assertThat(decoded.metadata().version()).isEqualTo(MetadataCodec.VERSION);
+            assertThat(decoded.metadata().recordType()).isEqualTo(Type.MESSAGE_APPEND);
+            assertThat(decoded.metadata().timestamp()).isEqualTo(100);
+            assertThat(decoded.metadata().destinationPath()).isEqualTo("/queue/orders");
+            assertThat(decoded.metadata().payload()).containsExactly(payloadBytes);
+        } finally {
+            payload.release();
+            if (encoded != null) {
+                encoded.release();
+            }
+        }
+    }
+
+    @Test
+    void encode_does_not_release_input_payload() {
+        Buffer payload = Buffer.alloc("payload", UTF_8);
+        Buffer encoded = null;
+
+        try {
+            Metadata metadata = Metadata.create(Type.MESSAGE_APPEND, 100, "/queue/orders", payload);
+            encoded = MetadataCodec.encode(metadata);
+
+            assertThat(payload.byteBuf().refCnt()).isEqualTo(1);
+        } finally {
+            payload.release();
+            if (encoded != null) {
+                encoded.release();
+            }
+        }
+    }
+
+    @Test
+    void invalid_magic_should_fail() {
+        assertInvalidRecord(0, (byte) 0);
+    }
+
+    @Test
+    void unsupported_version_should_fail() {
+        assertInvalidRecord(Integer.BYTES, (byte) 2);
+    }
+
+    @Test
+    void unknown_type_should_fail() {
+        assertInvalidRecord(Integer.BYTES + Short.BYTES + 1, (byte) 99);
+    }
+
+    @Test
+    void truncated_header_should_fail() {
+        byte[] truncated = new byte[MetadataCodec.HEADER_SIZE - 1];
+
+        assertThatThrownBy(() -> MetadataCodec.decode(truncated, 0))
+                .isInstanceOf(TruncatedBackupRecordException.class);
+    }
+
+    @Test
+    void truncated_body_should_fail() {
+        Buffer encoded = encodeSample();
+        try {
+            byte[] bytes = encoded.getBytes(0, encoded.length() - 1);
+
+            assertThatThrownBy(() -> MetadataCodec.decode(bytes, 0))
+                    .isInstanceOf(TruncatedBackupRecordException.class);
+        } finally {
+            encoded.release();
+        }
+    }
+
+    @Test
+    void crc32_mismatch_should_fail() {
+        Buffer encoded = encodeSample();
+        try {
+            byte[] bytes = encoded.getBytes();
+            bytes[bytes.length - 1] = (byte) (bytes[bytes.length - 1] + 1);
+
+            assertThatThrownBy(() -> MetadataCodec.decode(bytes, 0))
+                    .isInstanceOf(InvalidBackupRecordException.class)
+                    .hasMessageContaining("crc32");
+        } finally {
+            encoded.release();
+        }
+    }
+
+    private void assertInvalidRecord(int index, byte value) {
+        Buffer encoded = encodeSample();
+        try {
+            byte[] bytes = encoded.getBytes();
+            bytes[index] = value;
+
+            assertThatThrownBy(() -> MetadataCodec.decode(bytes, 0))
+                    .isInstanceOf(InvalidBackupRecordException.class);
+        } finally {
+            encoded.release();
+        }
+    }
+
+    private Buffer encodeSample() {
+        Buffer payload = Buffer.alloc("payload", UTF_8);
+        try {
+            return MetadataCodec.encode(Metadata.create(Type.MESSAGE_APPEND, 100, "/queue/orders", payload));
+        } finally {
+            payload.release();
+        }
+    }
+}

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncherTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/MonitorRuntimeLauncherTest.java
@@ -20,10 +20,7 @@ class MonitorRuntimeLauncherTest {
     @Test
     void runtime_launcher_stays_idle_when_monitor_is_disabled() {
         MonitorRuntimeLauncher launcher = new MonitorRuntimeLauncher();
-        Settings settings = Settings.builder()
-                .servers(List.of())
-                .monitor(Settings.MonitorSettings.disabled())
-                .build();
+        Settings settings = new Settings(List.of(), Settings.MonitorSettings.disabled(), null);
 
         assertThat(launcher.start(settings, List.of())).isEmpty();
     }


### PR DESCRIPTION
## Motivation:

Titan needs a durable backup foundation before queue restore and later snapshot/rewrite orchestration can be wired into startup. This PR introduces the first append-only backup log layer and exposes backup settings through the existing YAML bootstrap path.

## Modification:

- Add append-only backup metadata, record codec, file-backed append/replay log, fsync policy, and truncated-tail recovery policy.
- Add backup configuration models for `titan.backup`, including `type: aof | rdb | all`, path, sync policy, and recovery policy.
- Keep runtime settings non-null under `@NullMarked` while accepting nullable YAML inputs at mapper/factory boundaries.
- Add focused codec, replay, sync policy, truncated tail, CRC mismatch, and YAML mapping tests.

## Result:

Introduces the backup log foundation and configuration surface for future restore orchestration.

Validation:

```bash
./gradlew :bootstrap:test :core:test --no-configuration-cache
```
