### PR TITLE
Register shutdown hook for fanout cleanup

### DIFF
--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/GlobalShutdownHook.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/GlobalShutdownHook.java
@@ -44,11 +44,13 @@ public enum GlobalShutdownHook {
         return shutdownHook.isEnabled();
     }
 
-    public void addShutdownCallback(final Runnable runnable) {
-        shutdownHook.addShutdownCallback(runnable);
+    public void registerShutdownHook() {
+        shutdownHook.register();
     }
 
-    public Runnable action() {
-        return shutdownHook;
+    public void addShutdownCallback(final Runnable runnable) {
+        if (shutdownHook.isEnabled()) {
+            shutdownHook.addShutdownCallback(runnable);
+        }
     }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
@@ -77,6 +77,7 @@ public final class TitanBootstrap {
         try {
             ApplicationStarter applicationStarter = invokeCoreApplication(TitanBootstrap.class.getClassLoader());
 
+            GlobalShutdownHook.INSTANCE.registerShutdownHook();
             applicationStarter.start(settings);
         } catch (Exception e) {
             log.error("Failed bootstrapping titan = {}", e.getMessage());

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanShutdownHook.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanShutdownHook.java
@@ -26,18 +26,25 @@ package org.traffichunter.titan.bootstrap;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Registers Titan cleanup callbacks with the JVM shutdown hook mechanism.
  *
  * <p>Callbacks may be added by multiple runtime components. When this hook is
- * enabled and run, each callback is registered as a JVM shutdown hook thread.
- * The indirection allows bootstrap code to decide when shutdown integration is
- * active while still letting modules contribute their own cleanup work.</p>
+ * enabled and registered, the hook itself is installed once with the JVM. At
+ * shutdown time it runs every callback that modules contributed during
+ * bootstrap.</p>
  */
 public class TitanShutdownHook implements Runnable {
 
+    private static final Logger log = LoggerFactory.getLogger(TitanShutdownHook.class);
+
     private final Set<Runnable> shutdownCallbacks = ConcurrentHashMap.newKeySet();
+
+    private final AtomicBoolean registered = new AtomicBoolean();
 
     private volatile boolean enabledShutdown;
 
@@ -47,6 +54,14 @@ public class TitanShutdownHook implements Runnable {
 
     public boolean isEnabled() {
         return this.enabledShutdown;
+    }
+
+    public void register() {
+        if (!enabledShutdown || !registered.compareAndSet(false, true)) {
+            return;
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(this, "titan-shutdown-hook"));
     }
 
     @CanIgnoreReturnValue
@@ -62,8 +77,12 @@ public class TitanShutdownHook implements Runnable {
             return;
         }
 
-        for(Runnable callback : shutdownCallbacks) {
-            Runtime.getRuntime().addShutdownHook(new Thread(callback));
+        for (Runnable callback : shutdownCallbacks) {
+            try {
+                callback.run();
+            } catch (Exception e) {
+                log.warn("Failed to run Titan shutdown callback", e);
+            }
         }
     }
 }

--- a/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/TitanShutdownHookTest.java
+++ b/bootstrap/src/test/java/org/traffichunter/titan/bootstrap/TitanShutdownHookTest.java
@@ -1,0 +1,48 @@
+package org.traffichunter.titan.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class TitanShutdownHookTest {
+
+    @Test
+    void run_ignores_callbacks_when_disabled() {
+        TitanShutdownHook shutdownHook = new TitanShutdownHook();
+        AtomicInteger calls = new AtomicInteger();
+
+        shutdownHook.addShutdownCallback(calls::incrementAndGet);
+        shutdownHook.run();
+
+        assertThat(calls).hasValue(0);
+    }
+
+    @Test
+    void run_executes_registered_callbacks_when_enabled() {
+        TitanShutdownHook shutdownHook = new TitanShutdownHook();
+        AtomicInteger calls = new AtomicInteger();
+
+        shutdownHook.enableShutdown();
+        shutdownHook.addShutdownCallback(calls::incrementAndGet);
+        shutdownHook.addShutdownCallback(calls::incrementAndGet);
+        shutdownHook.run();
+
+        assertThat(calls).hasValue(2);
+    }
+
+    @Test
+    void run_continues_after_callback_failure() {
+        TitanShutdownHook shutdownHook = new TitanShutdownHook();
+        AtomicInteger calls = new AtomicInteger();
+
+        shutdownHook.enableShutdown();
+        shutdownHook.addShutdownCallback(() -> {
+            throw new IllegalStateException("boom");
+        });
+        shutdownHook.addShutdownCallback(calls::incrementAndGet);
+        shutdownHook.run();
+
+        assertThat(calls).hasValue(1);
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/AbstractExecutorFanoutGateway.java
@@ -282,14 +282,18 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
                 while (!isClosed()
                         && !Thread.currentThread().isInterrupted()
                         && !deletedQueues.contains(dispatcherQueue)) {
-                    damper.acquire();
                     try {
                         Message message = dispatcherQueue.dispatch(1, TimeUnit.SECONDS);
                         if (message == null) {
                             continue;
                         }
 
-                        exporter.export(destination, message);
+                        damper.acquire();
+                        try {
+                            exporter.export(destination, message);
+                        } finally {
+                            damper.release();
+                        }
                     } catch (InterruptedException e) {
                         log.error("Interrupted while waiting for message to be delivered", e);
                         Thread.currentThread().interrupt();
@@ -299,8 +303,6 @@ abstract class AbstractExecutorFanoutGateway implements FanoutGateway {
                         if (isClosed() || executor.isShutdown()) {
                             break;
                         }
-                    } finally {
-                        damper.release();
                     }
                 }
                 result.complete(null);

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompServerFanoutLauncher.java
@@ -94,7 +94,7 @@ public final class StompServerFanoutLauncher implements FanoutLauncher {
     }
 
     private FanoutHandler backupSystemFanoutHandler(Settings.BackupSettings backupSettings) {
-        if (backupSettings.enabled()) {
+        if (!backupSettings.enabled()) {
             return FanoutHandler.NOOP;
         }
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/TitanStompManagedServerFanoutAdapter.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.StompManagedServer;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManagers;
@@ -40,6 +41,8 @@ import java.util.function.Function;
  */
 @Slf4j
 public final class TitanStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 
     @Override
     public boolean supports(
@@ -64,6 +67,14 @@ public final class TitanStompManagedServerFanoutAdapter implements ManagedServer
         FanoutGateway fanoutGateway = gatewayFactory.apply(
                 new StompFanoutExporter(stompManagedServer.server().connection())
         );
+        SHUTDOWN_HOOK.addShutdownCallback(() -> {
+            try {
+                fanoutGateway.close();
+            } catch (Exception e) {
+                log.warn("Failed to close fanout gateway", e);
+            }
+        });
+
         DispatcherQueueManagers.register(managedServer.name(), fanoutGateway);
 
         stompManagedServer.server().onStomp(handler ->

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompManagedServerFanoutAdapter.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.fanout;
 
 import lombok.extern.slf4j.Slf4j;
+import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.core.message.dispatcher.DispatcherQueueManagers;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.vertx.VertxStompManagedServer;
@@ -40,6 +41,8 @@ import java.util.function.Function;
  */
 @Slf4j
 public final class VertxStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 
     @Override
     public boolean supports(
@@ -65,6 +68,14 @@ public final class VertxStompManagedServerFanoutAdapter implements ManagedServer
         FanoutGateway fanoutGateway = gatewayFactory.apply(
                 new VertxStompFanoutExporter(vertxStompManagedServer.server())
         );
+        SHUTDOWN_HOOK.addShutdownCallback(() -> {
+            try {
+                fanoutGateway.close();
+            } catch (Exception e) {
+                log.warn("Failed to close fanout gateway", e);
+            }
+        });
+
         DispatcherQueueManagers.register(managedServer.name(), fanoutGateway);
 
         vertxStompManagedServer.server().stompHandler()


### PR DESCRIPTION
## Motivation:

Titan collected shutdown callbacks from runtime modules, but the global shutdown hook was not installed as a single JVM shutdown hook. That meant fanout gateway cleanup callbacks could be registered without actually running during process shutdown.

## Modification:

- Register the global Titan shutdown hook once from bootstrap.
- Change `TitanShutdownHook` so it executes registered callbacks during JVM shutdown instead of trying to register nested shutdown hooks.
- Add fanout gateway cleanup callbacks for Titan and Vert.x STOMP managed servers.
- Keep fanout damper acquisition around export work only.
- Fix backup fanout handler selection so backup is skipped when backup is disabled.
- Add shutdown hook unit coverage.

## Result:

Shutdown cleanup now closes fanout resources through the global JVM hook path.

Validation:

- `./gradlew :bootstrap:test --no-configuration-cache`
- `./gradlew :fanout:test --no-configuration-cache`
