### PR TITLE
Add WebSocket frame codec support

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
@@ -58,8 +58,8 @@ public abstract class AbstractChannel implements Channel {
     private final ChannelHandShakeEventListener initializer;
     private final ChannelHandlerChain chain;
     private volatile Instant lastActiveAt = Instant.now();
-    private final String channelId = IdGenerator.randomId("channel");
-    private final String sessionId = IdGenerator.randomId("session");
+    private final String channelId = IdGenerator.randomId16("channel");
+    private final String sessionId = IdGenerator.randomId16("session");
 
     private static final AtomicReferenceFieldUpdater<AbstractChannel, ChannelState> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(AbstractChannel.class, ChannelState.class, "state");

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
@@ -191,7 +191,6 @@ public class ChannelHandlerChain {
             outHead.sparkChannelWrite(channel, buffer);
         } catch (Exception e) {
             log.error("Failed to process write", e);
-            buffer.release();
             channel.close();
         }
     }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
@@ -23,9 +23,11 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.channel;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.Noop;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.channel.chain.HandlerChain;
 
 /**
  * Owns the inbound and outbound handler pipelines for a channel.
@@ -83,6 +85,31 @@ public class ChannelHandlerChain {
         outHead = outTail = new ChannelOutBoundHandlerChainImpl(new ChannelOutBoundHandlerHead());
     }
 
+    @CanIgnoreReturnValue
+    public ChannelHandlerChain addFirst(ChannelInBoundHandler handler) {
+        ChannelInBoundHandlerChainImpl context = new ChannelInBoundHandlerChainImpl(handler);
+        context.next = inHead.next;
+        inHead.next = context;
+        if (inTail == inHead) {
+            inTail = context;
+        }
+
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public ChannelHandlerChain addFirst(ChannelOutBoundHandler handler) {
+        ChannelOutBoundHandlerChainImpl context = new ChannelOutBoundHandlerChainImpl(handler);
+        context.next = outHead.next;
+        outHead.next = context;
+        if (outTail == outHead) {
+            outTail = context;
+        }
+
+        return this;
+    }
+
+    @CanIgnoreReturnValue
     public ChannelHandlerChain add(ChannelInBoundHandler handler) {
         ChannelInBoundHandlerChainImpl context = new ChannelInBoundHandlerChainImpl(handler);
         inTail.next = context;
@@ -91,12 +118,55 @@ public class ChannelHandlerChain {
         return this;
     }
 
+    @CanIgnoreReturnValue
     public ChannelHandlerChain add(ChannelOutBoundHandler handler) {
         ChannelOutBoundHandlerChainImpl context = new ChannelOutBoundHandlerChainImpl(handler);
         outTail.next = context;
         outTail = context;
 
         return this;
+    }
+
+    public boolean remove(ChannelInBoundHandler handler) {
+        ChannelInBoundHandlerChainImpl previous = inHead;
+        ChannelInBoundHandlerChainImpl current = inHead.next;
+
+        while (current != null) {
+            if (current.handler == handler) {
+                previous.next = current.next;
+                if (inTail == current) {
+                    inTail = previous;
+                }
+                current.next = null;
+                return true;
+            }
+
+            previous = current;
+            current = current.next;
+        }
+
+        return false;
+    }
+
+    public boolean remove(ChannelOutBoundHandler handler) {
+        ChannelOutBoundHandlerChainImpl previous = outHead;
+        ChannelOutBoundHandlerChainImpl current = outHead.next;
+
+        while (current != null) {
+            if (current.handler == handler) {
+                previous.next = current.next;
+                if (outTail == current) {
+                    outTail = previous;
+                }
+                current.next = null;
+                return true;
+            }
+
+            previous = current;
+            current = current.next;
+        }
+
+        return false;
     }
 
     void processChannelConnecting(NetChannel channel) {
@@ -121,6 +191,7 @@ public class ChannelHandlerChain {
             outHead.sparkChannelWrite(channel, buffer);
         } catch (Exception e) {
             log.error("Failed to process write", e);
+            buffer.release();
             channel.close();
         }
     }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
@@ -44,7 +44,12 @@ public final class ChannelOutBoundHandlerChainImpl implements ChannelOutBoundHan
     public void sparkChannelWrite(NetChannel channel, Buffer buffer) {
         ChannelOutBoundHandlerChainImpl chain = next;
         if(chain == null) {
-            channel.write(buffer);
+            try {
+                channel.write(buffer);
+            } catch (RuntimeException e) {
+                buffer.release();
+                throw e;
+            }
             return;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
@@ -72,6 +72,7 @@ public final class ChannelWriteBuffer {
 
     public void add(Buffer buffer) {
         if(!buffer.hasRemaining()) {
+            buffer.release();
             return;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -139,8 +139,13 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
 
     @Override
     public void writeAndFlush(Buffer buffer) {
-        chain().processChannelWrite(this, buffer);
-        flush();
+        try {
+            chain().processChannelWrite(this, buffer);
+            flush();
+        } catch (RuntimeException e) {
+            close();
+            throw e;
+        }
     }
 
     @Override
@@ -281,12 +286,8 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
 
     @Override
     public void close() {
+        channelWriteBuffer.close();
         super.close();
-        if(isClosed()) {
-            channelWriteBuffer.close();
-        } else {
-            throw new ChannelException("Channel is not closed");
-        }
     }
 
     private void onWriteabilityChanged(boolean isWritable) {

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
@@ -23,26 +23,77 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec.websocket;
 
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader.*;
 
 /**
  * @author yun
  */
