### PR TITLE
Update docs for 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,32 +35,32 @@ repositories {
 Spring client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.2")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.3")
 ```
 
 STOMP client/server:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.2")
+implementation("org.traffichunter.titan:titan-stomp:0.7.3")
 ```
 
 Fanout support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-fanout:0.7.2")
+implementation("org.traffichunter.titan:titan-fanout:0.7.3")
 ```
 
 Monitoring support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-monitor:0.7.2")
+implementation("org.traffichunter.titan:titan-monitor:0.7.3")
 ```
 
 Bootstrap/runtime support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.2")
-implementation("org.traffichunter.titan:titan-core:0.7.2")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.3")
+implementation("org.traffichunter.titan:titan-core:0.7.3")
 ```
 
 ## Standalone Server
@@ -70,15 +70,15 @@ Download the executable server jar from GitHub Releases.
 Using `curl`:
 
 ```bash
-curl -L -o titan-server-0.7.2.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.2/titan-server-0.7.2.jar
+curl -L -o titan-server-0.7.3.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.3/titan-server-0.7.3.jar
 ```
 
 Using `wget`:
 
 ```bash
-wget -O titan-server-0.7.2.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.2/titan-server-0.7.2.jar
+wget -O titan-server-0.7.3.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.3/titan-server-0.7.3.jar
 ```
 
 Create `titan-env.yml`.
@@ -109,7 +109,7 @@ titan:
 Run Titan.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.2.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
 ```
 
 Inspect the running server from a terminal. The release page provides
@@ -118,7 +118,7 @@ CLI from source while developing.
 
 ```bash
 # prebuilt archive example
-tar -xzf titan-cli-0.7.2-linux-amd64.tar.gz
+tar -xzf titan-cli-0.7.3-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 
 # source checkout example

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.2")
+implementation("org.traffichunter.titan:titan-stomp:0.7.3")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.2")
-implementation("org.traffichunter.titan:titan-core:0.7.2")
-implementation("org.traffichunter.titan:titan-stomp:0.7.2")
-implementation("org.traffichunter.titan:titan-fanout:0.7.2")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.3")
+implementation("org.traffichunter.titan:titan-core:0.7.3")
+implementation("org.traffichunter.titan:titan-stomp:0.7.3")
+implementation("org.traffichunter.titan:titan-fanout:0.7.3")
 ```
 
 ### `titan-env.yml`

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.2")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.3")
 ```
 
 ## Enable Titan


### PR DESCRIPTION
## Motivation:

Release 0.7.3 has been published, so README and example documentation should point users to the latest released artifacts and download assets.

## Modification:

- Update README dependency snippets from 0.7.2 to 0.7.3.
- Update standalone server and CLI release asset examples to 0.7.3.
- Update docs examples for client, server, and Spring client dependencies to 0.7.3.

## Result:

The project documentation now references the 0.7.3 release artifacts.

Validation:
- ./gradlew updateReleaseDocsVersion -PreleaseVersion=0.7.3 --no-configuration-cache