### PR TITLE
Add destination backup fanout chain

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
+++ b/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
@@ -82,6 +82,7 @@ public class TitanApplication implements ApplicationStarter {
                             server
                     ))
                     .forEach(plugin -> plugin.apply(
+                            settings,
                             serverSettings.protocol(),
                             serverSettings.transport(),
                             serverSettings.resolvedProtocolOptions(),

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoopGroup.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoopGroup.java
@@ -129,7 +129,7 @@ public final class ChannelPrimaryIOEventLoopGroup implements ChannelEventLoopGro
 
     @Override
     public void gracefullyShutdown(long timeout, TimeUnit unit) {
-        group.forEach(IOEventLoop::gracefullyShutdown);
+        group.forEach(eventLoop -> eventLoop.gracefullyShutdown(timeout, unit));
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoopGroup.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoopGroup.java
@@ -128,7 +128,7 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
 
     @Override
     public void gracefullyShutdown(long timeout, TimeUnit unit) {
-        group.forEach(IOEventLoop::gracefullyShutdown);
+        group.forEach(eventLoop -> eventLoop.gracefullyShutdown(timeout, unit));
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -87,7 +87,7 @@ public interface NetChannel extends Channel {
     /**
      * Completes a pending non-blocking connect from the owning event-loop thread.
      */
-    boolean finishConnect();
+    boolean finishConnect() throws IOException;
 
     boolean isConnected();
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -259,7 +259,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
     }
 
     @Override
-    public boolean finishConnect() {
+    public boolean finishConnect() throws IOException {
         if(!eventLoop().inEventLoop()) {
             throw new ChannelException("Should be called in event loop");
         }
@@ -268,7 +268,9 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
             return channel().finishConnect();
         } catch (IOException e) {
             log.warn("Failed to finish connect = {}", e.getMessage());
-            return false;
+            failConnect(e);
+            close();
+            throw e;
         }
     }
 
@@ -325,6 +327,19 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         ChannelPromise p = this.connectPromise;
         if (p != null && !p.isDone()) {
             p.success();
+            connectPromise = null;
+        }
+    }
+
+    void failConnect(Throwable error) {
+        if(!eventLoop().inEventLoop()) {
+            eventLoop().register(() -> failConnect(error));
+            return;
+        }
+
+        ChannelPromise p = this.connectPromise;
+        if (p != null && !p.isDone()) {
+            p.fail(error);
             connectPromise = null;
         }
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofBackupCoordinator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AofBackupCoordinator.java
@@ -1,0 +1,122 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author yun
+ */
+class AofBackupCoordinator implements BackupCoordinator {
+
+    private static final Logger log = LoggerFactory.getLogger(AofBackupCoordinator.class);
+
+    private final Path backupFilePath;
+    private final BackupOption option;
+    private final AppendOnlyFile aof;
+    private final AtomicReference<BackupStatus> status = new AtomicReference<>(BackupStatus.INIT);
+
+    AofBackupCoordinator(Path backupFilePath) {
+        this(backupFilePath, BackupOption.defaults());
+    }
+
+    AofBackupCoordinator(Path backupFilePath, BackupOption option) {
+        this.backupFilePath = backupFilePath;
+        this.option = option;
+        this.aof = AppendOnlyFile.open(backupFilePath, option);
+        this.status.set(BackupStatus.RUNNING);
+    }
+
+    @Override
+    public Path path() {
+        return backupFilePath;
+    }
+
+    @Override
+    public synchronized boolean inspect() {
+        if (isStopped()) {
+            return false;
+        }
+        try {
+            aof.replay(metadata -> { });
+            return true;
+        } catch (BackupException e) {
+            log.error("Failed to inspect backup file {}", backupFilePath, e);
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized boolean restore(MetadataHandler handler) {
+        if (isStopped()) {
+            return false;
+        }
+        try {
+            aof.replay(handler);
+            return true;
+        } catch (BackupException e) {
+            log.error("Failed to restore backup file {}", backupFilePath, e);
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized void record(Metadata metadata) {
+        if (isStopped()) {
+            throw new BackupException("Backup coordinator is stopped");
+        }
+        aof.append(metadata);
+    }
+
+    @Override
+    public boolean isRunning() {
+        return status.get() == BackupStatus.RUNNING;
+    }
+
+    @Override
+    public boolean isStopped() {
+        return status.get() == BackupStatus.STOPPED;
+    }
+
+    @Override
+    public BackupStatus status() {
+        return status.get();
+    }
+
+    @Override
+    public BackupOption options() {
+        return option;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (status.getAndSet(BackupStatus.STOPPED) != BackupStatus.STOPPED) {
+            aof.close();
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/AppendOnlyFile.java
@@ -80,6 +80,8 @@ public interface AppendOnlyFile extends AutoCloseable {
      */
     Path path();
 
+    void truncate(long size);
+
     @Override
     void close();
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupCoordinator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupCoordinator.java
@@ -1,0 +1,51 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import java.nio.file.Path;
+
+/**
+ * @author yun
+ */
+public interface BackupCoordinator extends AutoCloseable {
+
+    Path path();
+
+    boolean inspect();
+
+    boolean restore(MetadataHandler handler);
+
+    void record(Metadata metadata);
+
+    boolean isRunning();
+
+    boolean isStopped();
+
+    BackupStatus status();
+
+    BackupOption options();
+
+    @Override
+    void close() throws Exception;
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupStatus.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupStatus.java
@@ -1,0 +1,34 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+/**
+ * @author yun
+ */
+public enum BackupStatus {
+    INIT,
+    RUNNING,
+    STOPPED,
+    ;
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupType.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/BackupType.java
@@ -65,4 +65,16 @@ public enum BackupType {
             default -> throw new IllegalArgumentException("Unknown backup type: " + value);
         };
     }
+
+    public boolean isAof() {
+        return this == AOF;
+    }
+
+    public boolean isRdb() {
+        return this == RDB;
+    }
+
+    public boolean isAll() {
+        return this == ALL;
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/DestinationBackupSystem.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/DestinationBackupSystem.java
@@ -1,0 +1,122 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.resilience.backup;
+
+import org.traffichunter.titan.core.util.file.FileHandler;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author yun
+ */
+public final class DestinationBackupSystem implements AutoCloseable {
+
+    private final Path backupDirectory;
+    private final BackupOption options;
+    private final Map<String, BackupCoordinator> coordinators = new ConcurrentHashMap<>();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public DestinationBackupSystem() {
+        this(BackupOption.defaults());
+    }
+
+    public DestinationBackupSystem(BackupOption options) {
+        this(Path.of("."), options);
+    }
+
+    public DestinationBackupSystem(Path backupDirectory, BackupOption options) {
+        this.backupDirectory = backupDirectory;
+        this.options = options;
+    }
+
+    public void record(Metadata metadata) {
+        if (closed.get()) {
+            throw new BackupException("Backup system is stopped");
+        }
+        if (options.type().isRdb()) {
+            return;
+        }
+
+        coordinator(metadata.destinationPath()).record(metadata);
+    }
+
+    public boolean inspect(String destination) {
+        if (closed.get()) {
+            return false;
+        }
+        if (options.type().isRdb()) {
+            return true;
+        }
+
+        return coordinator(destination).inspect();
+    }
+
+    public boolean restore(String destination, MetadataHandler handler) {
+        if (closed.get()) {
+            return false;
+        }
+        if (options.type().isRdb()) {
+            return true;
+        }
+
+        return coordinator(destination).restore(handler);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        Exception failure = null;
+        for (BackupCoordinator coordinator : coordinators.values()) {
+            try {
+                coordinator.close();
+            } catch (Exception e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
+        }
+        coordinators.clear();
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private BackupCoordinator coordinator(String destination) {
+        return coordinators.computeIfAbsent(destination, this::newAofCoordinator);
+    }
+
+    private BackupCoordinator newAofCoordinator(String destination) {
+        Path path = FileHandler.resolveDestinationFile(backupDirectory, destination);
+        return new AofBackupCoordinator(path, options);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/FileAppendOnlyFile.java
@@ -128,6 +128,11 @@ public final class FileAppendOnlyFile implements AppendOnlyFile {
     }
 
     @Override
+    public void truncate(long size) {
+        fileHandle.truncate(size);
+    }
+
+    @Override
     public void close() {
         fileHandle.close();
     }

--- a/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Metadata.java
+++ b/core/src/main/java/org/traffichunter/titan/core/resilience/backup/Metadata.java
@@ -38,13 +38,13 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  * @author yun
  */
 public record Metadata(
-        int magic,
-        short version,
-        short type,
-        long timestamp,
-        int destinationLength,
-        int payloadLength,
-        int crc32,
+        int    magic,
+        short  version,
+        short  type,
+        long   timestamp,
+        int    destinationLength,
+        int    payloadLength,
+        int    crc32,
         byte[] destination,
         byte[] payload
 ) {

--- a/core/src/main/java/org/traffichunter/titan/core/spi/FanoutLauncher.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/FanoutLauncher.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import org.traffichunter.titan.bootstrap.Settings;
 
 /**
  * Hook for optional module integrations, such as fanout.
@@ -41,4 +42,14 @@ public interface FanoutLauncher {
             Map<String, String> protocolOptions,
             ManagedServer managedServer
     );
+
+    default void apply(
+            Settings settings,
+            String protocol,
+            String transport,
+            Map<String, String> protocolOptions,
+            ManagedServer managedServer
+    ) {
+        apply(protocol, transport, protocolOptions, managedServer);
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/util/HandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/HandlerChain.java
@@ -1,0 +1,34 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author yun
+ */
+public interface HandlerChain<C> {
+
+    CompletableFuture<Void> next(C context);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandle.java
@@ -48,22 +48,22 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 public interface FileHandle extends AutoCloseable {
 
     static FileHandle open(Path path) {
-        FileUtils.createParentDirectories(path);
+        FileHandler.createParentDirectories(path);
         return new LocalFileHandle(path, CREATE, READ, WRITE);
     }
 
     static FileHandle openReadOnly(Path path) {
-        FileUtils.createParentDirectories(path);
+        FileHandler.createParentDirectories(path);
         return new LocalFileHandle(path, READ);
     }
 
     static FileHandle newOpen(Path path) {
-        FileUtils.createParentDirectories(path);
+        FileHandler.createParentDirectories(path);
         return new LocalFileHandle(path, CREATE_NEW, READ, WRITE);
     }
 
     static FileHandle open(Path path, OpenOption... options) {
-        FileUtils.createParentDirectories(path);
+        FileHandler.createParentDirectories(path);
         return new LocalFileHandle(path, options);
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/FileHandler.java
@@ -46,7 +46,19 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  *
  * @author yun
  */
-public final class FileUtils {
+public final class FileHandler {
+
+    private static final String SIGNATURE = "titan";
+    private static final String AOF_SUFFIX = ".aof";
+
+    public static Path resolveDestinationFile(String destination) {
+        return resolveDestinationFile(Path.of("."), destination);
+    }
+
+    public static Path resolveDestinationFile(Path directory, String destination) {
+        String destinationPathName = destination.replace('/', '_').trim();
+        return directory.resolve(SIGNATURE + destinationPathName + AOF_SUFFIX);
+    }
 
     public static void createParentDirectories(Path path) {
         Path parent = path.getParent();
@@ -212,5 +224,5 @@ public final class FileUtils {
         }
     }
 
-    private FileUtils() { }
+    private FileHandler() { }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/resilience/backup/DestinationBackupSystemTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/resilience/backup/DestinationBackupSystemTest.java
@@ -1,0 +1,78 @@
+package org.traffichunter.titan.core.resilience.backup;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.file.FileHandler;
+
+import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+
+/**
+ * @author yun
+ */
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class DestinationBackupSystemTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void record_writes_destination_specific_file() throws Exception {
+        Metadata orders = metadata("/queue/orders", "orders");
+        Metadata payments = metadata("/queue/payments", "payments");
+
+        try (DestinationBackupSystem system = new DestinationBackupSystem(tempDir, BackupOption.fromConfig("aof", "no", null))) {
+            system.record(orders);
+            system.record(payments);
+        }
+
+        assertThat(FileHandler.exists(FileHandler.resolveDestinationFile(tempDir, "/queue/orders"))).isTrue();
+        assertThat(FileHandler.exists(FileHandler.resolveDestinationFile(tempDir, "/queue/payments"))).isTrue();
+    }
+
+    @Test
+    void restore_replays_one_destination_file() throws Exception {
+        Metadata first = metadata("/queue/orders", "first");
+        Metadata second = metadata("/queue/orders", "second");
+        List<String> restored = new ArrayList<>();
+
+        try (DestinationBackupSystem system = new DestinationBackupSystem(tempDir, BackupOption.fromConfig("aof", "no", null))) {
+            system.record(first);
+            system.record(second);
+
+            assertThat(system.inspect("/queue/orders")).isTrue();
+            assertThat(system.restore("/queue/orders", metadata -> restored.add(new String(metadata.payload(), UTF_8))))
+                    .isTrue();
+        }
+
+        assertThat(restored).containsExactly("first", "second");
+    }
+
+    @Test
+    void record_fails_after_close() throws Exception {
+        DestinationBackupSystem system = new DestinationBackupSystem(tempDir, BackupOption.fromConfig("aof", "no", null));
+        system.record(metadata("/queue/orders", "payload"));
+        system.close();
+
+        assertThatThrownBy(() -> system.record(metadata("/queue/orders", "next")))
+                .isInstanceOf(BackupException.class)
+                .hasMessageContaining("stopped");
+    }
+
+    private Metadata metadata(String destination, String payload) {
+        Buffer buffer = Buffer.alloc(payload, UTF_8);
+        try {
+            return Metadata.create(Type.MESSAGE_APPEND, 100, destination, buffer);
+        } finally {
+            buffer.release();
+        }
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileHandlerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileHandlerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.util.file.FileHandle;
-import org.traffichunter.titan.core.util.file.FileUtils;
+import org.traffichunter.titan.core.util.file.FileHandler;
 
 import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
@@ -26,10 +26,20 @@ import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
  * @author yun
  */
 @DisplayNameGeneration(ReplaceUnderscores.class)
-class FileUtilsTest {
+class FileHandlerTest {
 
     @TempDir
     private Path tempDir;
+
+    @Test
+    void create_destination_path_name() {
+        String destination = "/queue/orders/test";
+        String destinationPath = "titan_queue_orders_test.aof";
+
+        Path path = FileHandler.resolveDestinationFile(destination);
+
+        assertThat(path.getFileName().toString()).isEqualTo(destinationPath);
+    }
 
     @Test
     void create_directories_and_open_create_file() {
@@ -42,8 +52,8 @@ class FileUtilsTest {
             content.release();
         }
 
-        assertThat(FileUtils.exists(file)).isTrue();
-        assertThat(FileUtils.isFile(file)).isTrue();
+        assertThat(FileHandler.exists(file)).isTrue();
+        assertThat(FileHandler.isFile(file)).isTrue();
     }
 
     @Test
@@ -111,13 +121,13 @@ class FileUtilsTest {
         Path moved = tempDir.resolve("nested/moved.log");
         Files.writeString(source, "data");
 
-        FileUtils.copy(source, copied);
-        FileUtils.move(copied, moved);
-        List<Path> files = FileUtils.list(tempDir);
-        FileUtils.deleteIfExists(source);
+        FileHandler.copy(source, copied);
+        FileHandler.move(copied, moved);
+        List<Path> files = FileHandler.list(tempDir);
+        FileHandler.deleteIfExists(source);
 
-        assertThat(FileUtils.exists(moved)).isTrue();
-        assertThat(FileUtils.exists(source)).isFalse();
+        assertThat(FileHandler.exists(moved)).isTrue();
+        assertThat(FileHandler.exists(source)).isFalse();
         assertThat(files).contains(source);
     }
 
@@ -125,10 +135,10 @@ class FileUtilsTest {
     void create_temp_file_creates_file_under_directory() {
         Path directory = tempDir.resolve("tmp");
 
-        Path temp = FileUtils.createTempFile(directory, "backup-", ".tmp");
+        Path temp = FileHandler.createTempFile(directory, "backup-", ".tmp");
 
         assertThat(temp).hasParent(directory);
-        assertThat(FileUtils.exists(temp)).isTrue();
+        assertThat(FileHandler.exists(temp)).isTrue();
     }
 
     @Test
@@ -138,13 +148,13 @@ class FileUtilsTest {
         Buffer content = Buffer.alloc("new", UTF_8);
 
         try {
-            FileUtils.atomicWrite(file, content);
+            FileHandler.atomicWrite(file, content);
         } finally {
             content.release();
         }
 
         assertThat(Files.readString(file)).isEqualTo("new");
-        assertThat(FileUtils.list(tempDir))
+        assertThat(FileHandler.list(tempDir))
                 .noneMatch(fileItem -> fileItem.getFileName().toString().startsWith(".manifest.json")
                         && fileItem.getFileName().toString().endsWith(".tmp"));
     }
@@ -157,9 +167,9 @@ class FileUtilsTest {
         Buffer read = null;
 
         try {
-            FileUtils.write(file, first);
-            long offset = FileUtils.append(file, second);
-            read = FileUtils.read(file);
+            FileHandler.write(file, first);
+            long offset = FileHandler.append(file, second);
+            read = FileHandler.read(file);
 
             assertThat(offset).isEqualTo(5);
             assertThat(read.toString(UTF_8)).isEqualTo("hello titan");

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
@@ -53,20 +53,31 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * virtual-thread variants.
  *
  * <p>Each destination has at most one active consumer task in {@link #consumers}.
- * Producer calls enqueue messages into a dispatcher queue, and the destination
- * consumer drains that queue sequentially into the configured
- * {@link FanoutExporter}. This gives a simple fanout invariant: ordering is
- * preserved per destination queue, while different destinations can progress
- * independently on the executor.</p>
+ * Producer calls are processed through a {@link FanoutHandlerChain}. The gateway
+ * always installs routing as the first handler and dispatch as the last handler,
+ * while optional middle handlers can add behavior such as backup without being
+ * embedded in the core fanout flow.</p>
+ *
+ * <p>Routing enqueues the message into the dispatcher queue. Dispatch starts the
+ * destination consumer if needed, and that consumer drains the queue sequentially
+ * into the configured {@link FanoutExporter}. This gives a simple fanout invariant:
+ * ordering is preserved per destination queue, while different destinations can
+ * progress independently on the executor.</p>
  *
  * <pre>{@code
  * publish(message)
  *      |
  *      v
- * route(message) -> DispatcherQueue(destination).enqueue(message)
+ * FanoutHandlerChain
  *      |
  *      v
- * fanout(destination) -> computeIfAbsent(destination, consume)
+ * RouteFanoutHandler -> DispatcherQueue(destination).enqueue(message)
+ *      |
+ *      v
+ * optional middle handlers (backup, metrics, ...)
+ *      |
+ *      v
+ * DispatchFanoutHandler -> fanout(destination) -> computeIfAbsent(destination, consume)
  *      |
  *      v
  * consume loop -> dispatcherQueue.dispatch() -> exporter.export(...)
@@ -81,6 +92,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractExecutorFanoutGateway.class);
+    private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
 
     private final Map<Destination, Future<?>> consumers = new ConcurrentHashMap<>();
     private final Set<DispatcherQueue> deletedQueues = ConcurrentHashMap.newKeySet();
@@ -90,6 +102,7 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
     private final Dispatcher dispatcher;
     private final AtomicBoolean isClosed = new AtomicBoolean();
     private final Damper damper;
+    private final FanoutHandlerChain fanoutHandlerChain;
 
     protected AbstractExecutorFanoutGateway(
             ExecutorService executor,
@@ -105,10 +118,24 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
             Dispatcher dispatcher,
             Damper damper
     ) {
+        this(executor, exporter, dispatcher, damper, FanoutHandlerChain.chain());
+    }
+
+    protected AbstractExecutorFanoutGateway(
+            ExecutorService executor,
+            FanoutExporter exporter,
+            Dispatcher dispatcher,
+            Damper damper,
+            FanoutHandlerChain fanoutChainHandlers
+    ) {
         this.executor = executor;
         this.exporter = exporter;
         this.dispatcher = dispatcher;
         this.damper = damper;
+        this.fanoutHandlerChain = FanoutHandlerChain.chain()
+                .add(new RouteFanoutHandler(executor, this::route))
+                .addAll(fanoutChainHandlers)
+                .add(new DispatchFanoutHandler(this::fanout));
     }
 
     @Override
@@ -157,12 +184,7 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
             throw new IllegalStateException("FanoutGateway is closed");
         }
 
-        return CompletableFuture.runAsync(() -> {
-            Message result = route(message);
-            if(result != null) {
-                fanout(result.getDestination());
-            }
-        }, executor);
+        return fanoutHandlerChain.next(new FanoutContext(message));
     }
 
     @Override
@@ -181,6 +203,22 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
             consumers.values().forEach(future -> future.cancel(true));
             consumers.clear();
             executor.shutdown();
+            try {
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                    if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        log.warn("Fanout executor did not terminate cleanly");
+                    }
+                }
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+            try {
+                fanoutHandlerChain.close();
+            } catch (Exception e) {
+                log.warn("Failed to close fanout handler chain", e);
+            }
         }
     }
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
@@ -31,6 +31,7 @@ import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueue;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueDeleteResult;
 import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.concurrent.Damper;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.concurrent.NoopDamper;
@@ -102,7 +103,8 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
     private final Dispatcher dispatcher;
     private final AtomicBoolean isClosed = new AtomicBoolean();
     private final Damper damper;
-    private final FanoutHandlerChain fanoutHandlerChain;
+
+    private FanoutHandlerChain fanoutHandlerChain;
 
     protected AbstractExecutorFanoutGateway(
             ExecutorService executor,
@@ -118,30 +120,27 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
             Dispatcher dispatcher,
             Damper damper
     ) {
-        this(executor, exporter, dispatcher, damper, FanoutHandlerChain.chain());
-    }
-
-    protected AbstractExecutorFanoutGateway(
-            ExecutorService executor,
-            FanoutExporter exporter,
-            Dispatcher dispatcher,
-            Damper damper,
-            FanoutHandlerChain fanoutChainHandlers
-    ) {
         this.executor = executor;
         this.exporter = exporter;
         this.dispatcher = dispatcher;
         this.damper = damper;
         this.fanoutHandlerChain = FanoutHandlerChain.chain()
                 .add(new RouteFanoutHandler(executor, this::route))
-                .addAll(fanoutChainHandlers)
                 .add(new DispatchFanoutHandler(this::fanout));
     }
 
     @Override
-    public List<Future<@Nullable Void>> fanout(Collection<Destination> destinations) {
-        Assert.checkNotNull(destinations, "destinations");
+    public FanoutGateway chainHandler(Handler<FanoutHandlerChain> chainHandler) {
+        FanoutHandlerChain chain = FanoutHandlerChain.chain();
+        chain.add(new RouteFanoutHandler(executor, this::route));
+        chainHandler.handle(chain);
+        chain.add(new DispatchFanoutHandler(this::fanout));
+        this.fanoutHandlerChain = chain;
+        return this;
+    }
 
+    @Override
+    public List<Future<@Nullable Void>> fanout(Collection<Destination> destinations) {
         if (isClosed.get()) {
             throw new IllegalStateException("FanoutGateway is closed");
         }
@@ -154,8 +153,6 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
     @SuppressWarnings("unchecked")
     @Override
     public Future<@Nullable Void> fanout(Destination destination) {
-        Assert.checkNotNull(destination, "destination");
-
         if (isClosed.get()) {
             throw new IllegalStateException("FanoutGateway is closed");
         }
@@ -165,8 +162,6 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
 
     @Override
     public List<Future<@Nullable Void>> publish(Collection<Message> messages) {
-        Assert.checkNotNull(messages, "messages");
-
         if (isClosed.get()) {
             throw new IllegalStateException("FanoutGateway is closed");
         }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/BackupFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/BackupFanoutHandler.java
@@ -1,0 +1,63 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.resilience.backup.DestinationBackupSystem;
+import org.traffichunter.titan.core.resilience.backup.Metadata;
+import org.traffichunter.titan.core.resilience.backup.Type;
+import org.traffichunter.titan.core.util.HandlerChain;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author yun
+ */
+public class BackupFanoutHandler implements FanoutHandler, AutoCloseable {
+
+    private final DestinationBackupSystem backupSystem;
+
+    public BackupFanoutHandler(DestinationBackupSystem backupSystem) {
+        this.backupSystem = backupSystem;
+    }
+
+    @Override
+    public CompletableFuture<Void> handle(FanoutContext context, HandlerChain<FanoutContext> chain) {
+        Message routed = context.getRoutedMessage();
+        if (routed != null) {
+            backupSystem.record(Metadata.create(
+                    Type.MESSAGE_APPEND,
+                    System.currentTimeMillis(),
+                    routed.getDestination().path(),
+                    routed.getBody()
+            ));
+        }
+        return chain.next(context);
+    }
+
+    @Override
+    public void close() throws Exception {
+        backupSystem.close();
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/DispatchFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/DispatchFanoutHandler.java
@@ -1,0 +1,53 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.HandlerChain;
+
+/**
+ * Starts the destination consumer after a message has been routed.
+ *
+ * @author yun
+ */
+final class DispatchFanoutHandler implements FanoutHandler {
+
+    private final Consumer<Destination> fanout;
+
+    DispatchFanoutHandler(Consumer<Destination> fanout) {
+        this.fanout = fanout;
+    }
+
+    @Override
+    public CompletableFuture<Void> handle(FanoutContext context, HandlerChain<FanoutContext> chain) {
+        Message routed = context.getRoutedMessage();
+        if (routed != null) {
+            fanout.accept(routed.getDestination());
+        }
+        return chain.next(context);
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutContext.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutContext.java
@@ -1,0 +1,54 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.message.Message;
+
+/**
+ * Mutable state shared while one message moves through the fanout chain.
+ *
+ * @author yun
+ */
+public class FanoutContext {
+
+    private final Message message;
+    private @Nullable Message routedMessage;
+
+    public FanoutContext(Message message) {
+        this.message = message;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public @Nullable Message getRoutedMessage() {
+        return routedMessage;
+    }
+
+    public void setRoutedMessage(@Nullable Message routedMessage) {
+        this.routedMessage = routedMessage;
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
@@ -23,16 +23,16 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.fanout;
 
-import org.traffichunter.titan.core.message.Message;
-import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.fanout.exporter.FanoutExporter;
-
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManager;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 
 /**
  * Asynchronous ingress and routing facade for fanout delivery.
@@ -59,8 +59,25 @@ public interface FanoutGateway extends Closeable, DispatcherQueueManager {
         return new ThreadPoolExecutorFanoutGateway(exporter);
     }
 
+    static FanoutGateway ofThread(FanoutExporter exporter, FanoutHandlerChain middleHandlers) {
+        return new ThreadPoolExecutorFanoutGateway(
+                Runtime.getRuntime().availableProcessors() * 2,
+                exporter,
+                Dispatcher.getDefault(),
+                middleHandlers
+        );
+    }
+
     static FanoutGateway ofVirtual(FanoutExporter exporter) {
         return new VirtualThreadExecutorFanoutGateway(exporter);
+    }
+
+    static FanoutGateway ofVirtual(FanoutExporter exporter, FanoutHandlerChain middleHandlers) {
+        return new VirtualThreadExecutorFanoutGateway(
+                exporter,
+                Dispatcher.getDefault(),
+                middleHandlers
+        );
     }
 
     /**

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutGateway.java
@@ -27,11 +27,14 @@ import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManager;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 
 /**
@@ -59,26 +62,24 @@ public interface FanoutGateway extends Closeable, DispatcherQueueManager {
         return new ThreadPoolExecutorFanoutGateway(exporter);
     }
 
-    static FanoutGateway ofThread(FanoutExporter exporter, FanoutHandlerChain middleHandlers) {
-        return new ThreadPoolExecutorFanoutGateway(
-                Runtime.getRuntime().availableProcessors() * 2,
-                exporter,
-                Dispatcher.getDefault(),
-                middleHandlers
-        );
-    }
-
     static FanoutGateway ofVirtual(FanoutExporter exporter) {
         return new VirtualThreadExecutorFanoutGateway(exporter);
     }
 
-    static FanoutGateway ofVirtual(FanoutExporter exporter, FanoutHandlerChain middleHandlers) {
-        return new VirtualThreadExecutorFanoutGateway(
-                exporter,
-                Dispatcher.getDefault(),
-                middleHandlers
-        );
-    }
+    /**
+     * Configures the fanout handler chain used by {@link #publish(Message)}.
+     *
+     * <p>The gateway adds the built-in route handler before invoking the callback and
+     * appends the built-in dispatch handler after the callback returns. Handlers added
+     * by the callback therefore run between routing and dispatch, which is the intended
+     * extension point for cross-cutting fanout behavior such as backup, metrics, or
+     * filtering.</p>
+     *
+     * @param chainHandler callback that adds custom handlers to the chain
+     * @return this gateway
+     */
+    @CanIgnoreReturnValue
+    FanoutGateway chainHandler(Handler<FanoutHandlerChain> chainHandler);
 
     /**
      * Starts consumers for the destinations if they are not already running.

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandler.java
@@ -33,5 +33,7 @@ import org.traffichunter.titan.core.util.HandlerChain;
  */
 public interface FanoutHandler {
 
+    FanoutHandler NOOP = (context, chain) -> chain.next(context);
+
     CompletableFuture<Void> handle(FanoutContext context, HandlerChain<FanoutContext> chain);
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandler.java
@@ -1,0 +1,37 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import java.util.concurrent.CompletableFuture;
+import org.traffichunter.titan.core.util.HandlerChain;
+
+/**
+ * Handles one step in the fanout publish lifecycle.
+ *
+ * @author yun
+ */
+public interface FanoutHandler {
+
+    CompletableFuture<Void> handle(FanoutContext context, HandlerChain<FanoutContext> chain);
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandlerChain.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandlerChain.java
@@ -1,0 +1,117 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.util.HandlerChain;
+
+/**
+ * Default forward-only fanout handler chain.
+ *
+ * @author yun
+ */
+public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoCloseable {
+
+    private final FanoutHandler handler;
+    private @Nullable FanoutHandlerChain next;
+    private FanoutHandlerChain tail;
+
+    public FanoutHandlerChain() {
+        this((context, chain) -> chain.next(context));
+        this.tail = this;
+    }
+
+    public FanoutHandlerChain(FanoutHandler... handlers) {
+        this(List.of(handlers));
+    }
+
+    public FanoutHandlerChain(List<FanoutHandler> handlers) {
+        this();
+        handlers.forEach(this::add);
+    }
+
+    private FanoutHandlerChain(FanoutHandler handler) {
+        this.handler = handler;
+        this.tail = this;
+    }
+
+    public static FanoutHandlerChain chain() {
+        return new FanoutHandlerChain();
+    }
+
+    @CanIgnoreReturnValue
+    public FanoutHandlerChain add(FanoutHandler handler) {
+        FanoutHandlerChain context = new FanoutHandlerChain(handler);
+        tail.next = context;
+        tail = context;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public FanoutHandlerChain addAll(FanoutHandlerChain chain) {
+        FanoutHandlerChain context = chain.next;
+        while (context != null) {
+            add(context.handler);
+            context = context.next;
+        }
+        return this;
+    }
+
+    @Override
+    public CompletableFuture<Void> next(FanoutContext context) {
+        FanoutHandlerChain chain = next;
+        if (chain == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        return chain.handler.handle(context, chain);
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        FanoutHandlerChain context = next;
+        while (context != null) {
+            if (context.handler instanceof AutoCloseable closeable) {
+                try {
+                    closeable.close();
+                } catch (Exception e) {
+                    if (failure == null) {
+                        failure = e;
+                    } else {
+                        failure.addSuppressed(e);
+                    }
+                }
+            }
+            context = context.next;
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandlerChain.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutHandlerChain.java
@@ -36,13 +36,11 @@ import org.traffichunter.titan.core.util.HandlerChain;
  */
 public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoCloseable {
 
-    private final FanoutHandler handler;
-    private @Nullable FanoutHandlerChain next;
-    private FanoutHandlerChain tail;
+    private final FanoutHandlerChainImpl head;
+    private FanoutHandlerChainImpl tail;
 
     public FanoutHandlerChain() {
-        this((context, chain) -> chain.next(context));
-        this.tail = this;
+        this.head = this.tail = new FanoutHandlerChainImpl(FanoutHandler.NOOP);
     }
 
     public FanoutHandlerChain(FanoutHandler... handlers) {
@@ -54,18 +52,13 @@ public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoClos
         handlers.forEach(this::add);
     }
 
-    private FanoutHandlerChain(FanoutHandler handler) {
-        this.handler = handler;
-        this.tail = this;
-    }
-
     public static FanoutHandlerChain chain() {
         return new FanoutHandlerChain();
     }
 
     @CanIgnoreReturnValue
     public FanoutHandlerChain add(FanoutHandler handler) {
-        FanoutHandlerChain context = new FanoutHandlerChain(handler);
+        FanoutHandlerChainImpl context = new FanoutHandlerChainImpl(handler);
         tail.next = context;
         tail = context;
         return this;
@@ -73,7 +66,7 @@ public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoClos
 
     @CanIgnoreReturnValue
     public FanoutHandlerChain addAll(FanoutHandlerChain chain) {
-        FanoutHandlerChain context = chain.next;
+        FanoutHandlerChainImpl context = chain.head.next;
         while (context != null) {
             add(context.handler);
             context = context.next;
@@ -83,18 +76,13 @@ public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoClos
 
     @Override
     public CompletableFuture<Void> next(FanoutContext context) {
-        FanoutHandlerChain chain = next;
-        if (chain == null) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        return chain.handler.handle(context, chain);
+        return head.next(context);
     }
 
     @Override
     public void close() throws Exception {
         Exception failure = null;
-        FanoutHandlerChain context = next;
+        FanoutHandlerChainImpl context = head.next;
         while (context != null) {
             if (context.handler instanceof AutoCloseable closeable) {
                 try {
@@ -112,6 +100,26 @@ public class FanoutHandlerChain implements HandlerChain<FanoutContext>, AutoClos
 
         if (failure != null) {
             throw failure;
+        }
+    }
+
+    private static final class FanoutHandlerChainImpl implements HandlerChain<FanoutContext> {
+
+        private final FanoutHandler handler;
+        private @Nullable FanoutHandlerChainImpl next;
+
+        private FanoutHandlerChainImpl(FanoutHandler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public CompletableFuture<Void> next(FanoutContext context) {
+            FanoutHandlerChainImpl chain = next;
+            if (chain == null) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            return chain.handler.handle(context, chain);
         }
     }
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
@@ -44,21 +44,11 @@ public enum FanoutMode {
         public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
             return FanoutGateway.ofThread(fanoutExporter);
         }
-
-        @Override
-        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers) {
-            return FanoutGateway.ofThread(fanoutExporter, middleHandlers);
-        }
     },
     VT_EXECUTOR("virtual") {
         @Override
         public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
             return FanoutGateway.ofVirtual(fanoutExporter);
-        }
-
-        @Override
-        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers) {
-            return FanoutGateway.ofVirtual(fanoutExporter, middleHandlers);
         }
     },
     ;
@@ -70,8 +60,6 @@ public enum FanoutMode {
     }
 
     public abstract FanoutGateway fanoutGateway(FanoutExporter fanoutExporter);
-
-    public abstract FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers);
 
     public static FanoutMode resolveMode(String modeName) {
         return switch (modeName) {

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/FanoutMode.java
@@ -44,11 +44,21 @@ public enum FanoutMode {
         public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
             return FanoutGateway.ofThread(fanoutExporter);
         }
+
+        @Override
+        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers) {
+            return FanoutGateway.ofThread(fanoutExporter, middleHandlers);
+        }
     },
     VT_EXECUTOR("virtual") {
         @Override
         public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter) {
             return FanoutGateway.ofVirtual(fanoutExporter);
+        }
+
+        @Override
+        public FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers) {
+            return FanoutGateway.ofVirtual(fanoutExporter, middleHandlers);
         }
     },
     ;
@@ -60,6 +70,8 @@ public enum FanoutMode {
     }
 
     public abstract FanoutGateway fanoutGateway(FanoutExporter fanoutExporter);
+
+    public abstract FanoutGateway fanoutGateway(FanoutExporter fanoutExporter, FanoutHandlerChain middleHandlers);
 
     public static FanoutMode resolveMode(String modeName) {
         return switch (modeName) {

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/RouteFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/RouteFanoutHandler.java
@@ -1,0 +1,56 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.fanout;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.util.HandlerChain;
+
+/**
+ * Routes a published message into memory before later fanout handlers run.
+ *
+ * @author yun
+ */
+final class RouteFanoutHandler implements FanoutHandler {
+
+    private final Executor executor;
+    private final Function<Message, @Nullable Message> route;
+
+    RouteFanoutHandler(Executor executor, Function<Message, @Nullable Message> route) {
+        this.executor = executor;
+        this.route = route;
+    }
+
+    @Override
+    public CompletableFuture<Void> handle(FanoutContext context, HandlerChain<FanoutContext> chain) {
+        return CompletableFuture.supplyAsync(() -> route.apply(context.getMessage()), executor)
+                .thenCompose(routed -> {
+                    context.setRoutedMessage(routed);
+                    return chain.next(context);
+                });
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
@@ -1,10 +1,14 @@
 package org.traffichunter.titan.fanout;
 
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.bootstrap.Settings;
+import org.traffichunter.titan.core.resilience.backup.BackupOption;
+import org.traffichunter.titan.core.resilience.backup.DestinationBackupSystem;
 import org.traffichunter.titan.core.spi.*;
 
 /**
@@ -47,6 +51,31 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
 
     @Override
     public void apply(
+            Settings settings,
+            final String protocol,
+            final String transport,
+            final Map<String, String> protocolOptions,
+            final ManagedServer managedServer
+    ) {
+        FanoutMode mode = resolveMode(protocolOptions);
+        FanoutHandlerChain fanoutChainHandlers = fanoutHandlers(settings.backup());
+        ManagedServerFanoutAdapter adapter = findAdapter(protocol, transport, protocolOptions, managedServer);
+        if (adapter == null) {
+            throw new IllegalStateException("No fanout adapter for protocol=" + protocol + ", transport=" + transport);
+        }
+
+        adapter.apply(
+                protocol,
+                transport,
+                protocolOptions,
+                managedServer,
+                exporter -> mode.fanoutGateway(exporter, fanoutChainHandlers)
+        );
+        log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), managedServer.name());
+    }
+
+    @Override
+    public void apply(
             final String protocol,
             final String transport,
             final Map<String, String> protocolOptions,
@@ -60,6 +89,23 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
 
         adapter.apply(protocol, transport, protocolOptions, managedServer, mode::fanoutGateway);
         log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), managedServer.name());
+    }
+
+    private static FanoutHandlerChain fanoutHandlers(Settings.BackupSettings backupSettings) {
+        FanoutHandlerChain chain = FanoutHandlerChain.chain();
+        if (!backupSettings.enabled()) {
+            return chain;
+        }
+
+        BackupOption option = BackupOption.fromConfig(
+                backupSettings.type(),
+                backupSettings.syncPolicy(),
+                backupSettings.recoveryPolicy()
+        );
+        DestinationBackupSystem backupSystem = backupSettings.path().isBlank()
+                ? new DestinationBackupSystem(option)
+                : new DestinationBackupSystem(Path.of(backupSettings.path()), option);
+        return chain.add(new BackupFanoutHandler(backupSystem));
     }
 
     private static @Nullable ManagedServerFanoutAdapter findAdapter(

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
@@ -58,7 +58,6 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
             final ManagedServer managedServer
     ) {
         FanoutMode mode = resolveMode(protocolOptions);
-        FanoutHandlerChain fanoutChainHandlers = fanoutHandlers(settings.backup());
         ManagedServerFanoutAdapter adapter = findAdapter(protocol, transport, protocolOptions, managedServer);
         if (adapter == null) {
             throw new IllegalStateException("No fanout adapter for protocol=" + protocol + ", transport=" + transport);
@@ -69,7 +68,10 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
                 transport,
                 protocolOptions,
                 managedServer,
-                exporter -> mode.fanoutGateway(exporter, fanoutChainHandlers)
+                exporter -> mode.fanoutGateway(exporter)
+                        .chainHandler(chain ->
+                                chain.add(backupSystemFanoutHandler(settings.backup()))
+                        )
         );
         log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), managedServer.name());
     }
@@ -91,10 +93,9 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
         log.info("Fanout launcher started fanout mode = {}, fanout server = {}", mode.getName(), managedServer.name());
     }
 
-    private static FanoutHandlerChain fanoutHandlers(Settings.BackupSettings backupSettings) {
-        FanoutHandlerChain chain = FanoutHandlerChain.chain();
-        if (!backupSettings.enabled()) {
-            return chain;
+    private FanoutHandler backupSystemFanoutHandler(Settings.BackupSettings backupSettings) {
+        if (backupSettings.enabled()) {
+            return FanoutHandler.NOOP;
         }
 
         BackupOption option = BackupOption.fromConfig(
@@ -105,7 +106,7 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
         DestinationBackupSystem backupSystem = backupSettings.path().isBlank()
                 ? new DestinationBackupSystem(option)
                 : new DestinationBackupSystem(Path.of(backupSettings.path()), option);
-        return chain.add(new BackupFanoutHandler(backupSystem));
+        return new BackupFanoutHandler(backupSystem);
     }
 
     private static @Nullable ManagedServerFanoutAdapter findAdapter(

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
@@ -48,22 +48,16 @@ class ThreadPoolExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
         this(Runtime.getRuntime().availableProcessors() * 2, exporter, dispatcher);
     }
 
-    public ThreadPoolExecutorFanoutGateway(int nThreads, FanoutExporter exporter, Dispatcher dispatcher) {
-        this(nThreads, exporter, dispatcher, FanoutHandlerChain.chain());
-    }
-
     public ThreadPoolExecutorFanoutGateway(
             int nThreads,
             FanoutExporter exporter,
-            Dispatcher dispatcher,
-            FanoutHandlerChain fanoutChainHanders
+            Dispatcher dispatcher
     ) {
         super(
                 Executors.newFixedThreadPool(nThreads, newThreadFactory()),
                 exporter,
                 dispatcher,
-                NoopDamper.getInstance(),
-                fanoutChainHanders
+                NoopDamper.getInstance()
         );
     }
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/ThreadPoolExecutorFanoutGateway.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import org.traffichunter.titan.core.message.dispatcher.Dispatcher;
+import org.traffichunter.titan.core.util.concurrent.NoopDamper;
 import org.traffichunter.titan.fanout.exporter.FanoutExporter;
 
 import java.util.concurrent.Executors;
@@ -48,7 +49,22 @@ class ThreadPoolExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
     }
 
     public ThreadPoolExecutorFanoutGateway(int nThreads, FanoutExporter exporter, Dispatcher dispatcher) {
-        super(Executors.newFixedThreadPool(nThreads, newThreadFactory()), exporter, dispatcher);
+        this(nThreads, exporter, dispatcher, FanoutHandlerChain.chain());
+    }
+
+    public ThreadPoolExecutorFanoutGateway(
+            int nThreads,
+            FanoutExporter exporter,
+            Dispatcher dispatcher,
+            FanoutHandlerChain fanoutChainHanders
+    ) {
+        super(
+                Executors.newFixedThreadPool(nThreads, newThreadFactory()),
+                exporter,
+                dispatcher,
+                NoopDamper.getInstance(),
+                fanoutChainHanders
+        );
     }
 
     private static ThreadFactory newThreadFactory() {

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
@@ -49,21 +49,15 @@ class VirtualThreadExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
         this(exporter, Dispatcher.getDefault());
     }
 
-    public VirtualThreadExecutorFanoutGateway(FanoutExporter exporter, Dispatcher dispatcher) {
-        this(exporter, dispatcher, FanoutHandlerChain.chain());
-    }
-
     public VirtualThreadExecutorFanoutGateway(
             FanoutExporter exporter,
-            Dispatcher dispatcher,
-            FanoutHandlerChain fanoutChainHandlers
+            Dispatcher dispatcher
     ) {
         super(
                 Executors.newThreadPerTaskExecutor(newThreadFactory()),
                 exporter,
                 dispatcher,
-                new SemaphoreBasedFlowControlDamper(DEFAULT_CONCURRENCY_LIMIT),
-                fanoutChainHandlers
+                new SemaphoreBasedFlowControlDamper(DEFAULT_CONCURRENCY_LIMIT)
         );
     }
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VirtualThreadExecutorFanoutGateway.java
@@ -50,11 +50,20 @@ class VirtualThreadExecutorFanoutGateway extends AbstractExecutorFanoutGateway {
     }
 
     public VirtualThreadExecutorFanoutGateway(FanoutExporter exporter, Dispatcher dispatcher) {
+        this(exporter, dispatcher, FanoutHandlerChain.chain());
+    }
+
+    public VirtualThreadExecutorFanoutGateway(
+            FanoutExporter exporter,
+            Dispatcher dispatcher,
+            FanoutHandlerChain fanoutChainHandlers
+    ) {
         super(
                 Executors.newThreadPerTaskExecutor(newThreadFactory()),
                 exporter,
                 dispatcher,
-                new SemaphoreBasedFlowControlDamper(DEFAULT_CONCURRENCY_LIMIT)
+                new SemaphoreBasedFlowControlDamper(DEFAULT_CONCURRENCY_LIMIT),
+                fanoutChainHandlers
         );
     }
 

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/FanoutHandlerChainTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/FanoutHandlerChainTest.java
@@ -1,0 +1,135 @@
+package org.traffichunter.titan.fanout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.message.Priority;
+import org.traffichunter.titan.core.resilience.backup.BackupOption;
+import org.traffichunter.titan.core.resilience.backup.DestinationBackupSystem;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.file.FileHandler;
+
+class FanoutHandlerChainTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void chain_runs_handlers_in_order() {
+        List<String> calls = new ArrayList<>();
+        FanoutHandlerChain chain = new FanoutHandlerChain()
+                .add((context, next) -> {
+                    calls.add("first");
+                    return next.next(context);
+                })
+                .add((context, next) -> {
+                    calls.add("second");
+                    return next.next(context);
+                });
+
+        chain.next(new FanoutContext(message("/queue/chain-order"))).join();
+
+        assertThat(calls).containsExactly("first", "second");
+    }
+
+    @Test
+    void route_handler_sets_routed_message_before_next_handler() {
+        Message message = message("/queue/route");
+        FanoutHandlerChain chain = new FanoutHandlerChain(List.of(
+                new RouteFanoutHandler(Runnable::run, ignored -> message),
+                (context, next) -> {
+                    assertThat(context.getRoutedMessage()).isSameAs(message);
+                    return next.next(context);
+                }
+        ));
+
+        chain.next(new FanoutContext(message)).join();
+    }
+
+    @Test
+    void dispatch_handler_ignores_unrouted_message() {
+        AtomicInteger fanoutCount = new AtomicInteger();
+        FanoutHandlerChain chain = new FanoutHandlerChain(List.of(
+                new DispatchFanoutHandler(ignored -> fanoutCount.incrementAndGet())
+        ));
+
+        chain.next(new FanoutContext(message("/queue/no-route"))).join();
+
+        assertThat(fanoutCount).hasValue(0);
+    }
+
+    @Test
+    void dispatch_handler_uses_routed_destination() {
+        AtomicInteger fanoutCount = new AtomicInteger();
+        Message message = message("/queue/fanout");
+        FanoutContext context = new FanoutContext(message);
+        context.setRoutedMessage(message);
+        FanoutHandlerChain chain = new FanoutHandlerChain(List.of(
+                new DispatchFanoutHandler(destination -> {
+                    assertThat(destination).isEqualTo(message.getDestination());
+                    fanoutCount.incrementAndGet();
+                })
+        ));
+
+        chain.next(context).join();
+
+        assertThat(fanoutCount).hasValue(1);
+    }
+
+    @Test
+    void route_handler_can_run_on_supplied_executor() {
+        try (var executor = Executors.newSingleThreadExecutor()) {
+            Message message = message("/queue/async-route");
+            FanoutHandlerChain chain = new FanoutHandlerChain(List.of(
+                    new RouteFanoutHandler(executor, ignored -> message)
+            ));
+
+            CompletableFuture<?> future = chain.next(new FanoutContext(message));
+
+            future.join();
+        }
+    }
+
+    @Test
+    void middle_chain_can_add_backup_between_route_and_dispatch() throws Exception {
+        DestinationBackupSystem backupSystem = new DestinationBackupSystem(
+                tempDir,
+                BackupOption.fromConfig("aof", "no", null)
+        );
+        Message message = message("/queue/backup-chain");
+        AtomicInteger fanoutCount = new AtomicInteger();
+        FanoutHandlerChain middleHandlers = FanoutHandlerChain.chain()
+                .add(new BackupFanoutHandler(backupSystem));
+        FanoutHandlerChain.chain()
+                .add(new RouteFanoutHandler(Runnable::run, ignored -> message))
+                .addAll(middleHandlers)
+                .add(new DispatchFanoutHandler(ignored -> fanoutCount.incrementAndGet()))
+                .next(new FanoutContext(message))
+                .join();
+
+        backupSystem.close();
+
+        assertThat(fanoutCount).hasValue(1);
+        assertThat(FileHandler.resolveDestinationFile(tempDir, "/queue/backup-chain")).exists();
+    }
+
+    private static Message message(String destination) {
+        return Message.builder()
+                .priority(Priority.DEFAULT)
+                .destination(Destination.create(destination))
+                .createdAt(Instant.now())
+                .producerId("test")
+                .body(Buffer.alloc("test".getBytes()))
+                .build();
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompReconnectIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompReconnectIntegrationTest.java
@@ -33,6 +33,7 @@ import java.net.SocketAddress;
 import java.time.Duration;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
@@ -44,8 +45,10 @@ import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
 class StompReconnectIntegrationTest {
 
     private static final String HOST = "127.0.0.1";
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 20;
 
     @Test
+    @Timeout(value = 20, unit = SECONDS)
     void client_reconnects_after_server_restart() throws Exception {
         StompServer server = startServer(0);
         int port = localPort(server);
@@ -54,11 +57,11 @@ class StompReconnectIntegrationTest {
         try {
             StompConnection initialConnection = client.connect().get(3, SECONDS);
             StompServer initialServer = server;
-            await().atMost(3, SECONDS)
+            await().atMost(10, SECONDS)
                     .untilAsserted(() -> assertThat(initialServer.connection().connections()).hasSize(1));
 
-            server.shutdown();
-            await().atMost(3, SECONDS)
+            server.shutdown(SHUTDOWN_TIMEOUT_SECONDS, SECONDS);
+            await().atMost(10, SECONDS)
                     .untilAsserted(() -> assertThat(initialConnection.isConnected()).isFalse());
 
             server = startServer(port);
@@ -71,9 +74,9 @@ class StompReconnectIntegrationTest {
                         assertThat(client.connection().isConnected()).isTrue();
                     });
         } finally {
-            client.shutdown();
+            client.shutdown(SHUTDOWN_TIMEOUT_SECONDS, SECONDS);
             if (!server.isShutdown()) {
-                server.shutdown();
+                server.shutdown(SHUTDOWN_TIMEOUT_SECONDS, SECONDS);
             }
         }
     }

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompServerExtension.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompServerExtension.java
@@ -45,6 +45,7 @@ public final class StompServerExtension implements
         AfterEachCallback,
         ParameterResolver {
 
+    private static final int SHUTDOWN_TIMEOUT_SECONDS = 3;
     private static final ExtensionContext.Namespace NS = ExtensionContext.Namespace.create(StompServerExtension.class);
     private static final String KEY = "stomp-test-server";
 
@@ -87,7 +88,7 @@ public final class StompServerExtension implements
     public void afterEach(ExtensionContext context) {
         StompTestServer testServer = context.getStore(NS).remove(KEY, StompTestServer.class);
         if (testServer != null) {
-            testServer.server().shutdown();
+            testServer.server().shutdown(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
## Motivation:

Add the first destination-scoped backup path for fanout messages and make reconnect failures easier to observe during STOMP reconnect tests.

## Modification:

Introduce destination backup coordinators and a destination backup system on top of the append-only file support. Add a linked fanout handler chain with route, backup, and dispatch handlers so backup can be composed into the fanout flow. Rename the file utility API toward file handling semantics and update related tests. Propagate non-blocking connect failures from `finishConnect()` instead of letting them surface later as connect completion timeouts, and add JUnit timeout protection around the reconnect integration test.

## Result:

Destination backup can be attached through the fanout chain, append-only backup files are managed per destination, and STOMP reconnect failures now fail fast with their original connect error.

Validation:

- `./gradlew :core:compileJava :titan-stomp:test --rerun-tasks --no-configuration-cache`