-public class WebSocketFrame {
-
-    private final WebSocketFrameHeader header;
-    private final Buffer payload;
+public record WebSocketFrame(
+        WebSocketFrameHeader header,
+        Buffer payload,
+        Protocol subProtocol
+) {
 
     public WebSocketFrame(WebSocketFrameHeader header, Buffer payload) {
-        this.header = header;
-        this.payload = payload;
+        this(header, payload, Protocol.STOMP);
     }
 
-    public WebSocketFrameHeader header() {
-        return header;
+    public WebSocketFrame(WebSocketFrameHeader header, Buffer payload, String subProtocol) {
+        this(header, payload, Protocol.subProtocol(subProtocol));
     }
 
-    public Buffer payload() {
-        return payload;
+    /**
+     * Encodes this frame into the RFC 6455 wire representation.
+     *
+     * <p>The returned buffer owns independent storage. This method does not consume or release
+     * the frame payload.</p>
+     */
+    public Buffer toBuffer() {
+        long payloadLength = header.getPayloadLength();
+        if (payloadLength != payload.length()) {
+            throw new WebSocketFrameException(
+                    "Frame payload length mismatch: header=" + payloadLength + ", actual=" + payload.length());
+        }
+
+        Buffer frame = Buffer.alloc(Math.addExact(header.size(), payload.length()));
+        try {
+            int firstByte = (header.isFin() ? 0x80 : 0) | header.getOpCode().code();
+            int maskBit = header.isMasked() ? 0x80 : 0;
+            frame.accumulateByte((byte) firstByte);
+
+            if (payloadLength <= 125) {
+                frame.accumulateByte((byte) (maskBit | (int) payloadLength));
+            } else if (payloadLength <= 0xFFFF) {
+                frame.accumulateByte((byte) (maskBit | 126));
+                frame.accumulateUnsignedShort((int) payloadLength);
+            } else {
+                frame.accumulateByte((byte) (maskBit | 127));
+                frame.accumulateLong(payloadLength);
+            }
+
+            byte[] payloadBytes = payload.getBytes();
+            if (header.isMasked()) {
+                frame.accumulateInt(header.getMaskingKey());
+                payloadBytes = WebSocketFrameHeader.unmask(payloadBytes, header.getMaskingKey());
+            }
+            frame.accumulateBytes(payloadBytes);
+            return frame;
+        } catch (Exception e) {
+            frame.release();
+            throw new WebSocketFrameException("WebSocket frame encoding failed: " + e.getMessage());
+        }
     }
+
+    static boolean isControlFrame(OpCode opcode) {
+        return opcode == OpCode.CLOSE || opcode == OpCode.PING || opcode == OpCode.PONG;
+    }
+
+    static boolean isDataFrame(OpCode opcode) {
+        return opcode == OpCode.TEXT || opcode == OpCode.BINARY;
+    }
+
 }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
@@ -1,0 +1,48 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * @author yun
+ */
+public class WebSocketFrame {
+
+    private final WebSocketFrameHeader header;
+    private final Buffer payload;
+
+    public WebSocketFrame(WebSocketFrameHeader header, Buffer payload) {
+        this.header = header;
+        this.payload = payload;
+    }
+
+    public WebSocketFrameHeader header() {
+        return header;
+    }
+
+    public Buffer payload() {
+        return payload;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
@@ -24,17 +24,176 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.codec.websocket;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.traffichunter.titan.core.codec.websocket.WebSocketFrame.isControlFrame;
+import static org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader.*;
 
 /**
  * @author yun
  */
 public class WebSocketFrameDecoder extends ChannelDecoder {
 
+    private static final Logger log = LoggerFactory.getLogger(WebSocketFrameDecoder.class);
+
+    private final WebSocketFrameParser parser;
+
+    public WebSocketFrameDecoder() {
+        this(Protocol.STOMP);
+    }
+
+    public WebSocketFrameDecoder(String subProtocol) {
+        this(Protocol.subProtocol(subProtocol));
+    }
+
+    public WebSocketFrameDecoder(Protocol subProtocol) {
+        this.parser = new WebSocketFrameParser(subProtocol);
+    }
+
     @Override
     protected @Nullable Buffer decode(NetChannel channel, Buffer buffer) {
-        return null;
+        try {
+            WebSocketFrame websocketFrame = parser.parse(buffer);
+            if (websocketFrame == null) {
+                return null;
+            }
+            if (isControlFrame(websocketFrame.header().getOpCode())) {
+                websocketFrame.payload().release();
+                if (websocketFrame.header().getOpCode() == OpCode.CLOSE) {
+                    channel.close();
+                }
+                return null;
+            }
+
+            return websocketFrame.payload();
+        } catch (WebSocketFrameException e) {
+            log.warn("Rejected invalid websocket frame. reason={}", e.getMessage());
+            discard(buffer);
+            channel.close();
+            return null;
+        } catch (Exception e) {
+            log.error("Failed to parse websocket frame", e);
+            discard(buffer);
+            channel.close();
+            return null;
+        }
+    }
+
+    private static void discard(Buffer buffer) {
+        if (buffer.isReadable()) {
+            buffer.skipBytes(buffer.length());
+        }
+    }
+
+    private static final class WebSocketFrameParser {
+
+        private static final int FIN_MASK = 0x80;
+        private static final int RSV_MASK = 0x70;
+        private static final int OPCODE_MASK = 0x0F;
+        private static final int MASK_BIT = 0x80;
+        private static final int PAYLOAD_LENGTH_MASK = 0x7F;
+        private static final int SHORT_PAYLOAD_LENGTH_MARKER = 126;
+        private static final int CONTROL_FRAME_MAX_PAYLOAD_LENGTH = 125;
+
+        private final Protocol subProtocol;
+
+        private WebSocketFrameParser(Protocol subProtocol) {
+            this.subProtocol = subProtocol;
+        }
+
+        @Nullable WebSocketFrame parse(Buffer buffer) {
+            if (!buffer.isReadable()) {
+                return null;
+            }
+
+            int readerIndex = buffer.byteBuf().readerIndex();
+            int readableBytes = buffer.byteBuf().readableBytes();
+            if (readableBytes < MIN_FRAME_HEADER_LENGTH) {
+                return null;
+            }
+
+            short firstByte = buffer.getUnsignedByte(readerIndex);
+            short secondByte = buffer.getUnsignedByte(readerIndex + 1);
+            if ((firstByte & RSV_MASK) != 0) {
+                throw new WebSocketFrameException("WebSocket extensions are not supported");
+            }
+
+            boolean fin = (firstByte & FIN_MASK) != 0;
+            OpCode opcode = OpCode.of(firstByte & OPCODE_MASK);
+            long lengthCode = secondByte & PAYLOAD_LENGTH_MASK;
+
+            int headerLength = MIN_FRAME_HEADER_LENGTH;
+            long payloadLength;
+            if (lengthCode < SHORT_PAYLOAD_LENGTH_MARKER) {
+                payloadLength = lengthCode;
+            } else if (lengthCode == SHORT_PAYLOAD_LENGTH_MARKER) {
+                if (readableBytes < headerLength + Short.BYTES) {
+                    return null;
+                }
+                payloadLength = buffer.getUnsignedShort(readerIndex + headerLength);
+                headerLength += 2;
+                if (payloadLength < SHORT_PAYLOAD_LENGTH_MARKER) {
+                    throw new WebSocketFrameException("Non-minimal WebSocket payload length encoding");
+                }
+            } else {
+                if (readableBytes < headerLength + Long.BYTES) {
+                    return null;
+                }
+                payloadLength = buffer.getLong(readerIndex + headerLength);
+                headerLength += Long.BYTES;
+                if (payloadLength <= 0xFFFF) {
+                    throw new WebSocketFrameException("Non-minimal WebSocket payload length encoding");
+                }
+            }
+
+            validate(opcode, fin, payloadLength);
+
+            boolean isMasked = (secondByte & MASK_BIT) != 0;
+            int maskingKey = 0;
+            if (isMasked) {
+                if (readableBytes < headerLength + Integer.BYTES) {
+                    return null;
+                }
+                maskingKey = buffer.getInt(readerIndex + headerLength);
+                headerLength += Integer.BYTES;
+            }
+
+            if (readableBytes < headerLength + payloadLength) {
+                return null;
+            }
+
+            buffer.skipBytes(headerLength);
+            Buffer payload = buffer.readRetainedSlice((int) payloadLength);
+            if (isMasked) {
+                payload = WebSocketFrameHeader.unmask(payload, maskingKey);
+            }
+
+            WebSocketFrameHeader.Builder headerBuilder = WebSocketFrameHeader.builder()
+                    .op(opcode, fin)
+                    .payloadLength(payloadLength);
+            if (isMasked) {
+                headerBuilder.masked(maskingKey);
+            }
+            WebSocketFrameHeader header = headerBuilder.build();
+
+            return new WebSocketFrame(header, payload, subProtocol);
+        }
+
+        private static void validate(OpCode opcode, boolean fin, long payloadLength) {
+            if (!fin || opcode == OpCode.CONTINUATION) {
+                throw new WebSocketFrameException("Fragmented WebSocket messages are not supported");
+            }
+            if (isControlFrame(opcode) && payloadLength > CONTROL_FRAME_MAX_PAYLOAD_LENGTH) {
+                throw new WebSocketFrameException("Control frame payload must be less than 126 bytes");
+            }
+            if (payloadLength < 0 || payloadLength > Integer.MAX_VALUE) {
+                throw new WebSocketFrameException("Invalid WebSocket payload length: " + payloadLength);
+            }
+        }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
@@ -1,0 +1,40 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.codec.ChannelDecoder;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * @author yun
+ */
+public class WebSocketFrameDecoder extends ChannelDecoder {
+
+    @Override
+    protected @Nullable Buffer decode(NetChannel channel, Buffer buffer) {
+        return null;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
@@ -1,0 +1,40 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.codec.ChannelEncoder;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * @author yun
+ */
+public class WebSocketFrameEncoder extends ChannelEncoder {
+
+    @Override
+    protected @Nullable Buffer encode(NetChannel channel, Buffer buffer) {
+        return null;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
@@ -24,8 +24,11 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.codec.websocket;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.ChannelEncoder;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
@@ -33,8 +36,102 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  */
 public class WebSocketFrameEncoder extends ChannelEncoder {
 
+    private static final Logger log = LoggerFactory.getLogger(WebSocketFrameEncoder.class);
+
+    private final WebSocketFrameParser parser;
+
+    public WebSocketFrameEncoder(WebSocketSide side) {
+        this(side, Protocol.STOMP);
+    }
+
+    public WebSocketFrameEncoder(WebSocketSide side, String subProtocol) {
+        this(side, Protocol.subProtocol(subProtocol));
+    }
+
+    public WebSocketFrameEncoder(WebSocketSide side, Protocol subProtocol) {
+        this.parser = new WebSocketFrameParser(side, subProtocol);
+    }
+
     @Override
     protected @Nullable Buffer encode(NetChannel channel, Buffer buffer) {
-        return null;
+        try {
+            WebSocketFrame websocketFrame = parser.parse(buffer);
+
+            if (WebSocketFrame.isControlFrame(websocketFrame.header().getOpCode())) {
+                if (websocketFrame.header().getOpCode() == WebSocketFrameHeader.OpCode.CLOSE) {
+                    channel.close();
+                }
+                return null;
+            }
+
+            return websocketFrame.toBuffer();
+        } catch (WebSocketFrameException e) {
+            log.warn("Rejected invalid websocket frame. reason={}", e.getMessage());
+            channel.close();
+            return null;
+        } catch (Exception e) {
+            log.error("Failed to encode websocket frame", e);
+            channel.close();
+            return null;
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static final class WebSocketFrameParser {
+
+        private final WebSocketSide side;
+        private final Protocol subProtocol;
+
+        private WebSocketFrameParser(WebSocketSide side, Protocol subProtocol) {
+            this.side = side;
+            this.subProtocol = subProtocol;
+        }
+
+        WebSocketFrame parse(Buffer payload) {
+            WebSocketFrameHeader.Builder webSocketFrameHeaderBuilder = WebSocketFrameHeader.builder()
+                    .op(opCode(subProtocol), true)
+                    .payloadLength(payload.length());
+
+            if(side == WebSocketSide.CLIENT) {
+                webSocketFrameHeaderBuilder.masked(WebSocketFrameHeader.generateMaskingKey());
+            }
+
+            WebSocketFrameHeader webSocketFrameHeader = webSocketFrameHeaderBuilder.build();
+
+            validate(side, webSocketFrameHeader);
+
+            return new WebSocketFrame(
+                    webSocketFrameHeader,
+                    payload,
+                    subProtocol
+            );
+        }
+
+        private static void validate(WebSocketSide side, WebSocketFrameHeader header) {
+            if (header.isMasked() && header.getMaskingKey() == 0) {
+                throw new WebSocketFrameException("Masking key must not be zero");
+            }
+
+            switch (side) {
+                case SERVER -> {
+                    if (header.isMasked()) {
+                        throw new WebSocketFrameException("Masked frames are not allowed on the server");
+                    }
+                }
+                case CLIENT -> {
+                    if (!header.isMasked()) {
+                        throw new WebSocketFrameException("Masked frames are not allowed on the client");
+                    }
+                }
+            }
+        }
+
+        private static WebSocketFrameHeader.OpCode opCode(Protocol subProtocol) {
+            return switch (subProtocol) {
+                case STOMP -> WebSocketFrameHeader.OpCode.TEXT;
+                case MQTT -> WebSocketFrameHeader.OpCode.BINARY;
+            };
+        }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameException.java
@@ -1,0 +1,36 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.traffichunter.titan.core.codec.CodecException;
+
+/**
+ * @author yun
+ */
+public class WebSocketFrameException extends CodecException {
+
+    public WebSocketFrameException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
@@ -24,14 +24,19 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.codec.websocket;
 
 import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.security.SecureRandom;
 
 /**
  * Refer to <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-5.2">RFC 6455</a>
  * <p>
  * WebSocket frame header metadata.
- *
- * <p>Titan does not currently support WebSocket extensions, so RSV1, RSV2, and RSV3 are expected
- * to be {@code 0} when a frame is decoded.</p>
+ *</p>
+ * <p>
+ * Titan does not currently support WebSocket extensions, so RSV1, RSV2, and RSV3 are expected
+ * to be {@code 0} when a frame is decoded.
+ * </p>
  *
  * <pre>
  *  0                   1                   2                   3
@@ -58,7 +63,10 @@ import org.traffichunter.titan.core.util.Assert;
  */
 public class WebSocketFrameHeader {
 
+    public static final int MIN_FRAME_HEADER_LENGTH = 2;
     public static final int MAX_FRAME_HEADER_LENGTH = 14;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final byte firstByte;
     private final boolean masked;
@@ -74,6 +82,42 @@ public class WebSocketFrameHeader {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public static int generateMaskingKey() {
+        return SECURE_RANDOM.nextInt();
+    }
+
+    static Buffer unmask(Buffer payload, int maskingKey) {
+        try {
+            return Buffer.alloc(unmask(payload.getBytes(), maskingKey));
+        } finally {
+            payload.release();
+        }
+    }
+
+    static byte[] unmask(byte[] payload, int maskingKey) {
+        byte[] masked = new byte[payload.length];
+        for (int i = 0; i < payload.length; i++) {
+            masked[i] = (byte) (payload[i] ^ maskByte(maskingKey, i));
+        }
+        return masked;
+    }
+
+    Buffer mask(Buffer payload) {
+        try {
+            return Buffer.alloc(mask(payload.getBytes()));
+        } finally {
+            payload.release();
+        }
+    }
+
+    byte[] mask(byte[] payload) {
+        byte[] masked = new byte[payload.length];
+        for (int i = 0; i < payload.length; i++) {
+            masked[i] = (byte) (payload[i] ^ maskByte(maskingKey, i));
+        }
+        return masked;
     }
 
     public enum OpCode {
@@ -110,6 +154,10 @@ public class WebSocketFrameHeader {
         return payloadLength == 0;
     }
 
+    public long getPayloadLength() {
+        return payloadLength;
+    }
+
     public int getMaskingKey() {
         return maskingKey;
     }
@@ -139,6 +187,11 @@ public class WebSocketFrameHeader {
         return size;
     }
 
+    private static byte maskByte(int maskingKey, int index) {
+        int shift = 24 - ((index % 4) * 8);
+        return (byte) ((maskingKey >> shift) & 0xFF);
+    }
+
     public static class Builder {
 
         private byte firstByte;
@@ -154,11 +207,6 @@ public class WebSocketFrameHeader {
         public Builder masked(int maskingKey) {
             this.masked = true;
             this.maskingKey = maskingKey;
-            return this;
-        }
-
-        public Builder unMasked() {
-            this.masked = false;
             return this;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
@@ -1,0 +1,175 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.traffichunter.titan.core.util.Assert;
+
+/**
+ * Refer to <a href="https://datatracker.ietf.org/doc/html/rfc6455#section-5.2">RFC 6455</a>
+ * <p>
+ * WebSocket frame header metadata.
+ *
+ * <p>Titan does not currently support WebSocket extensions, so RSV1, RSV2, and RSV3 are expected
+ * to be {@code 0} when a frame is decoded.</p>
+ *
+ * <pre>
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-------+-+-------------+-------------------------------+
+ * |F|R|R|R| opcode|M| Payload len | Extended payload length       |
+ * |I|S|S|S|  (4)  |A|     (7)     |      (16/64, optional)        |
+ * |N|V|V|V|       |S|             |                               |
+ * | |1|2|3|       |K|             |                               |
+ * +-+-+-+-+-------+-+-------------+-------------------------------+
+ * | Masking-key, if MASK set      | Payload data                  |
+ * +-------------------------------+-------------------------------+
+ *
+ * FIN            1 bit   Last fragment of a WebSocket message.
+ * RSV1/2/3       1 bit   Reserved for negotiated extensions; unsupported here.
+ * opcode         4 bits  Frame type, such as text, binary, close, ping, or pong.
+ * MASK           1 bit   Indicates whether payload bytes are masked.
+ * Payload len    7 bits  Inline length when 0..125, or 126/127 for extended length.
+ * Extended len   16/64   Present only when Payload len is 126 or 127.
+ * Masking-key    32 bits Present only when MASK is set.
+ * </pre>
+ *
+ * @author yun
+ */
+public class WebSocketFrameHeader {
+
+    public static final int MAX_FRAME_HEADER_LENGTH = 14;
+
+    private final byte firstByte;
+    private final boolean masked;
+    private final long payloadLength;
+    private final int maskingKey;
+
+    private WebSocketFrameHeader(Builder builder) {
+        this.firstByte = builder.firstByte;
+        this.masked = builder.masked;
+        this.payloadLength = builder.payloadLength;
+        this.maskingKey = builder.maskingKey;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public enum OpCode {
+        CONTINUATION(0),
+        TEXT(1),
+        BINARY(2),
+        CLOSE(8),
+        PING(9),
+        PONG(10),
+        ;
+
+        private final int code;
+
+        OpCode(int code) {
+            this.code = code;
+        }
+
+        public static OpCode of(int code) {
+            for (OpCode opCode : values()) {
+                if (opCode.code == code) {
+                    return opCode;
+                }
+            }
+
+            throw new WebSocketFrameException("Unknown opcode: " + code);
+        }
+
+        public int code() {
+            return code;
+        }
+    }
+
+    public boolean isPayloadEmpty() {
+        return payloadLength == 0;
+    }
+
+    public int getMaskingKey() {
+        return maskingKey;
+    }
+
+    public boolean isFin() {
+        return (firstByte & 0x80) != 0;
+    }
+
+    public OpCode getOpCode() {
+        return OpCode.of(firstByte & 0xF);
+    }
+
+    public boolean isMasked() {
+        return masked;
+    }
+
+    public int size() {
+        int size = 2;
+        if (payloadLength > 0xFFFF) {
+            size += Long.BYTES;
+        } else if (payloadLength > 125) {
+            size += Short.BYTES;
+        }
+        if (masked) {
+            size += Integer.BYTES;
+        }
+        return size;
+    }
+
+    public static class Builder {
+
+        private byte firstByte;
+        private boolean masked;
+        private long payloadLength;
+        private int maskingKey;
+
+        public Builder op(OpCode opcode, boolean fin) {
+            this.firstByte = (byte) (opcode.code() | (fin ? 0x80 : 0));
+            return this;
+        }
+
+        public Builder masked(int maskingKey) {
+            this.masked = true;
+            this.maskingKey = maskingKey;
+            return this;
+        }
+
+        public Builder unMasked() {
+            this.masked = false;
+            return this;
+        }
+
+        public Builder payloadLength(long payloadLength) {
+            Assert.checkArgument(payloadLength >= 0, "payloadLength must be non-negative");
+            this.payloadLength = payloadLength;
+            return this;
+        }
+
+        public WebSocketFrameHeader build() {
+            return new WebSocketFrameHeader(this);
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketSide.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketSide.java
@@ -1,0 +1,32 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+/**
+ * @author yun
+ */
+public enum WebSocketSide {
+    CLIENT,
+    SERVER;
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketType.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketType.java
@@ -1,0 +1,34 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+/**
+ * @author yun
+ */
+public enum WebSocketType {
+
+    TEXT,
+
+    BINARY,
+}

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
@@ -26,7 +26,6 @@ package org.traffichunter.titan.core.transport;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.ChannelHandShakeEventListener;
@@ -45,7 +44,6 @@ import org.traffichunter.titan.core.util.channel.ChannelRegistry;
  *
  * @author yun
  */
-@Slf4j
 public abstract class AbstractTransport<C extends Channel> {
 
     private final EventLoopGroups eventLoopGroups;

--- a/core/src/main/java/org/traffichunter/titan/core/transport/HttpRequest.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/HttpRequest.java
@@ -1,0 +1,226 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.codec.frame.Headers;
+
+import java.net.http.HttpClient;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author yun
+ */
+public final class HttpRequest {
+
+    private static final String CRLF = "\r\n";
+    private static final String SP = " ";
+
+    private String uri = "/";
+    private String method = "GET";
+    private HttpClient.Version version = HttpClient.Version.HTTP_1_1;
+    private final HttpHeaders headers = new HttpHeaders();
+
+    public static HttpRequest parse(String rawRequest) {
+        String[] lines = rawRequest.split(CRLF);
+        if (lines.length == 0) {
+            throw new IllegalArgumentException("Missing HTTP request line");
+        }
+
+        String[] requestLine = lines[0].split(SP, 3);
+        if (requestLine.length != 3) {
+            throw new IllegalArgumentException("Invalid HTTP request line: " + lines[0]);
+        }
+
+        HttpRequest request = new HttpRequest()
+                .method(requestLine[0])
+                .uri(requestLine[1])
+                .version(parseVersion(requestLine[2]));
+
+        for (int i = 1; i < lines.length; i++) {
+            int delimiter = lines[i].indexOf(':');
+            if (delimiter < 0) {
+                continue;
+            }
+
+            String name = lines[i].substring(0, delimiter).trim();
+            String value = lines[i].substring(delimiter + 1).trim();
+            request.header(name, value);
+        }
+
+        return request;
+    }
+
+    @CanIgnoreReturnValue
+    public HttpRequest uri(String uri) {
+        this.uri = uri;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public HttpRequest method(String method) {
+        this.method = method;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public HttpRequest version(HttpClient.Version version) {
+        this.version = version;
+        return this;
+    }
+
+    public String uri() {
+        return uri;
+    }
+
+    public String method() {
+        return method;
+    }
+
+    public HttpClient.Version version() {
+        return version;
+    }
+
+    @CanIgnoreReturnValue
+    public HttpRequest header(String key, String value) {
+        headers.put(key, value);
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public @Nullable String header(String key) {
+        return headers.get(key);
+    }
+
+    @CanIgnoreReturnValue
+    public HttpRequest headerIfAbsent(String key, String value) {
+        headers.putIfAbsent(key, value);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(method)
+                .append(SP)
+                .append(uri)
+                .append(SP)
+                .append(formatVersion(version))
+                .append(CRLF);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            sb.append(entry.getKey()).append(": ").append(entry.getValue()).append(CRLF);
+        }
+        sb.append(CRLF);
+        return sb.toString();
+    }
+
+    private static String formatVersion(HttpClient.Version version) {
+        return switch (version) {
+            case HTTP_1_1 -> "HTTP/1.1";
+            case HTTP_2 -> "HTTP/2";
+        };
+    }
+
+    private static HttpClient.Version parseVersion(String version) {
+        return switch (version) {
+            case "HTTP/1.1" -> HttpClient.Version.HTTP_1_1;
+            case "HTTP/2" -> HttpClient.Version.HTTP_2;
+            default -> throw new IllegalArgumentException("Unsupported HTTP version: " + version);
+        };
+    }
+
+    private static final class HttpHeaders extends Headers<String, String, HttpHeaders> {
+
+        private HttpHeaders() {
+            super(new LinkedHashMap<>());
+        }
+
+        @Override
+        public void put(String key, String value) {
+            map.put(key, value);
+        }
+
+        @Override
+        public void putIfAbsent(String key, String value) {
+            map.putIfAbsent(key, value);
+        }
+
+        @Override
+        public String getOrDefault(String key, String defaultValue) {
+            String value = get(key);
+            return value == null ? defaultValue : value;
+        }
+
+        @Override
+        public @Nullable String get(String key) {
+            String value = map.get(key);
+            if (value != null) {
+                return value;
+            }
+            for (Map.Entry<String, String> entry : map.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(key)) {
+                    return entry.getValue();
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public boolean containsKey(String key) {
+            if (map.containsKey(key)) {
+                return true;
+            }
+            for (String header : map.keySet()) {
+                if (header.equalsIgnoreCase(key)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Set<String> keySet() {
+            return map.keySet();
+        }
+
+        @Override
+        public Set<Map.Entry<String, String>> entrySet() {
+            return map.entrySet();
+        }
+
+        @Override
+        public Iterator<Map.Entry<String, String>> iterator() {
+            return map.entrySet().iterator();
+        }
+
+        @Override
+        public HttpHeaders getHeader() {
+            return this;
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -25,8 +25,6 @@ package org.traffichunter.titan.core.transport;
 
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,10 +40,10 @@ import org.traffichunter.titan.core.channel.NewIONetChannel;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.option.InetClientOption;
+import org.traffichunter.titan.core.transport.websocket.WebSocketClientHandshaker;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.Noop;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.core.util.channel.ChannelRegistry;
 
 /**
  * TCP client transport that can own multiple outbound channels.
@@ -61,6 +59,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
     private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
     private final InetClientOption option;
+    private boolean upgradeWebsocket = false;
 
     private Handler<Channel> channelHandler = channel -> {};
 
@@ -91,6 +90,12 @@ public class InetClient extends AbstractTransport<NetChannel> {
     @CanIgnoreReturnValue
     public InetClient onChannel(Handler<Channel> channelHandler) {
         this.channelHandler = channelHandler;
+        return this;
+    }
+
+    @CanIgnoreReturnValue
+    public InetClient upgradeWebsocket() {
+        this.upgradeWebsocket = true;
         return this;
     }
 
@@ -177,6 +182,12 @@ public class InetClient extends AbstractTransport<NetChannel> {
                 }
             });
         });
+
+        if (upgradeWebsocket) {
+            return connectResult.thenCompose(netChannel ->
+                    new WebSocketClientHandshaker(remoteAddress.getHostString()).handshake(netChannel)
+            );
+        }
 
         return connectResult;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -38,6 +38,7 @@ import org.traffichunter.titan.core.transport.option.InetClientOption;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
+import org.traffichunter.titan.core.transport.websocket.WebSocketServerHandshaker;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.util.channel.ChannelRegistry;
 
@@ -101,6 +102,12 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         return this;
     }
 
+    @CanIgnoreReturnValue
+    public InetServer upgradeWebsocket() {
+        this.acceptor.setUpgradeWebsocket();
+        return this;
+    }
+
     /**
      * Registers a callback invoked for accepted child channels.
      *
@@ -150,28 +157,6 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         ChannelPromise resultPromise = ChannelPromise.newPromise(channel);
         listen(address, resultPromise);
         return resultPromise;
-    }
-
-    private void listen(InetSocketAddress address, ChannelPromise resultPromise) {
-        bind(address).addListener(future -> {
-            if (!future.isSuccess()) {
-                state.compareAndSet(State.LISTENING, State.STARTED);
-                resultPromise.fail(future.error());
-                return;
-            }
-
-            ChannelPrimaryIOEventLoop eventLoop = groups().primaryGroup().next();
-            eventLoop.register(() -> {
-                try {
-                    eventLoop.ioSelector().registerAccept(channel);
-                    log.info("InetServer listen ready. session={}, address={}", channel.session(), address);
-                    resultPromise.success();
-                } catch (IOException e) {
-                    state.compareAndSet(State.LISTENING, State.STARTED);
-                    resultPromise.fail(new ServerException("Failed to register accept event", e));
-                }
-            });
-        });
     }
 
     @Override
@@ -243,6 +228,28 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         }
     }
 
+    private void listen(InetSocketAddress address, ChannelPromise resultPromise) {
+        bind(address).addListener(future -> {
+            if (!future.isSuccess()) {
+                state.compareAndSet(State.LISTENING, State.STARTED);
+                resultPromise.fail(future.error());
+                return;
+            }
+
+            ChannelPrimaryIOEventLoop eventLoop = groups().primaryGroup().next();
+            eventLoop.register(() -> {
+                try {
+                    eventLoop.ioSelector().registerAccept(channel);
+                    log.info("InetServer listen ready. session={}, address={}", channel.session(), address);
+                    resultPromise.success();
+                } catch (IOException e) {
+                    state.compareAndSet(State.LISTENING, State.STARTED);
+                    resultPromise.fail(new ServerException("Failed to register accept event", e));
+                }
+            });
+        });
+    }
+
     private Promise<Void> bind(InetSocketAddress address) {
         return groups().primaryGroup().submit(() -> {
             try {
@@ -267,6 +274,8 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
 
         private volatile InetClientOption childOption = InetClientOption.DEFAULT_INET_CLIENT_OPTION;
         private volatile Handler<Channel> childHandler = ch -> {};
+        private volatile boolean upgradeWebsocket;
+        private final WebSocketServerHandshaker webSocketHandshaker = new WebSocketServerHandshaker();
 
         ServerChannelAcceptor(
                 ChannelEventLoopGroup<ChannelSecondaryIOEventLoop> secondaryGroup,
@@ -282,6 +291,10 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
 
         void setChildHandler(Handler<Channel> childHandler) {
             this.childHandler = childHandler;
+        }
+
+        void setUpgradeWebsocket() {
+            this.upgradeWebsocket = true;
         }
 
         @SuppressWarnings("unchecked")
@@ -304,6 +317,15 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
                     loop.ioSelector().registerRead(netChannel);
                     loop.register(netChannel);
                     channelRegistry.addChannel(netChannel);
+                    if (upgradeWebsocket) {
+                        webSocketHandshaker.handshake(netChannel).addListener(result -> {
+                            if (result.isSuccess()) {
+                                childHandler.handle(netChannel);
+                            }
+                        });
+                        return;
+                    }
+
                     childHandler.handle(netChannel);
                 } catch (IOException e) {
                     throw new ServerException("Failed to init child channel", e);

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
@@ -1,0 +1,150 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.codec.ChannelDecoder;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameDecoder;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameEncoder;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+/**
+ * Common WebSocket handshake support for both client and server upgrade flows.
+ *
+ * @author yun
+ */
+abstract class AbstractWebSocketHandshaker {
+
+    private final String subProtocol;
+    private final String version;
+
+    protected AbstractWebSocketHandshaker(String subProtocol, String version) {
+        this.subProtocol = subProtocol;
+        this.version = version;
+    }
+
+    protected String subProtocol() {
+        return subProtocol;
+    }
+
+    protected String version() {
+        return version;
+    }
+
+    public abstract Promise<NetChannel> handshake(NetChannel channel);
+
+    abstract static class HttpUpgradeHandler extends ChannelDecoder {
+
+        private static final Logger log = LoggerFactory.getLogger(HttpUpgradeHandler.class);
+        private static final byte LF = '\n';
+        private static final byte CR = '\r';
+
+        private final Promise<NetChannel> upgradeResult;
+        private boolean upgraded;
+
+        HttpUpgradeHandler(Promise<NetChannel> upgradeResult) {
+            this.upgradeResult = upgradeResult;
+        }
+
+        @Override
+        protected @Nullable Buffer decode(NetChannel channel, Buffer buffer) {
+            if (upgraded) {
+                return buffer.isReadable() ? buffer.readRetainedSlice(buffer.length()) : null;
+            }
+
+            int headEnd = findEndOfHead(buffer);
+            if (headEnd < 0) {
+                return null;
+            }
+
+            int readerIndex = buffer.byteBuf().readerIndex();
+            Buffer head = buffer.readRetainedSlice(headEnd - readerIndex);
+            try {
+                handleHead(channel, head.toString(ISO_8859_1));
+                upgraded = true;
+                upgradeResult.success(channel);
+                onSuccess(channel);
+                return buffer.isReadable() ? buffer.readRetainedSlice(buffer.length()) : null;
+            } catch (Exception e) {
+                upgradeResult.fail(e);
+                channel.close();
+                log.error("Failed to upgrade WebSocket connection", e);
+                return null;
+            } finally {
+                head.release();
+            }
+        }
+
+        protected abstract void handleHead(NetChannel channel, String head);
+
+        protected void onSuccess(NetChannel channel) {
+        }
+
+        protected final void installWebSocketCodec(NetChannel channel) {
+            channel.chain()
+                    .add(new WebSocketFrameEncoder())
+                    .add(new WebSocketFrameDecoder());
+        }
+
+        private static int findEndOfHead(Buffer buffer) {
+            int cursor = buffer.byteBuf().readerIndex();
+            int end = cursor + buffer.length();
+            while (cursor < end) {
+                int eol = findEol(buffer, cursor, end);
+                if (eol < 0) {
+                    return -1;
+                }
+
+                if (buffer.getByte(eol) != CR) {
+                    cursor = eol + 1;
+                    continue;
+                }
+                if (end - eol < 4) {
+                    return -1;
+                }
+                if (buffer.getByte(eol + 2) == CR && buffer.getByte(eol + 3) == LF) {
+                    return eol + 4;
+                }
+                cursor = eol + 2;
+            }
+
+            return -1;
+        }
+
+        private static int findEol(Buffer buffer, int fromIndex, int toIndex) {
+            int idx = buffer.indexOf(fromIndex, toIndex, LF);
+            if (idx > fromIndex && buffer.getByte(idx - 1) == CR) {
+                return idx - 1;
+            }
+
+            return idx;
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
@@ -30,6 +30,7 @@ import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrameDecoder;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrameEncoder;
+import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -107,10 +108,14 @@ abstract class AbstractWebSocketHandshaker {
         protected void onSuccess(NetChannel channel) {
         }
 
-        protected final void installWebSocketCodec(NetChannel channel) {
+        protected final void installWebSocketCodec(
+                NetChannel channel,
+                WebSocketSide side,
+                String subProtocol
+        ) {
             channel.chain()
-                    .add(new WebSocketFrameEncoder())
-                    .add(new WebSocketFrameDecoder());
+                    .add(new WebSocketFrameEncoder(side, subProtocol))
+                    .add(new WebSocketFrameDecoder(subProtocol));
         }
 
         private static int findEndOfHead(Buffer buffer) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -1,0 +1,167 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.transport.HttpRequest;
+import org.traffichunter.titan.core.util.IdGenerator;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+/**
+ * @author yun
+ */
+public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketClientHandshaker.class);
+
+    private static final String ACCEPT_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    private static final String CRLF = "\r\n";
+
+    private static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
+    private static final String SEC_WEBSOCKET_VERSION = "Sec-WebSocket-Version";
+    private static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
+    private static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
+    private static final String HOST = "Host";
+    private static final String UPGRADE = "Upgrade";
+    private static final String WEBSOCKET = "websocket";
+    private static final String CONNECTION = "Connection";
+    private static final String VERSION = "13";
+    private static final String STOMP_SUB_PROTOCOL = "v12.stomp";
+
+    private static final String WEBSOCKET_URI = "/titan";
+    private static final String STATUS_SWITCHING_PROTOCOLS = "HTTP/1.1 101";
+
+    private final String host;
+
+    public WebSocketClientHandshaker(String host) {
+        super(STOMP_SUB_PROTOCOL, VERSION);
+        this.host = host;
+    }
+
+    @Override
+    public Promise<NetChannel> handshake(NetChannel channel) {
+        String key = generateKey();
+        HttpRequest request = new HttpRequest()
+                .uri(WEBSOCKET_URI)
+                .header(HOST, host)
+                .header(UPGRADE, WEBSOCKET)
+                .header(CONNECTION, UPGRADE)
+                .header(SEC_WEBSOCKET_KEY, key)
+                .header(SEC_WEBSOCKET_PROTOCOL, subProtocol())
+                .header(SEC_WEBSOCKET_VERSION, version());
+
+        Promise<NetChannel> upgradeResult = Promise.newPromise(channel.eventLoop());
+        channel.chain().add(new WebSocketUpgradeHandler(this, key, upgradeResult));
+
+        channel.eventLoop().submit(() -> {
+            channel.writeAndFlush(Buffer.alloc(request.toString()));
+            return channel;
+        }).addListener(result -> {
+            if (result.isFailed() && !upgradeResult.isDone()) {
+                Throwable error = result.error();
+                upgradeResult.fail(error == null
+                        ? new WebSocketHandshakeException("Failed to write WebSocket upgrade request")
+                        : error);
+            }
+        });
+
+        return upgradeResult;
+    }
+
+    void validateResponse(String response, String key) {
+        String[] lines = response.split(CRLF);
+        if (lines.length == 0 || !lines[0].startsWith(STATUS_SWITCHING_PROTOCOLS)) {
+            throw new WebSocketHandshakeException(
+                    "Invalid WebSocket upgrade status: " + (lines.length == 0 ? "" : lines[0]));
+        }
+
+        String accept = null;
+        for (int i = 1; i < lines.length; i++) {
+            int delimiter = lines[i].indexOf(':');
+            if (delimiter < 0) {
+                continue;
+            }
+
+            String name = lines[i].substring(0, delimiter).trim();
+            if (SEC_WEBSOCKET_ACCEPT.equalsIgnoreCase(name)) {
+                accept = lines[i].substring(delimiter + 1).trim();
+                break;
+            }
+        }
+
+        if (!acceptKey(key).equals(accept)) {
+            throw new WebSocketHandshakeException("Invalid Sec-WebSocket-Accept header");
+        }
+    }
+
+    static String acceptKey(String key) {
+        try {
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+            byte[] digest = sha1.digest((key + ACCEPT_MAGIC).getBytes(ISO_8859_1));
+            return Base64.getEncoder().encodeToString(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new WebSocketHandshakeException("SHA-1 is not available", e);
+        }
+    }
+
+    private static String generateKey() {
+        return IdGenerator.randomId16(null);
+    }
+
+    static final class WebSocketUpgradeHandler extends AbstractWebSocketHandshaker.HttpUpgradeHandler {
+
+        private final String key;
+        private final WebSocketClientHandshaker handshaker;
+
+        WebSocketUpgradeHandler(
+                WebSocketClientHandshaker handshaker,
+                String key,
+                Promise<NetChannel> upgradeResult
+        ) {
+            super(upgradeResult);
+            this.handshaker = handshaker;
+            this.key = key;
+        }
+
+        @Override
+        protected void handleHead(NetChannel channel, String head) {
+            handshaker.validateResponse(head, key);
+            installWebSocketCodec(channel);
+        }
+
+        @Override
+        protected void onSuccess(NetChannel channel) {
+            log.info("WebSocket connection established");
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
 import org.traffichunter.titan.core.transport.HttpRequest;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
@@ -156,7 +157,7 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
         @Override
         protected void handleHead(NetChannel channel, String head) {
             handshaker.validateResponse(head, key);
-            installWebSocketCodec(channel);
+            installWebSocketCodec(channel, WebSocketSide.CLIENT, handshaker.subProtocol());
         }
 
         @Override

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -136,7 +136,7 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
     }
 
     private static String generateKey() {
-        return IdGenerator.randomId16(null);
+        return IdGenerator.randomBase64Id16();
     }
 
     static final class WebSocketUpgradeHandler extends AbstractWebSocketHandshaker.HttpUpgradeHandler {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketHandshakeException.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketHandshakeException.java
@@ -1,0 +1,38 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+/**
+ * @author yun
+ */
+public class WebSocketHandshakeException extends RuntimeException {
+
+    public WebSocketHandshakeException(String message) {
+        super(message);
+    }
+
+    public WebSocketHandshakeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
 import org.traffichunter.titan.core.transport.HttpRequest;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -163,7 +164,7 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
         protected void handleHead(NetChannel channel, String head) {
             HttpRequest parsed = handshaker.parseRequest(head);
             channel.writeAndFlush(Buffer.alloc(handshaker.createResponse(parsed)));
-            installWebSocketCodec(channel);
+            installWebSocketCodec(channel, WebSocketSide.SERVER, handshaker.subProtocol());
             request = parsed;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -1,0 +1,178 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.transport.HttpRequest;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * Performs the server side of the WebSocket HTTP upgrade handshake.
+ *
+ * @author yun
+ */
+public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketServerHandshaker.class);
+
+    private static final String CRLF = "\r\n";
+    private static final String METHOD_GET = "GET";
+    private static final String SWITCHING_PROTOCOLS_RESPONSE = "HTTP/1.1 101 Switching Protocols";
+
+    private static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
+    private static final String SEC_WEBSOCKET_VERSION = "Sec-WebSocket-Version";
+    private static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
+    private static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
+    private static final String UPGRADE = "Upgrade";
+    private static final String WEBSOCKET = "websocket";
+    private static final String CONNECTION = "Connection";
+    private static final String UPGRADE_CONNECTION = "Upgrade";
+    private static final String VERSION = "13";
+    private static final String STOMP_SUB_PROTOCOL = "v12.stomp";
+
+    public WebSocketServerHandshaker() {
+        super(STOMP_SUB_PROTOCOL, VERSION);
+    }
+
+    @Override
+    public Promise<NetChannel> handshake(NetChannel channel) {
+        Promise<NetChannel> upgradeResult = Promise.newPromise(channel.eventLoop());
+        channel.chain().add(new WebSocketUpgradeHandler(this, upgradeResult));
+        return upgradeResult;
+    }
+
+    HttpRequest parseRequest(String request) {
+        HttpRequest upgradeRequest;
+        try {
+            upgradeRequest = HttpRequest.parse(request);
+        } catch (IllegalArgumentException e) {
+            throw new WebSocketHandshakeException(e.getMessage(), e);
+        }
+
+        validateRequest(upgradeRequest);
+        return upgradeRequest;
+    }
+
+    String createResponse(HttpRequest request) {
+        String key = key(request);
+        if (key == null || key.isBlank()) {
+            throw new WebSocketHandshakeException("Missing Sec-WebSocket-Key header");
+        }
+
+        StringBuilder response = new StringBuilder()
+                .append(SWITCHING_PROTOCOLS_RESPONSE).append(CRLF)
+                .append(UPGRADE).append(": ").append(WEBSOCKET).append(CRLF)
+                .append(CONNECTION).append(": ").append(UPGRADE_CONNECTION).append(CRLF)
+                .append(SEC_WEBSOCKET_ACCEPT).append(": ")
+                .append(WebSocketClientHandshaker.acceptKey(key))
+                .append(CRLF);
+
+        String protocol = protocol(request);
+        if (protocol != null) {
+            response.append(SEC_WEBSOCKET_PROTOCOL).append(": ").append(protocol).append(CRLF);
+        }
+
+        return response.append(CRLF).toString();
+    }
+
+    private void validateRequest(HttpRequest request) {
+        if (!METHOD_GET.equals(request.method())) {
+            throw new WebSocketHandshakeException("Invalid WebSocket upgrade method: " + request.method());
+        }
+        if (!WEBSOCKET.equalsIgnoreCase(request.header(UPGRADE))) {
+            throw new WebSocketHandshakeException("Invalid WebSocket Upgrade header");
+        }
+        if (!containsToken(request.header(CONNECTION), UPGRADE_CONNECTION)) {
+            throw new WebSocketHandshakeException("Invalid WebSocket Connection header");
+        }
+        if (!VERSION.equals(request.header(SEC_WEBSOCKET_VERSION))) {
+            throw new WebSocketHandshakeException("Invalid WebSocket version");
+        }
+        String key = key(request);
+        if (key == null || key.isBlank()) {
+            throw new WebSocketHandshakeException("Missing Sec-WebSocket-Key header");
+        }
+
+        String protocol = protocol(request);
+        if (protocol != null && !containsToken(protocol, STOMP_SUB_PROTOCOL)) {
+            throw new WebSocketHandshakeException("Unsupported WebSocket subprotocol: " + protocol);
+        }
+    }
+
+    private static @Nullable String key(HttpRequest request) {
+        return request.header(SEC_WEBSOCKET_KEY);
+    }
+
+    private @Nullable String protocol(HttpRequest request) {
+        String protocol = request.header(SEC_WEBSOCKET_PROTOCOL);
+        if (protocol == null) {
+            return null;
+        }
+        return containsToken(protocol, STOMP_SUB_PROTOCOL) ? STOMP_SUB_PROTOCOL : protocol;
+    }
+
+    private static boolean containsToken(@Nullable String header, String expected) {
+        if (header == null) {
+            return false;
+        }
+        String[] tokens = header.split(",");
+        for (String token : tokens) {
+            if (expected.equalsIgnoreCase(token.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static final class WebSocketUpgradeHandler extends AbstractWebSocketHandshaker.HttpUpgradeHandler {
+
+        private @Nullable HttpRequest request;
+        private final WebSocketServerHandshaker handshaker;
+
+        WebSocketUpgradeHandler(WebSocketServerHandshaker handshaker, Promise<NetChannel> upgradeResult) {
+            super(upgradeResult);
+            this.handshaker = handshaker;
+        }
+
+        @Override
+        protected void handleHead(NetChannel channel, String head) {
+            HttpRequest parsed = handshaker.parseRequest(head);
+            channel.writeAndFlush(Buffer.alloc(handshaker.createResponse(parsed)));
+            installWebSocketCodec(channel);
+            request = parsed;
+        }
+
+        @Override
+        protected void onSuccess(NetChannel channel) {
+            HttpRequest parsed = request;
+            if (parsed != null) {
+                log.info("WebSocket server connection established. uri={}", parsed.uri());
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
@@ -35,24 +35,35 @@ import org.traffichunter.titan.bootstrap.Configurations;
 public final class IdGenerator {
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-    private static final int RANDOM_ID_BYTES = 16;
+    private static final char[] ALPHANUMERIC =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final int RANDOM_ID_LENGTH = 16;
 
     public static String uuid() {
         return UUID.randomUUID().toString();
     }
 
     public static String randomId16(@Nullable String prefix) {
-        byte[] bytes = new byte[RANDOM_ID_BYTES];
-        SECURE_RANDOM.nextBytes(bytes);
+        char[] randomId = new char[RANDOM_ID_LENGTH];
+        for (int i = 0; i < randomId.length; i++) {
+            randomId[i] = ALPHANUMERIC[SECURE_RANDOM.nextInt(ALPHANUMERIC.length)];
+        }
+        String value = new String(randomId);
 
         if (prefix == null) {
-            return Base64.getEncoder().encodeToString(bytes);
+            return value;
         }
 
         if (prefix.isBlank()) {
             prefix = "titan";
         }
-        return prefix + "-" + Base64.getEncoder().encodeToString(bytes);
+        return prefix + "-" + value;
+    }
+
+    public static String randomBase64Id16() {
+        byte[] bytes = new byte[RANDOM_ID_LENGTH];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     public static String name() {

--- a/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/IdGenerator.java
@@ -41,15 +41,18 @@ public final class IdGenerator {
         return UUID.randomUUID().toString();
     }
 
-    public static String randomId(@Nullable String prefix) {
-        if (prefix == null) {
-            prefix = "titan";
-        }
-
+    public static String randomId16(@Nullable String prefix) {
         byte[] bytes = new byte[RANDOM_ID_BYTES];
         SECURE_RANDOM.nextBytes(bytes);
 
-        return prefix + "-" + Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        if (prefix == null) {
+            return Base64.getEncoder().encodeToString(bytes);
+        }
+
+        if (prefix.isBlank()) {
+            prefix = "titan";
+        }
+        return prefix + "-" + Base64.getEncoder().encodeToString(bytes);
     }
 
     public static String name() {

--- a/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
@@ -30,15 +30,27 @@ import lombok.Getter;
  */
 @Getter
 public enum Protocol {
-    STOMP("stomp", "1.2"),
-    MQTT("mqtt", "5.0"),
+    STOMP("stomp", "1.2", "v12.stomp"),
+    MQTT("mqtt", "5.0", "v50.mqtt"),
     ;
 
     private final String name;
     private final String version;
+    private final String subProtocol;
 
-    Protocol(final String name, final String version) {
+    Protocol(final String name, final String version, final String subProtocol) {
         this.name = name;
         this.version = version;
+        this.subProtocol = subProtocol;
+    }
+
+    public static Protocol subProtocol(String subProtocol) {
+        for (Protocol protocol : values()) {
+            if (protocol.subProtocol.equals(subProtocol)) {
+                return protocol;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown sub protocol: " + subProtocol);
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 
@@ -57,6 +60,38 @@ class ChannelInBoundHandlerChainImplTest {
         buf.release();
     }
 
+    @Test
+    void addFirst_places_inbound_handler_before_existing_handlers() {
+        Buffer buf = Buffer.alloc("data");
+        List<String> order = new ArrayList<>();
+        ChannelHandlerChain chain = new ChannelHandlerChain();
+        chain.add(new RecordingInboundHandler("second", order));
+        chain.addFirst(new RecordingInboundHandler("first", order));
+
+        chain.processChannelRead(new InMemoryNetChannel(), buf);
+
+        assertThat(order).containsExactly("first", "second");
+    }
+
+    @Test
+    void addFirst_places_outbound_handler_before_existing_handlers() {
+        Buffer buf = Buffer.alloc("data");
+        List<String> order = new ArrayList<>();
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        ChannelHandlerChain chain = channel.chain();
+        chain.add(new RecordingOutboundHandler("second", order));
+        chain.addFirst(new RecordingOutboundHandler("first", order));
+
+        chain.processChannelWrite(channel, buf);
+        channel.flush();
+
+        assertThat(order).containsExactly("first", "second");
+        Buffer written = channel.pollWritten();
+        assertThat(written).isNotNull();
+        written.release();
+        buf.release();
+    }
+
     private static class PassThroughHandler implements ChannelInBoundHandler {
         @Override
         public void sparkChannelRead(@NonNull NetChannel channel,
@@ -73,6 +108,32 @@ class ChannelInBoundHandlerChainImplTest {
                                      @NonNull ChannelInBoundHandlerChain chain) {
             buffer.retain();
             chain.sparkChannelRead(channel, buffer);
+        }
+    }
+
+    private record RecordingInboundHandler(
+            String name,
+            List<String> order
+    ) implements ChannelInBoundHandler {
+
+        @Override
+        public void sparkChannelRead(@NonNull NetChannel channel,
+                                     @NonNull Buffer buffer,
+                                     @NonNull ChannelInBoundHandlerChain chain) {
+            order.add(name);
+            chain.sparkChannelRead(channel, buffer);
+        }
+    }
+
+    private record RecordingOutboundHandler(
+            String name,
+            List<String> order
+    ) implements ChannelOutBoundHandler {
+
+        @Override
+        public void sparkChannelWrite(NetChannel channel, Buffer buffer, ChannelOutBoundHandlerChainImpl chain) {
+            order.add(name);
+            chain.sparkChannelWrite(channel, buffer);
         }
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
@@ -1,0 +1,360 @@
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author yun
+ */
+class WebSocketFrameDecoderTest {
+
+    private static final int SHORT_EXTENDED_PAYLOAD_LENGTH = 126;
+    private static final int LONG_EXTENDED_PAYLOAD_LENGTH = 127;
+
+    @Test
+    void decode_unmasked_text_frame_with_two_byte_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+
+        byte[] bytes = {(byte) 0x81, (byte) 0x02, 'O', 'K'};
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.toString()).isEqualTo("OK");
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_unmasked_text_frame_with_four_byte_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+
+        byte[] bytes = {(byte) 0x81, (byte) 0x04, 'O', 'K', 'O', 'K'};
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.toString()).isEqualTo("OKOK");
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_unmasked_binary_frame_with_four_byte_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+
+        // ASCII payloads = 'A', 'B', 'A', 'B'
+        byte[] bytes = {(byte) 0x82, (byte) 0x04, (byte) 0x41, (byte) 0x42, (byte) 0x41, (byte) 0x42};
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.toString()).isEqualTo("ABAB");
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_masked_text_frame_with_two_byte_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        int maskingKey = 0x01020304;
+        byte[] body = mask(new byte[]{'O', 'K'}, maskingKey);
+        byte[] bytes = {
+                (byte) 0x81,
+                (byte) 0x82,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                body[0],
+                body[1]
+        };
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.toString()).isEqualTo("OK");
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_masked_text_frame_with_zero_masking_key() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        byte[] bytes = {
+                (byte) 0x81,
+                (byte) 0x82,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                'O',
+                'K'
+        };
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.toString()).isEqualTo("OK");
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_unmasked_text_frame_with_126_marker_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        byte[] body = repeated('A', 126);
+        byte[] bytes = new byte[4 + body.length];
+        bytes[0] = (byte) 0x81;
+        bytes[1] = (byte) SHORT_EXTENDED_PAYLOAD_LENGTH;
+        bytes[2] = 0x00;
+        bytes[3] = 0x7E;
+        System.arraycopy(body, 0, bytes, 4, body.length);
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.length()).isEqualTo(126);
+        assertThat(payload.toString()).isEqualTo("A".repeat(126));
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void decode_unmasked_text_frame_with_127_marker_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        byte[] body = repeated('B', 65_536);
+        byte[] bytes = new byte[10 + body.length];
+        bytes[0] = (byte) 0x81;
+        bytes[1] = (byte) LONG_EXTENDED_PAYLOAD_LENGTH;
+        bytes[2] = 0x00;
+        bytes[3] = 0x00;
+        bytes[4] = 0x00;
+        bytes[5] = 0x00;
+        bytes[6] = 0x00;
+        bytes[7] = 0x01;
+        bytes[8] = 0x00;
+        bytes[9] = 0x00;
+        System.arraycopy(body, 0, bytes, 10, body.length);
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNotNull();
+        assertThat(payload.length()).isEqualTo(65_536);
+        assertThat(payload.toString()).isEqualTo("B".repeat(65_536));
+        assertThat(buffer.isReadable()).isFalse();
+
+        payload.release();
+        buffer.release();
+    }
+
+    @Test
+    void return_null_when_frame_header_is_incomplete() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81});
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isFalse();
+        assertThat(buffer.isReadable()).isTrue();
+
+        buffer.release();
+    }
+
+    @Test
+    void preserve_buffer_when_extended_length_is_incomplete() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81, 0x7E, 0x00});
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isFalse();
+        assertThat(buffer.byteBuf().readerIndex()).isZero();
+        assertThat(buffer.isReadable()).isTrue();
+
+        buffer.release();
+    }
+
+    @Test
+    void preserve_buffer_when_payload_is_incomplete() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81, 0x04, 'O', 'K'});
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isFalse();
+        assertThat(buffer.byteBuf().readerIndex()).isZero();
+        assertThat(buffer.isReadable()).isTrue();
+
+        buffer.release();
+    }
+
+    @Test
+    void close_channel_when_rsv_bit_is_set() {
+        byte[] payload = {(byte) 0xC1, 0x00};
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void close_channel_when_opcode_is_unknown() {
+        byte[] payload = {(byte) 0x83, 0x00};
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void close_channel_when_fragmented_frame_is_received() {
+        byte[] payload = {0x01, 0x00};
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void close_channel_when_control_frame_payload_is_too_large() {
+        byte[] payload = {(byte) 0x88, 0x7E, 0x00, 0x7E};
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void close_channel_when_126_length_marker_uses_inline_length() {
+        byte[] payload = {(byte) 0x81, 0x7E, 0x00, 0x7D};
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void close_channel_when_127_length_marker_uses_short_extended_length() {
+        byte[] payload = {
+                (byte) 0x81,
+                0x7F,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x7E
+        };
+
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    @Test
+    void consume_close_frame_without_forwarding_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x88, 0x00});
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isTrue();
+        assertThat(buffer.isReadable()).isFalse();
+
+        buffer.release();
+    }
+
+    @Test
+    void consume_ping_frame_without_forwarding_payload() {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x89, 0x02, 'O', 'K'});
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isFalse();
+        assertThat(buffer.isReadable()).isFalse();
+
+        buffer.release();
+    }
+
+    @Test
+    void close_channel_when_long_payload_length_exceeds_supported_size() {
+        byte[] payload = {
+                (byte) 0x81,
+                0x7F,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                (byte) 0x80,
+                0x00,
+                0x00,
+                0x00
+        };
+        assertInvalidFrameClosesChannel(payload);
+    }
+
+    private static void assertInvalidFrameClosesChannel(byte[] bytes) {
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        Buffer buffer = Buffer.alloc(bytes);
+
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        Buffer payload = decoder.decode(channel, buffer);
+
+        assertThat(payload).isNull();
+        assertThat(channel.isClosed()).isTrue();
+
+        buffer.release();
+    }
+
+    private static byte[] repeated(char value, int count) {
+        byte[] bytes = new byte[count];
+        Arrays.fill(bytes, (byte) value);
+        return bytes;
+    }
+
+    private static byte[] mask(byte[] payload, int maskingKey) {
+        byte[] masked = new byte[payload.length];
+        for (int i = 0; i < payload.length; i++) {
+            masked[i] = (byte) (payload[i] ^ maskByte(maskingKey, i));
+        }
+        return masked;
+    }
+
+    private static byte maskByte(int maskingKey, int index) {
+        int shift = 24 - ((index % 4) * 8);
+        return (byte) ((maskingKey >> shift) & 0xFF);
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoderTest.java
@@ -1,0 +1,65 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+class WebSocketFrameEncoderTest {
+
+    @Test
+    void release_input_after_encoding_server_frame() {
+        Buffer input = Buffer.alloc("OK");
+
+        Buffer encoded = new WebSocketFrameEncoder(WebSocketSide.SERVER)
+                .encode(new InMemoryNetChannel(), input);
+
+        assertThat(encoded).isNotNull();
+        assertThat(encoded.getBytes()).containsExactly((byte) 0x81, 0x02, 'O', 'K');
+        assertThat(input.byteBuf().refCnt()).isZero();
+
+        encoded.release();
+    }
+
+    @Test
+    void release_input_after_encoding_client_frame() {
+        Buffer input = Buffer.alloc("OK");
+
+        Buffer encoded = new WebSocketFrameEncoder(WebSocketSide.CLIENT)
+                .encode(new InMemoryNetChannel(), input);
+
+        assertThat(encoded).isNotNull();
+        assertThat(encoded.getUnsignedByte(0)).isEqualTo((short) 0x81);
+        assertThat(encoded.getUnsignedByte(1) & 0x80).isEqualTo(0x80);
+        assertThat(input.byteBuf().refCnt()).isZero();
+
+        encoded.release();
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
@@ -1,0 +1,99 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader.OpCode.TEXT;
+
+/**
+ * @author yun
+ */
+class WebSocketFrameTest {
+
+    @Test
+    void convert_unmasked_frame_to_buffer() {
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrameHeader header = WebSocketFrameHeader.builder()
+                .op(TEXT, true)
+                .payloadLength(payload.length())
+                .build();
+        WebSocketFrame frame = new WebSocketFrame(header, payload);
+
+        Buffer encoded = frame.toBuffer();
+
+        assertThat(encoded.getBytes()).containsExactly((byte) 0x81, 0x02, 'O', 'K');
+        assertThat(payload.toString()).isEqualTo("OK");
+
+        encoded.release();
+        payload.release();
+    }
+
+    @Test
+    void convert_masked_frame_to_buffer() {
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrameHeader header = WebSocketFrameHeader.builder()
+                .op(TEXT, true)
+                .masked(0x01020304)
+                .payloadLength(payload.length())
+                .build();
+        WebSocketFrame frame = new WebSocketFrame(header, payload);
+
+        Buffer encoded = frame.toBuffer();
+
+        assertThat(encoded.getBytes()).containsExactly(
+                (byte) 0x81,
+                (byte) 0x82,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                (byte) ('O' ^ 0x01),
+                (byte) ('K' ^ 0x02)
+        );
+        assertThat(payload.toString()).isEqualTo("OK");
+
+        encoded.release();
+        payload.release();
+    }
+
+    @Test
+    void reject_payload_length_mismatch() {
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrameHeader header = WebSocketFrameHeader.builder()
+                .op(TEXT, true)
+                .payloadLength(1)
+                .build();
+        WebSocketFrame frame = new WebSocketFrame(header, payload);
+
+        assertThatThrownBy(frame::toBuffer)
+                .isInstanceOf(WebSocketFrameException.class)
+                .hasMessageContaining("payload length mismatch");
+
+        payload.release();
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/HttpRequestTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/HttpRequestTest.java
@@ -1,0 +1,84 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.test.implementation;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.transport.HttpRequest;
+
+/**
+ * @author yun
+ */
+public class HttpRequestTest {
+
+    @Test
+    void http_request_header_test() {
+        HttpRequest request = new HttpRequest();
+        request.uri("/titan")
+                .header("Host", "localhost:8080")
+                .header("Upgrade", "websocket")
+                .header("Connection", "Upgrade")
+                .header("Sec-WebSocket-Key", "123")
+                .header("Sec-WebSocket-Version", "13");
+
+        Assertions.assertThat(request.header("Sec-WebSocket-Key")).isEqualTo("123");
+        Assertions.assertThat(request.header("Sec-WebSocket-Version")).isEqualTo("13");
+        Assertions.assertThat(request.toString()).isEqualTo("""
+                GET /titan HTTP/1.1\r
+                Host: localhost:8080\r
+                Upgrade: websocket\r
+                Connection: Upgrade\r
+                Sec-WebSocket-Key: 123\r
+                Sec-WebSocket-Version: 13\r
+                \r
+                """);
+    }
+
+    @Test
+    void parse_http_request_test() {
+        HttpRequest request = HttpRequest.parse("""
+                GET /titan HTTP/1.1\r
+                Host: localhost:8080\r
+                Upgrade: websocket\r
+                Connection: keep-alive, Upgrade\r
+                Sec-WebSocket-Key: 123\r
+                Sec-WebSocket-Version: 13\r
+                \r
+                """);
+
+        Assertions.assertThat(request.method()).isEqualTo("GET");
+        Assertions.assertThat(request.uri()).isEqualTo("/titan");
+        Assertions.assertThat(request.header("host")).isEqualTo("localhost:8080");
+        Assertions.assertThat(request.header("SEC-WEBSOCKET-KEY")).isEqualTo("123");
+        Assertions.assertThat(request.toString()).isEqualTo("""
+                GET /titan HTTP/1.1\r
+                Host: localhost:8080\r
+                Upgrade: websocket\r
+                Connection: keep-alive, Upgrade\r
+                Sec-WebSocket-Key: 123\r
+                Sec-WebSocket-Version: 13\r
+                \r
+                """);
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
@@ -12,7 +12,7 @@ class IdGeneratorTest {
 
     @Test
     void generate_random_id_test() {
-        String randomId = IdGenerator.randomId(null);
+        String randomId = IdGenerator.randomId16(null);
 
         assertThat(randomId).isNotNull();
         assertThat(randomId).startsWith("titan-");
@@ -21,7 +21,7 @@ class IdGeneratorTest {
 
     @Test
     void generate_random_id_prefix_test() {
-        String randomId = IdGenerator.randomId("qwer");
+        String randomId = IdGenerator.randomId16("qwer");
 
         assertThat(randomId).isNotNull();
         assertThat(randomId).startsWith("qwer-");

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/IdGeneratorTest.java
@@ -3,6 +3,8 @@ package org.traffichunter.titan.core.test.implementation;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.util.IdGenerator;
 
+import java.util.Base64;
+
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -12,11 +14,12 @@ class IdGeneratorTest {
 
     @Test
     void generate_random_id_test() {
-        String randomId = IdGenerator.randomId16(null);
+        String randomId = IdGenerator.randomId16("");
 
         assertThat(randomId).isNotNull();
         assertThat(randomId).startsWith("titan-");
-        assertThat(randomId).hasSize("titan-".length() + 22);
+        assertThat(randomId).hasSize("titan-".length() + 16);
+        assertThat(randomId.substring("titan-".length())).matches("[A-Za-z0-9]{16}");
     }
 
     @Test
@@ -25,6 +28,21 @@ class IdGeneratorTest {
 
         assertThat(randomId).isNotNull();
         assertThat(randomId).startsWith("qwer-");
-        assertThat(randomId).hasSize("qwer-".length() + 22);
+        assertThat(randomId).hasSize("qwer-".length() + 16);
+        assertThat(randomId.substring("qwer-".length())).matches("[A-Za-z0-9]{16}");
+    }
+
+    @Test
+    void generate_random_id_without_prefix_test() {
+        String randomId = IdGenerator.randomId16(null);
+
+        assertThat(randomId).matches("[A-Za-z0-9]{16}");
+    }
+
+    @Test
+    void generate_sixteen_byte_base64_id_test() {
+        String randomId = IdGenerator.randomBase64Id16();
+
+        assertThat(Base64.getDecoder().decode(randomId)).hasSize(16);
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
@@ -1,0 +1,188 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
+import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.TaskEventLoop;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.transport.websocket.WebSocketClientHandshaker.WebSocketUpgradeHandler;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * @author yun
+ */
+class WebSocketClientHandshakerTest {
+
+    private static final String KEY = "dGhlIHNhbXBsZSBub25jZQ==";
+    private static final String ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+    private static final String RESPONSE = "HTTP/1.1 101 Switching Protocols\r\n"
+            + "Upgrade: websocket\r\n"
+            + "Connection: Upgrade\r\n"
+            + "Sec-WebSocket-Accept: " + ACCEPT + "\r\n"
+            + "\r\n";
+
+    @Test
+    void accept_key_matches_rfc_6455_example() {
+        String accept = WebSocketClientHandshaker.acceptKey(KEY);
+
+        assertThat(accept).isEqualTo(ACCEPT);
+    }
+
+    @Test
+    void validate_response_accepts_switching_protocols_response() {
+        assertThatNoException()
+                .isThrownBy(() -> new WebSocketClientHandshaker("localhost").validateResponse(RESPONSE, KEY));
+    }
+
+    @Test
+    void validate_response_rejects_invalid_accept_key() {
+        String response = RESPONSE.replace(ACCEPT, "invalid");
+
+        assertThatThrownBy(() -> new WebSocketClientHandshaker("localhost").validateResponse(response, KEY))
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Invalid Sec-WebSocket-Accept");
+    }
+
+    @Test
+    void upgrade_handler_completes_when_response_arrives_in_one_read() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(RESPONSE);
+
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.chain.reads).isEmpty();
+    }
+
+    @Test
+    void upgrade_handler_completes_when_response_arrives_fragmented() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read("HTTP/1.1 101 Switching");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        harness.read(" Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        // terminating CRLF + CRLF split in the middle
+        harness.read("Sec-WebSocket-Accept: " + ACCEPT + "\r\n\r");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        harness.read("\n");
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.chain.reads).isEmpty();
+    }
+
+    @Test
+    void upgrade_handler_completes_when_response_arrives_byte_by_byte() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        byte[] response = RESPONSE.getBytes(ISO_8859_1);
+        for (byte b : response) {
+            assertThat(harness.promise.isDone()).isFalse();
+            harness.read(new byte[]{b});
+        }
+
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.chain.reads).isEmpty();
+    }
+
+    @Test
+    void upgrade_handler_passes_through_bytes_arriving_with_and_after_response() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(RESPONSE + "FRAME");
+
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.chain.reads).containsExactly("FRAME");
+
+        harness.read("MORE");
+
+        assertThat(harness.chain.reads).containsExactly("FRAME", "MORE");
+    }
+
+    @Test
+    void upgrade_handler_rejects_invalid_accept_header() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(RESPONSE.replace(ACCEPT, "invalid"));
+
+        assertThat(harness.promise.isFailed()).isTrue();
+        assertThat(harness.promise.error())
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Invalid Sec-WebSocket-Accept");
+        assertThat(harness.channel.isClosed()).isTrue();
+    }
+
+    private static final class UpgradeHarness {
+
+        private final InMemoryNetChannel channel = new InMemoryNetChannel();
+        private final Promise<NetChannel> promise = Promise.newPromise(new TaskEventLoop());
+        private final CapturingChain chain = new CapturingChain();
+        private final WebSocketUpgradeHandler handler =
+                new WebSocketUpgradeHandler(new WebSocketClientHandshaker("localhost"), KEY, promise);
+
+        private void read(String data) {
+            read(data.getBytes(ISO_8859_1));
+        }
+
+        private void read(byte[] data) {
+            handler.sparkChannelRead(channel, Buffer.alloc(data), chain);
+        }
+    }
+
+    private static final class CapturingChain implements ChannelInBoundHandlerChain {
+
+        private final List<String> reads = new ArrayList<>();
+
+        @Override
+        public void sparkChannelConnecting(NetChannel channel) {
+        }
+
+        @Override
+        public void sparkChannelAfterConnected(NetChannel channel) {
+        }
+
+        @Override
+        public void sparkChannelRead(NetChannel channel, Buffer buffer) {
+            try {
+                reads.add(buffer.toString(ISO_8859_1));
+            } finally {
+                buffer.release();
+            }
+        }
+
+        @Override
+        public void sparkExceptionCaught(Throwable error) {
+        }
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
@@ -1,0 +1,201 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
+import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.TaskEventLoop;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.transport.HttpRequest;
+import org.traffichunter.titan.core.transport.websocket.WebSocketServerHandshaker.WebSocketUpgradeHandler;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author yun
+ */
+class WebSocketServerHandshakerTest {
+
+    private static final String KEY = "dGhlIHNhbXBsZSBub25jZQ==";
+    private static final String ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+    private static final String REQUEST = "GET /titan HTTP/1.1\r\n"
+            + "Host: localhost:8080\r\n"
+            + "Upgrade: websocket\r\n"
+            + "Connection: keep-alive, Upgrade\r\n"
+            + "Sec-WebSocket-Key: " + KEY + "\r\n"
+            + "Sec-WebSocket-Protocol: v12.stomp\r\n"
+            + "Sec-WebSocket-Version: 13\r\n"
+            + "\r\n";
+
+    @Test
+    void parse_request_extracts_websocket_upgrade_headers() {
+        HttpRequest request = new WebSocketServerHandshaker().parseRequest(REQUEST);
+
+        assertThat(request.uri()).isEqualTo("/titan");
+        assertThat(request.header("Sec-WebSocket-Key")).isEqualTo(KEY);
+        assertThat(request.header("Sec-WebSocket-Protocol")).isEqualTo("v12.stomp");
+    }
+
+    @Test
+    void create_response_returns_switching_protocols_response() {
+        WebSocketServerHandshaker handshaker = new WebSocketServerHandshaker();
+        HttpRequest request = handshaker.parseRequest(REQUEST);
+
+        String response = handshaker.createResponse(request);
+
+        assertThat(response).isEqualTo("HTTP/1.1 101 Switching Protocols\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Sec-WebSocket-Accept: " + ACCEPT + "\r\n"
+                + "Sec-WebSocket-Protocol: v12.stomp\r\n"
+                + "\r\n");
+    }
+
+    @Test
+    void parse_request_rejects_invalid_upgrade_request() {
+        String request = REQUEST.replace("Upgrade: websocket", "Upgrade: h2c");
+
+        assertThatThrownBy(() -> new WebSocketServerHandshaker().parseRequest(request))
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Invalid WebSocket Upgrade header");
+    }
+
+    @Test
+    void upgrade_handler_completes_when_request_arrives_in_one_read() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(REQUEST);
+
+        String response = harness.written();
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(response).contains("HTTP/1.1 101 Switching Protocols");
+        assertThat(response).contains("Sec-WebSocket-Accept: " + ACCEPT);
+        assertThat(harness.chain.reads).isEmpty();
+    }
+
+    @Test
+    void upgrade_handler_completes_when_request_arrives_fragmented() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read("GET /titan HTTP/1.1\r\nHost: localhost:8080\r\n");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        harness.read("Upgrade: websocket\r\nConnection: keep-alive, Upgrade\r\n");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        harness.read("Sec-WebSocket-Key: " + KEY + "\r\n"
+                + "Sec-WebSocket-Protocol: v12.stomp\r\n"
+                + "Sec-WebSocket-Version: 13\r\n\r");
+        assertThat(harness.promise.isDone()).isFalse();
+
+        harness.read("\n");
+
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.written()).contains("HTTP/1.1 101 Switching Protocols");
+    }
+
+    @Test
+    void upgrade_handler_passes_through_bytes_arriving_with_and_after_request() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(REQUEST + "FRAME");
+
+        assertThat(harness.promise.isSuccess()).isTrue();
+        assertThat(harness.chain.reads).containsExactly("FRAME");
+
+        harness.read("MORE");
+
+        assertThat(harness.chain.reads).containsExactly("FRAME", "MORE");
+    }
+
+    @Test
+    void upgrade_handler_fails_promise_and_closes_channel_when_request_is_invalid() {
+        UpgradeHarness harness = new UpgradeHarness();
+
+        harness.read(REQUEST.replace("Sec-WebSocket-Version: 13", "Sec-WebSocket-Version: 12"));
+
+        assertThat(harness.promise.isFailed()).isTrue();
+        assertThat(harness.promise.error())
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Invalid WebSocket version");
+        assertThat(harness.channel.isClosed()).isTrue();
+    }
+
+    private static final class UpgradeHarness {
+
+        private final InMemoryNetChannel channel = new InMemoryNetChannel();
+        private final Promise<NetChannel> promise = Promise.newPromise(new TaskEventLoop());
+        private final CapturingChain chain = new CapturingChain();
+        private final WebSocketUpgradeHandler handler =
+                new WebSocketUpgradeHandler(new WebSocketServerHandshaker(), promise);
+
+        private void read(String data) {
+            handler.sparkChannelRead(channel, Buffer.alloc(data.getBytes(ISO_8859_1)), chain);
+        }
+
+        private String written() {
+            Buffer written = channel.pollWritten();
+            assertThat(written).isNotNull();
+            try {
+                return written.toString(ISO_8859_1);
+            } finally {
+                written.release();
+            }
+        }
+    }
+
+    private static final class CapturingChain implements ChannelInBoundHandlerChain {
+
+        private final List<String> reads = new ArrayList<>();
+
+        @Override
+        public void sparkChannelConnecting(NetChannel channel) {
+        }
+
+        @Override
+        public void sparkChannelAfterConnected(NetChannel channel) {
+        }
+
+        @Override
+        public void sparkChannelRead(NetChannel channel, Buffer buffer) {
+            try {
+                reads.add(buffer.toString(ISO_8859_1));
+            } finally {
+                buffer.release();
+            }
+        }
+
+        @Override
+        public void sparkExceptionCaught(Throwable error) {
+        }
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannelImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannelImpl.java
@@ -48,7 +48,6 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
-import static org.traffichunter.titan.core.codec.stomp.StompFrame.AckMode;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.create;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 
@@ -58,7 +57,7 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 @Slf4j
 public class StompClientChannelImpl implements StompClientChannel {
 
-    private final String sessionId = IdGenerator.randomId("session");
+    private final String sessionId = IdGenerator.randomId16("session");
     private final NetChannel netChannel;
     private final StompClientHandler stompClientHandler;
     private final StompClientOption option;


### PR DESCRIPTION
## Motivation:

Titan needs native WebSocket transport support so STOMP traffic can be upgraded, framed, and decoded without relying on an external WebSocket engine.

## Modification:

- Added client and server HTTP upgrade handshakes with subprotocol negotiation.
- Added WebSocket frame headers, frame encoding and decoding, masking, payload-length validation, and endpoint-side handling.
- Added buffer ownership safeguards for outbound frame transformations and write failures.
- Refined random ID generation and separated RFC-compatible WebSocket handshake keys.
- Added focused tests for handshakes, frame boundaries, masking, malformed frames, and buffer release behavior.

## Result:

Titan can establish WebSocket connections and encode or decode STOMP WebSocket data frames with strict RFC 6455 validation. Fragmentation and control-frame protocol handling remain explicit follow-up work.

Validation:

- `./gradlew :core:test --tests org.traffichunter.titan.core.codec.websocket.WebSocketFrameDecoderTest --tests org.traffichunter.titan.core.codec.websocket.WebSocketFrameEncoderTest --tests org.traffichunter.titan.core.transport.websocket.WebSocketClientHandshakerTest --tests org.traffichunter.titan.core.transport.websocket.WebSocketServerHandshakerTest --no-configuration-cache`
- `./gradlew :core:test --tests org.traffichunter.titan.core.test.implementation.IdGeneratorTest --no-configuration-cache`
