### PR TITLE
Add STOMP over WebSocket transports

### DIFF
--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/ServerSettings.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/ServerSettings.java
@@ -59,8 +59,8 @@ public record ServerSettings(
         if (name == null) {
             name = "";
         }
-        if (transport == null) {
-            transport = "";
+        if (transport == null || transport.isBlank()) {
+            transport = "tcp";
         }
         if (protocol == null) {
             protocol = "";

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
@@ -1,0 +1,206 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.websocket;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.ChannelHandlerChain;
+import org.traffichunter.titan.core.channel.IOEventLoop;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
+import org.traffichunter.titan.core.concurrent.ChannelPromise;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketOption;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author yun
+ */
+public final class WebSocketChannel implements NetChannel {
+
+    private final NetChannel delegate;
+    private final Protocol subProtocol;
+
+    public WebSocketChannel(NetChannel delegate, Protocol subProtocol) {
+        this.delegate = delegate;
+        this.subProtocol = subProtocol;
+    }
+
+    @Override
+    public <T> NetChannel setOption(SocketOption<T> option, T value) {
+        delegate.setOption(option, value);
+        return this;
+    }
+
+    @Override
+    public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException {
+        delegate.connect(remote, timeOut, timeUnit);
+    }
+
+    @Override
+    public void disconnect() {
+        delegate.disconnect();
+    }
+
+    @Override
+    public int read(Buffer buffer) {
+        return delegate.read(buffer);
+    }
+
+    @Override
+    public void write(Buffer buffer) {
+        delegate.write(buffer);
+    }
+
+    @Override
+    public void writeAndFlush(Buffer buffer) {
+        delegate.writeAndFlush(buffer);
+    }
+
+    public void writeAndFlush(WebSocketFrame frame) {
+        if (frame.subProtocol() != subProtocol) {
+            throw new IllegalArgumentException("WebSocket frame subprotocol does not match channel subprotocol");
+        }
+
+        Buffer encoded = frame.encode();
+        boolean accepted = false;
+        try {
+            delegate.write(encoded);
+            accepted = true;
+            delegate.flush();
+        } finally {
+            if (!accepted) {
+                encoded.release();
+            }
+        }
+    }
+
+    @Override
+    public void flush() {
+        delegate.flush();
+    }
+
+    @Override
+    public void onWritabilityChanged(boolean isWritable) {
+        delegate.onWritabilityChanged(isWritable);
+    }
+
+    @Override
+    public boolean finishConnect() throws IOException {
+        return delegate.finishConnect();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return delegate.isConnected();
+    }
+
+    @Override
+    public ChannelHandlerChain chain() {
+        return delegate.chain();
+    }
+
+    @Override
+    public ChannelPromise register(IOEventLoop eventLoop, ChannelPromise promise) {
+        return delegate.register(eventLoop, promise);
+    }
+
+    @Override
+    public IOEventLoop eventLoop() {
+        return delegate.eventLoop();
+    }
+
+    @Override
+    public String id() {
+        return delegate.id();
+    }
+
+    @Override
+    public String session() {
+        return delegate.session();
+    }
+
+    @Override
+    public @Nullable <T> T getOption(SocketOption<T> option) {
+        return delegate.getOption(option);
+    }
+
+    @Override
+    public Instant lastActivatedAt() {
+        return delegate.lastActivatedAt();
+    }
+
+    @Override
+    public Instant setLastActivatedAt() {
+        return delegate.setLastActivatedAt();
+    }
+
+    @Override
+    public @Nullable SocketAddress localAddress() {
+        return delegate.localAddress();
+    }
+
+    @Override
+    public @Nullable SocketAddress remoteAddress() {
+        return delegate.remoteAddress();
+    }
+
+    public Protocol subProtocol() {
+        return subProtocol;
+    }
+
+    public NetChannel unwrap() {
+        return delegate;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isRegistered() {
+        return delegate.isRegistered();
+    }
+
+    @Override
+    public boolean isActive() {
+        return delegate.isActive();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketContext.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketContext.java
@@ -1,0 +1,36 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.websocket;
+
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
+import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
+
+/**
+ * @author yun
+ */
+public record WebSocketContext(
+        WebSocketChannel channel,
+        WebSocketFrame frame,
+        WebSocketSide side
+) { }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandler.java
@@ -1,0 +1,42 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.websocket;
+
+import org.traffichunter.titan.core.util.Handler;
+
+/**
+ * Handles WebSocket control frames consumed by the frame decoder.
+ *
+ * <p>The handler owns the received frame payload and must release it or transfer
+ * its ownership before returning. The context carries the local endpoint side,
+ * allowing the same stateless handler to serve client and server channels.</p>
+ *
+ * @author yun
+ */
+@FunctionalInterface
+public interface WebSocketControlFrameHandler extends Handler<WebSocketContext> {
+
+    @Override
+    void handle(WebSocketContext context);
+}

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandlerImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandlerImpl.java
@@ -1,0 +1,90 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.websocket;
+
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameException;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrames;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+/**
+ * @author yun
+ */
+public final class WebSocketControlFrameHandlerImpl implements WebSocketControlFrameHandler {
+
+    @Override
+    public void handle(WebSocketContext context) {
+        WebSocketFrame frame = context.frame();
+
+        switch (frame.header().getOpCode()) {
+            case PING -> handlePing(context);
+            case PONG -> frame.payload().release();
+            case CLOSE -> handleClose(context);
+            default -> throw new WebSocketFrameException("Not a control frame");
+        }
+    }
+
+    private void handlePing(WebSocketContext context) {
+        WebSocketFrame frame = context.frame();
+        try {
+            WebSocketFrame pong = WebSocketFrames.pong(
+                    Buffer.alloc(frame.payload().getBytes()),
+                    context.side(),
+                    frame.subProtocol()
+            );
+            write(context.channel(), pong);
+        } finally {
+            frame.payload().release();
+        }
+    }
+
+    private void handleClose(WebSocketContext context) {
+        WebSocketFrame frame = context.frame();
+        Buffer closePayload = Buffer.alloc(frame.payload().getBytes());
+        try {
+            WebSocketFrame close = WebSocketFrames.close(
+                    closePayload,
+                    context.side(),
+                    frame.subProtocol()
+            );
+            write(context.channel(), close).addListener(result -> context.channel().close());
+        } catch (RuntimeException e) {
+            closePayload.release();
+            throw e;
+        } finally {
+            frame.payload().release();
+        }
+    }
+
+    private Promise<Void> write(WebSocketChannel channel, WebSocketFrame frame) {
+        return channel.eventLoop().submit(() -> {
+            try {
+                channel.writeAndFlush(frame);
+            } finally {
+                frame.payload().release();
+            }
+        });
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/package-info.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * @author yun
+ */
+@NullMarked
+package org.traffichunter.titan.core.channel.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec.websocket;
 
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -52,11 +51,10 @@ public record WebSocketFrame(
      * <p>The returned buffer owns independent storage. This method does not consume or release
      * the frame payload.</p>
      */
-    public Buffer toBuffer() {
+    public Buffer encode() {
         long payloadLength = header.getPayloadLength();
         if (payloadLength != payload.length()) {
-            throw new WebSocketFrameException(
-                    "Frame payload length mismatch: header=" + payloadLength + ", actual=" + payload.length());
+            throw new WebSocketFrameException("Frame payload length mismatch: header=" + payloadLength + ", actual=" + payload.length());
         }
 
         Buffer frame = Buffer.alloc(Math.addExact(header.size(), payload.length()));
@@ -88,12 +86,19 @@ public record WebSocketFrame(
         }
     }
 
-    static boolean isControlFrame(OpCode opcode) {
+    public static boolean isControlFrame(OpCode opcode) {
         return opcode == OpCode.CLOSE || opcode == OpCode.PING || opcode == OpCode.PONG;
     }
 
-    static boolean isDataFrame(OpCode opcode) {
+    public static boolean isDataFrame(OpCode opcode) {
         return opcode == OpCode.TEXT || opcode == OpCode.BINARY;
     }
 
+    public boolean isControlFrame() {
+        return isControlFrame(header.getOpCode());
+    }
+
+    public boolean isDataFrame() {
+        return isDataFrame(header.getOpCode());
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoder.java
@@ -27,6 +27,10 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketContext;
+import org.traffichunter.titan.core.channel.websocket.WebSocketControlFrameHandler;
+import org.traffichunter.titan.core.channel.websocket.WebSocketControlFrameHandlerImpl;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
 import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
@@ -42,16 +46,28 @@ public class WebSocketFrameDecoder extends ChannelDecoder {
     private static final Logger log = LoggerFactory.getLogger(WebSocketFrameDecoder.class);
 
     private final WebSocketFrameParser parser;
+    private final WebSocketSide side;
+    private final WebSocketControlFrameHandler controlFrameHandler;
 
     public WebSocketFrameDecoder() {
-        this(Protocol.STOMP);
+        this(WebSocketSide.SERVER, Protocol.STOMP);
     }
 
     public WebSocketFrameDecoder(String subProtocol) {
-        this(Protocol.subProtocol(subProtocol));
+        this(WebSocketSide.SERVER, Protocol.subProtocol(subProtocol));
     }
 
-    public WebSocketFrameDecoder(Protocol subProtocol) {
+    public WebSocketFrameDecoder(WebSocketSide side, Protocol subProtocol) {
+        this(side, subProtocol, new WebSocketControlFrameHandlerImpl());
+    }
+
+    public WebSocketFrameDecoder(
+            WebSocketSide side,
+            Protocol subProtocol,
+            WebSocketControlFrameHandler controlFrameHandler
+    ) {
+        this.side = side;
+        this.controlFrameHandler = controlFrameHandler;
         this.parser = new WebSocketFrameParser(subProtocol);
     }
 
@@ -62,11 +78,14 @@ public class WebSocketFrameDecoder extends ChannelDecoder {
             if (websocketFrame == null) {
                 return null;
             }
-            if (isControlFrame(websocketFrame.header().getOpCode())) {
-                websocketFrame.payload().release();
-                if (websocketFrame.header().getOpCode() == OpCode.CLOSE) {
-                    channel.close();
-                }
+            if (websocketFrame.isControlFrame()) {
+                WebSocketContext webSocketContext = new WebSocketContext(
+                        new WebSocketChannel(channel, websocketFrame.subProtocol()),
+                        websocketFrame,
+                        side
+                );
+
+                controlFrameHandler.handle(webSocketContext);
                 return null;
             }
 

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoder.java
@@ -56,15 +56,7 @@ public class WebSocketFrameEncoder extends ChannelEncoder {
     protected @Nullable Buffer encode(NetChannel channel, Buffer buffer) {
         try {
             WebSocketFrame websocketFrame = parser.parse(buffer);
-
-            if (WebSocketFrame.isControlFrame(websocketFrame.header().getOpCode())) {
-                if (websocketFrame.header().getOpCode() == WebSocketFrameHeader.OpCode.CLOSE) {
-                    channel.close();
-                }
-                return null;
-            }
-
-            return websocketFrame.toBuffer();
+            return websocketFrame.encode();
         } catch (WebSocketFrameException e) {
             log.warn("Rejected invalid websocket frame. reason={}", e.getMessage());
             channel.close();
@@ -109,10 +101,6 @@ public class WebSocketFrameEncoder extends ChannelEncoder {
         }
 
         private static void validate(WebSocketSide side, WebSocketFrameHeader header) {
-            if (header.isMasked() && header.getMaskingKey() == 0) {
-                throw new WebSocketFrameException("Masking key must not be zero");
-            }
-
             switch (side) {
                 case SERVER -> {
                     if (header.isMasked()) {

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrames.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrames.java
@@ -1,0 +1,136 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader.OpCode;
+import org.traffichunter.titan.core.util.Assert;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author yun
+ */
+public final class WebSocketFrames {
+
+    public static WebSocketFrame ping(
+            Buffer payload,
+            WebSocketSide side,
+            Protocol protocol
+    ) {
+        validateControlPayload(payload);
+        WebSocketFrameHeader.Builder header = WebSocketFrameHeader.builder()
+                .op(WebSocketFrameHeader.OpCode.PING, true)
+                .payloadLength(payload.length());
+
+        if (side == WebSocketSide.CLIENT) {
+            header.masked(WebSocketFrameHeader.generateMaskingKey());
+        }
+
+        return new WebSocketFrame(
+                header.build(),
+                payload,
+                protocol
+        );
+    }
+
+    public static WebSocketFrame pong(
+            Buffer pingPayload,
+            WebSocketSide side,
+            Protocol protocol
+    ) {
+        validateControlPayload(pingPayload);
+        WebSocketFrameHeader.Builder header = WebSocketFrameHeader.builder()
+                .op(WebSocketFrameHeader.OpCode.PONG, true)
+                .payloadLength(pingPayload.length());
+
+        if (side == WebSocketSide.CLIENT) {
+            header.masked(WebSocketFrameHeader.generateMaskingKey());
+        }
+
+        return new WebSocketFrame(
+                header.build(),
+                pingPayload,
+                protocol
+        );
+    }
+
+    public static WebSocketFrame close(
+            int statusCode,
+            String reason,
+            WebSocketSide side,
+            Protocol protocol
+    ) {
+        byte[] reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
+
+        Assert.check(reasonBytes.length <= 123, () -> new WebSocketFrameException("Close reason must be at most 123 bytes"));
+
+        Buffer payload = Buffer.alloc(Short.BYTES + reasonBytes.length)
+                .accumulateUnsignedShort(statusCode)
+                .accumulateBytes(reasonBytes);
+
+        WebSocketFrameHeader.Builder header = WebSocketFrameHeader.builder()
+                .op(OpCode.CLOSE, true)
+                .payloadLength(payload.length());
+
+        if (side == WebSocketSide.CLIENT) {
+            header.masked(WebSocketFrameHeader.generateMaskingKey());
+        }
+
+        return new WebSocketFrame(
+                header.build(),
+                payload,
+                protocol
+        );
+    }
+
+    public static WebSocketFrame close(
+            Buffer payload,
+            WebSocketSide side,
+            Protocol protocol
+    ) {
+        validateControlPayload(payload);
+        if (payload.length() == 1) {
+            throw new WebSocketFrameException("Close frame payload must be empty or at least 2 bytes");
+        }
+
+        WebSocketFrameHeader.Builder header = WebSocketFrameHeader.builder()
+                .op(OpCode.CLOSE, true)
+                .payloadLength(payload.length());
+        if (side == WebSocketSide.CLIENT) {
+            header.masked(WebSocketFrameHeader.generateMaskingKey());
+        }
+        return new WebSocketFrame(header.build(), payload, protocol);
+    }
+
+    private static void validateControlPayload(Buffer payload) {
+        if (payload.length() > 125) {
+            throw new WebSocketFrameException("Control frame payload must be at most 125 bytes");
+        }
+    }
+
+    private WebSocketFrames() {
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -40,9 +40,10 @@ import org.traffichunter.titan.core.channel.NewIONetChannel;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.transport.option.InetClientOption;
-import org.traffichunter.titan.core.transport.websocket.WebSocketClientHandshaker;
+import org.traffichunter.titan.core.transport.websocket.WebSocketClient;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.Noop;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
@@ -59,8 +60,6 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
     private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
     private final InetClientOption option;
-    private boolean upgradeWebsocket = false;
-
     private Handler<Channel> channelHandler = channel -> {};
 
     private enum State {
@@ -94,9 +93,8 @@ public class InetClient extends AbstractTransport<NetChannel> {
     }
 
     @CanIgnoreReturnValue
-    public InetClient upgradeWebsocket() {
-        this.upgradeWebsocket = true;
-        return this;
+    public WebSocketClient upgradeWebsocket(Protocol subProtocol) {
+        return new WebSocketClient(this, subProtocol);
     }
 
     @Override
@@ -183,12 +181,6 @@ public class InetClient extends AbstractTransport<NetChannel> {
             });
         });
 
-        if (upgradeWebsocket) {
-            return connectResult.thenCompose(netChannel ->
-                    new WebSocketClientHandshaker(remoteAddress.getHostString()).handshake(netChannel)
-            );
-        }
-
         return connectResult;
     }
 
@@ -201,6 +193,10 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
         // Outbound sends are distributed across the currently registered client channels.
         NetChannel channel = channelRegistry.selector().next();
+        return send(channel, buffer);
+    }
+
+    public Promise<Void> send(NetChannel channel, Buffer buffer) {
         if (state.get() != State.STARTED || channel.isClosed() || !channel.isConnected()) {
             log.error("Not ready to connect");
             return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Not ready to connect"));
@@ -216,6 +212,14 @@ public class InetClient extends AbstractTransport<NetChannel> {
                 throw new ClientException("Failed to send data", e);
             }
         });
+    }
+
+    public <C> Promise<C> failedPromise(Throwable error) {
+        return Promise.failedPromise(groups().secondaryGroup(), error);
+    }
+
+    public void disconnect(NetChannel channel) {
+        destroyChannel(channel);
     }
 
     public void shutdown() {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -97,6 +97,11 @@ public class InetClient extends AbstractTransport<NetChannel> {
         return new WebSocketClient(this, subProtocol);
     }
 
+    @CanIgnoreReturnValue
+    public WebSocketClient upgradeWebsocket(Protocol subProtocol, String path) {
+        return new WebSocketClient(this, subProtocol, path);
+    }
+
     @Override
     public void start() {
         if (!state.compareAndSet(State.INIT, State.STARTED)) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -104,7 +104,12 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
 
     @CanIgnoreReturnValue
     public InetServer upgradeWebsocket() {
-        this.acceptor.setUpgradeWebsocket();
+        return upgradeWebsocket("/titan");
+    }
+
+    @CanIgnoreReturnValue
+    public InetServer upgradeWebsocket(String path) {
+        this.acceptor.setUpgradeWebsocket(path);
         return this;
     }
 
@@ -275,7 +280,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         private volatile InetClientOption childOption = InetClientOption.DEFAULT_INET_CLIENT_OPTION;
         private volatile Handler<Channel> childHandler = ch -> {};
         private volatile boolean upgradeWebsocket;
-        private final WebSocketServerHandshaker webSocketHandshaker = new WebSocketServerHandshaker();
+        private volatile WebSocketServerHandshaker webSocketHandshaker = new WebSocketServerHandshaker();
 
         ServerChannelAcceptor(
                 ChannelEventLoopGroup<ChannelSecondaryIOEventLoop> secondaryGroup,
@@ -293,7 +298,8 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
             this.childHandler = childHandler;
         }
 
-        void setUpgradeWebsocket() {
+        void setUpgradeWebsocket(String path) {
+            this.webSocketHandshaker = new WebSocketServerHandshaker(path);
             this.upgradeWebsocket = true;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/AbstractWebSocketHandshaker.java
@@ -32,6 +32,7 @@ import org.traffichunter.titan.core.codec.websocket.WebSocketFrameDecoder;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrameEncoder;
 import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
@@ -115,7 +116,7 @@ abstract class AbstractWebSocketHandshaker {
         ) {
             channel.chain()
                     .add(new WebSocketFrameEncoder(side, subProtocol))
-                    .add(new WebSocketFrameDecoder(subProtocol));
+                    .add(new WebSocketFrameDecoder(side, Protocol.subProtocol(subProtocol)));
         }
 
         private static int findEndOfHead(Buffer buffer) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
@@ -1,0 +1,159 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameException;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.transport.ClientException;
+import org.traffichunter.titan.core.transport.InetClient;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.channel.ChannelRegistry;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author yun
+ */
+public final class WebSocketClient {
+
+    private final InetClient inetClient;
+    private final Protocol subProtocol;
+    private final ChannelRegistry<WebSocketChannel> channels = new ChannelRegistry<>();
+
+    public WebSocketClient(InetClient inetClient, Protocol subProtocol) {
+        this.inetClient = inetClient;
+        this.subProtocol = subProtocol;
+    }
+
+    public void start() {
+        inetClient.start();
+    }
+
+    public Promise<WebSocketChannel> connect(String host, int port) {
+        return connect(host, port, 30, TimeUnit.SECONDS);
+    }
+
+    public Promise<WebSocketChannel> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
+        return connect(new InetSocketAddress(host, port), timeOut, timeUnit);
+    }
+
+    public Promise<WebSocketChannel> connect(InetSocketAddress remoteAddress) {
+        return connect(remoteAddress, 30, TimeUnit.SECONDS);
+    }
+
+    public Promise<WebSocketChannel> connect(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) {
+        WebSocketClientHandshaker handshaker = new WebSocketClientHandshaker(remoteAddress.getHostString(), subProtocol);
+        return inetClient.connect(remoteAddress, timeOut, timeUnit)
+                .thenCompose(channel -> {
+                    Promise<NetChannel> handshake = handshaker.handshake(channel);
+                    handshake.onFailure(error -> inetClient.disconnect(channel));
+                    return handshake;
+                })
+                .map(channel -> {
+                    WebSocketChannel webSocketChannel = new WebSocketChannel(channel, subProtocol);
+                    channels.addChannel(webSocketChannel);
+                    return webSocketChannel;
+                });
+    }
+
+    public Promise<Void> send(WebSocketFrame frame) {
+        WebSocketFrameHeader header = frame.header();
+        if (!WebSocketFrame.isDataFrame(header.getOpCode())) {
+            return inetClient.failedPromise(
+                    new WebSocketFrameException("Only data frames can be sent through the payload encoder")
+            );
+        }
+
+        if (!header.isFin()) {
+            return inetClient.failedPromise(
+                    new WebSocketFrameException("Fragmented frames are not supported")
+            );
+        }
+
+        if (frame.subProtocol() != subProtocol) {
+            return inetClient.failedPromise(
+                    new WebSocketFrameException("Frame subprotocol does not match client subprotocol")
+            );
+        }
+
+        return send(frame.payload());
+    }
+
+    public Promise<Void> send(Buffer buffer) {
+        WebSocketChannel channel = readyChannel();
+        if (channel == null) {
+            return inetClient.failedPromise(new ClientException("WebSocket client is not connected"));
+        }
+        return inetClient.send(channel.unwrap(), buffer);
+    }
+
+    public void disconnect(WebSocketChannel channel) {
+        channels.removeChannel(channel);
+        inetClient.disconnect(channel.unwrap());
+    }
+
+    public void shutdown() {
+        channels.getChannels().forEach(this::disconnect);
+        inetClient.shutdown();
+    }
+
+    public void shutdown(long timeout, TimeUnit unit) {
+        channels.getChannels().forEach(this::disconnect);
+        inetClient.shutdown(timeout, unit);
+    }
+
+    public boolean isStarted() {
+        return inetClient.isStarted();
+    }
+
+    public boolean isShutdown() {
+        return inetClient.isShutdown();
+    }
+
+    public Protocol subProtocol() {
+        return subProtocol;
+    }
+
+    public List<WebSocketChannel> channels() {
+        return channels.getChannels();
+    }
+
+    private @Nullable WebSocketChannel readyChannel() {
+        for (WebSocketChannel channel : channels.getChannels()) {
+            if (channel.isConnected() && !channel.isClosed()) {
+                return channel;
+            }
+            channels.removeChannel(channel);
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
@@ -29,6 +29,7 @@ import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrameException;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.transport.ClientException;
 import org.traffichunter.titan.core.transport.InetClient;
@@ -47,11 +48,20 @@ public final class WebSocketClient {
 
     private final InetClient inetClient;
     private final Protocol subProtocol;
+    private final String path;
     private final ChannelRegistry<WebSocketChannel> channels = new ChannelRegistry<>();
 
     public WebSocketClient(InetClient inetClient, Protocol subProtocol) {
+        this(inetClient, subProtocol, "/titan");
+    }
+
+    public WebSocketClient(InetClient inetClient, Protocol subProtocol, String path) {
         this.inetClient = inetClient;
         this.subProtocol = subProtocol;
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
+        this.path = path;
     }
 
     public void start() {
@@ -71,10 +81,27 @@ public final class WebSocketClient {
     }
 
     public Promise<WebSocketChannel> connect(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) {
-        WebSocketClientHandshaker handshaker = new WebSocketClientHandshaker(remoteAddress.getHostString(), subProtocol);
+        WebSocketClientHandshaker handshaker = new WebSocketClientHandshaker(remoteAddress.getHostString(), subProtocol, path);
         return inetClient.connect(remoteAddress, timeOut, timeUnit)
                 .thenCompose(channel -> {
                     Promise<NetChannel> handshake = handshaker.handshake(channel);
+                    ScheduledPromise<?> connectionCheck = channel.eventLoop().scheduleAtFixedRate(() -> {
+                        if (!handshake.isDone() && channel.isClosed()) {
+                            handshake.tryFail(new WebSocketHandshakeException(
+                                    "Connection closed before WebSocket upgrade completed"
+                            ));
+                        }
+                    }, 1, 10, TimeUnit.MILLISECONDS);
+                    ScheduledPromise<?> timeout = channel.eventLoop().schedule(() -> {
+                        if (!handshake.isDone()) {
+                            handshake.tryFail(new WebSocketHandshakeException("WebSocket upgrade timed out"));
+                            channel.close();
+                        }
+                    }, timeOut, timeUnit);
+                    handshake.addListener(result -> {
+                        connectionCheck.cancel();
+                        timeout.cancel();
+                    });
                     handshake.onFailure(error -> inetClient.disconnect(channel));
                     return handshake;
                 })

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -63,17 +63,26 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
     private static final String STATUS_SWITCHING_PROTOCOLS = "HTTP/1.1 101";
 
     private final String host;
+    private final String path;
 
     public WebSocketClientHandshaker(String host, Protocol subProtocol) {
+        this(host, subProtocol, WEBSOCKET_URI);
+    }
+
+    public WebSocketClientHandshaker(String host, Protocol subProtocol, String path) {
         super(subProtocol.getSubProtocol(), VERSION);
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
         this.host = host;
+        this.path = path;
     }
 
     @Override
     public Promise<NetChannel> handshake(NetChannel channel) {
         String key = generateKey();
         HttpRequest request = new HttpRequest()
-                .uri(WEBSOCKET_URI)
+                .uri(path)
                 .header(HOST, host)
                 .header(UPGRADE, WEBSOCKET)
                 .header(CONNECTION, UPGRADE)

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -30,6 +30,7 @@ import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.codec.websocket.WebSocketSide;
 import org.traffichunter.titan.core.transport.HttpRequest;
 import org.traffichunter.titan.core.util.IdGenerator;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.security.MessageDigest;
@@ -57,15 +58,14 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
     private static final String WEBSOCKET = "websocket";
     private static final String CONNECTION = "Connection";
     private static final String VERSION = "13";
-    private static final String STOMP_SUB_PROTOCOL = "v12.stomp";
 
     private static final String WEBSOCKET_URI = "/titan";
     private static final String STATUS_SWITCHING_PROTOCOLS = "HTTP/1.1 101";
 
     private final String host;
 
-    public WebSocketClientHandshaker(String host) {
-        super(STOMP_SUB_PROTOCOL, VERSION);
+    public WebSocketClientHandshaker(String host, Protocol subProtocol) {
+        super(subProtocol.getSubProtocol(), VERSION);
         this.host = host;
     }
 
@@ -107,6 +107,7 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
         }
 
         String accept = null;
+        String selectedSubProtocol = null;
         for (int i = 1; i < lines.length; i++) {
             int delimiter = lines[i].indexOf(':');
             if (delimiter < 0) {
@@ -116,12 +117,18 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
             String name = lines[i].substring(0, delimiter).trim();
             if (SEC_WEBSOCKET_ACCEPT.equalsIgnoreCase(name)) {
                 accept = lines[i].substring(delimiter + 1).trim();
-                break;
+            } else if (SEC_WEBSOCKET_PROTOCOL.equalsIgnoreCase(name)) {
+                selectedSubProtocol = lines[i].substring(delimiter + 1).trim();
             }
         }
 
         if (!acceptKey(key).equals(accept)) {
             throw new WebSocketHandshakeException("Invalid Sec-WebSocket-Accept header");
+        }
+        if (!subProtocol().equals(selectedSubProtocol)) {
+            throw new WebSocketHandshakeException(
+                    "Invalid Sec-WebSocket-Protocol header: " + selectedSubProtocol
+            );
         }
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -55,9 +55,20 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
     private static final String UPGRADE_CONNECTION = "Upgrade";
     private static final String VERSION = "13";
     private static final String STOMP_SUB_PROTOCOL = "v12.stomp";
+    private static final String DEFAULT_PATH = "/titan";
+
+    private final String path;
 
     public WebSocketServerHandshaker() {
+        this(DEFAULT_PATH);
+    }
+
+    public WebSocketServerHandshaker(String path) {
         super(STOMP_SUB_PROTOCOL, VERSION);
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
+        this.path = path;
     }
 
     @Override
@@ -76,6 +87,9 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
         }
 
         validateRequest(upgradeRequest);
+        if (!path.equals(upgradeRequest.uri())) {
+            throw new WebSocketHandshakeException("Unexpected WebSocket path: " + upgradeRequest.uri());
+        }
         return upgradeRequest;
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
@@ -46,7 +46,7 @@ public enum Protocol {
 
     public static Protocol subProtocol(String subProtocol) {
         for (Protocol protocol : values()) {
-            if (protocol.subProtocol.equals(subProtocol)) {
+            if (protocol.subProtocol.equalsIgnoreCase(subProtocol) || protocol.name.equalsIgnoreCase(subProtocol)) {
                 return protocol;
             }
         }

--- a/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
@@ -1,0 +1,89 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
+import org.traffichunter.titan.core.codec.websocket.WebSocketFrameHeader;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author yun
+ */
+class WebSocketChannelTest {
+
+    @Test
+    void write_frame_directly_to_underlying_channel() {
+        NetChannel delegate = mock(NetChannel.class);
+        WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrame frame = new WebSocketFrame(
+                WebSocketFrameHeader.builder()
+                        .op(WebSocketFrameHeader.OpCode.TEXT, true)
+                        .payloadLength(payload.length())
+                        .build(),
+                payload,
+                Protocol.STOMP
+        );
+
+        channel.writeAndFlush(frame);
+
+        ArgumentCaptor<Buffer> encoded = ArgumentCaptor.forClass(Buffer.class);
+        verify(delegate).write(encoded.capture());
+        verify(delegate).flush();
+        assertThat(encoded.getValue().getBytes()).containsExactly((byte) 0x81, 0x02, 'O', 'K');
+
+        encoded.getValue().release();
+        payload.release();
+    }
+
+    @Test
+    void reject_frame_with_different_subprotocol() {
+        NetChannel delegate = mock(NetChannel.class);
+        WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
+        Buffer payload = Buffer.alloc("data");
+        WebSocketFrame frame = new WebSocketFrame(
+                WebSocketFrameHeader.builder()
+                        .op(WebSocketFrameHeader.OpCode.BINARY, true)
+                        .payloadLength(payload.length())
+                        .build(),
+                payload,
+                Protocol.MQTT
+        );
+
+        assertThatThrownBy(() -> channel.writeAndFlush(frame))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("subprotocol");
+
+        payload.release();
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
@@ -2,9 +2,12 @@ package org.traffichunter.titan.core.codec.websocket;
 
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketContext;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -298,14 +301,23 @@ class WebSocketFrameDecoderTest {
     void consume_ping_frame_without_forwarding_payload() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
         Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x89, 0x02, 'O', 'K'});
+        AtomicReference<WebSocketContext> received = new AtomicReference<>();
 
-        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
+        WebSocketFrameDecoder decoder = new WebSocketFrameDecoder(
+                WebSocketSide.SERVER,
+                Protocol.STOMP,
+                received::set
+        );
         Buffer payload = decoder.decode(channel, buffer);
 
         assertThat(payload).isNull();
         assertThat(channel.isClosed()).isFalse();
         assertThat(buffer.isReadable()).isFalse();
+        assertThat(received.get().side()).isEqualTo(WebSocketSide.SERVER);
+        assertThat(received.get().frame().header().getOpCode()).isEqualTo(WebSocketFrameHeader.OpCode.PING);
+        assertThat(received.get().frame().payload().toString()).isEqualTo("OK");
 
+        received.get().frame().payload().release();
         buffer.release();
     }
 

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
@@ -44,7 +44,7 @@ class WebSocketFrameTest {
                 .build();
         WebSocketFrame frame = new WebSocketFrame(header, payload);
 
-        Buffer encoded = frame.toBuffer();
+        Buffer encoded = frame.encode();
 
         assertThat(encoded.getBytes()).containsExactly((byte) 0x81, 0x02, 'O', 'K');
         assertThat(payload.toString()).isEqualTo("OK");
@@ -63,7 +63,7 @@ class WebSocketFrameTest {
                 .build();
         WebSocketFrame frame = new WebSocketFrame(header, payload);
 
-        Buffer encoded = frame.toBuffer();
+        Buffer encoded = frame.encode();
 
         assertThat(encoded.getBytes()).containsExactly(
                 (byte) 0x81,
@@ -90,7 +90,7 @@ class WebSocketFrameTest {
                 .build();
         WebSocketFrame frame = new WebSocketFrame(header, payload);
 
-        assertThatThrownBy(frame::toBuffer)
+        assertThatThrownBy(frame::encode)
                 .isInstanceOf(WebSocketFrameException.class)
                 .hasMessageContaining("payload length mismatch");
 

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFramesTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFramesTest.java
@@ -1,0 +1,92 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.codec.websocket;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author yun
+ */
+class WebSocketFramesTest {
+
+    @Test
+    void create_unmasked_server_ping_frame() {
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrame frame = WebSocketFrames.ping(payload, WebSocketSide.SERVER, Protocol.STOMP);
+
+        assertThat(frame.header().getOpCode()).isEqualTo(WebSocketFrameHeader.OpCode.PING);
+        assertThat(frame.header().isFin()).isTrue();
+        assertThat(frame.header().isMasked()).isFalse();
+
+        payload.release();
+    }
+
+    @Test
+    void create_masked_client_pong_frame() {
+        Buffer payload = Buffer.alloc("OK");
+        WebSocketFrame frame = WebSocketFrames.pong(payload, WebSocketSide.CLIENT, Protocol.STOMP);
+
+        assertThat(frame.header().getOpCode()).isEqualTo(WebSocketFrameHeader.OpCode.PONG);
+        assertThat(frame.header().isMasked()).isTrue();
+
+        payload.release();
+    }
+
+    @Test
+    void encode_close_status_and_reason() {
+        WebSocketFrame frame = WebSocketFrames.close(1000, "bye", WebSocketSide.SERVER, Protocol.STOMP);
+
+        assertThat(frame.payload().getUnsignedShort(0)).isEqualTo(1000);
+        assertThat(frame.payload().getBytes()).containsExactly(0x03, (byte) 0xE8, 'b', 'y', 'e');
+
+        frame.payload().release();
+    }
+
+    @Test
+    void reject_oversized_control_frame_payload() {
+        Buffer payload = Buffer.alloc(new byte[126]);
+
+        assertThatThrownBy(() -> WebSocketFrames.ping(payload, WebSocketSide.SERVER, Protocol.STOMP))
+                .isInstanceOf(WebSocketFrameException.class)
+                .hasMessageContaining("at most 125 bytes");
+
+        payload.release();
+    }
+
+    @Test
+    void reject_one_byte_close_payload() {
+        Buffer payload = Buffer.alloc(new byte[1]);
+
+        assertThatThrownBy(() -> WebSocketFrames.close(payload, WebSocketSide.SERVER, Protocol.STOMP))
+                .isInstanceOf(WebSocketFrameException.class)
+                .hasMessageContaining("empty or at least 2 bytes");
+
+        payload.release();
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/WebSocketTransportIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/WebSocketTransportIntegrationTest.java
@@ -1,0 +1,126 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.test.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.transport.InetClient;
+import org.traffichunter.titan.core.transport.InetServer;
+import org.traffichunter.titan.core.transport.websocket.WebSocketClient;
+import org.traffichunter.titan.core.util.Protocol;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+class WebSocketTransportIntegrationTest {
+
+    private InetServer server;
+    private WebSocketClient client;
+
+    @AfterEach
+    void tearDown() {
+        if (client != null && !client.isShutdown()) {
+            client.shutdown();
+        }
+        if (server != null && !server.isShutdown()) {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void exchange_payload_after_websocket_upgrade() throws Exception {
+        LinkedBlockingQueue<String> serverMessages = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<String> clientMessages = new LinkedBlockingQueue<>();
+
+        server = InetServer.open(EventLoopGroups.group(1))
+                .upgradeWebsocket("/stomp")
+                .onChannel(channel -> channel.chain().add(echo(serverMessages)));
+        server.start();
+        server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+
+        int port = ((InetSocketAddress) server.localAddress()).getPort();
+        client = InetClient.open(EventLoopGroups.group(1))
+                .upgradeWebsocket(Protocol.STOMP, "/stomp");
+        client.start();
+
+        WebSocketChannel channel = client.connect("localhost", port, 5, TimeUnit.SECONDS)
+                .get(5, TimeUnit.SECONDS);
+        channel.chain().add(capture(clientMessages));
+
+        client.send(Buffer.alloc("hello websocket")).get(5, TimeUnit.SECONDS);
+
+        assertThat(serverMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("hello websocket");
+        assertThat(clientMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("echo:hello websocket");
+    }
+
+    private static ChannelInBoundHandler echo(LinkedBlockingQueue<String> messages) {
+        return new ChannelInBoundHandler() {
+            @Override
+            public void sparkChannelRead(
+                    NetChannel channel,
+                    Buffer buffer,
+                    ChannelInBoundHandlerChain chain
+            ) {
+                try {
+                    String message = buffer.toString();
+                    messages.add(message);
+                    channel.writeAndFlush(Buffer.alloc("echo:" + message));
+                } finally {
+                    buffer.release();
+                }
+            }
+        };
+    }
+
+    private static ChannelInBoundHandler capture(LinkedBlockingQueue<String> messages) {
+        return new ChannelInBoundHandler() {
+            @Override
+            public void sparkChannelRead(
+                    NetChannel channel,
+                    Buffer buffer,
+                    ChannelInBoundHandlerChain chain
+            ) {
+                try {
+                    messages.add(buffer.toString());
+                } finally {
+                    buffer.release();
+                }
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
@@ -29,6 +29,7 @@ import org.traffichunter.titan.core.channel.InMemoryNetChannel;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.TaskEventLoop;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.transport.websocket.WebSocketClientHandshaker.WebSocketUpgradeHandler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -49,6 +50,7 @@ class WebSocketClientHandshakerTest {
             + "Upgrade: websocket\r\n"
             + "Connection: Upgrade\r\n"
             + "Sec-WebSocket-Accept: " + ACCEPT + "\r\n"
+            + "Sec-WebSocket-Protocol: v12.stomp\r\n"
             + "\r\n";
 
     @Test
@@ -61,16 +63,28 @@ class WebSocketClientHandshakerTest {
     @Test
     void validate_response_accepts_switching_protocols_response() {
         assertThatNoException()
-                .isThrownBy(() -> new WebSocketClientHandshaker("localhost").validateResponse(RESPONSE, KEY));
+                .isThrownBy(() -> new WebSocketClientHandshaker("localhost", Protocol.STOMP)
+                        .validateResponse(RESPONSE, KEY));
     }
 
     @Test
     void validate_response_rejects_invalid_accept_key() {
         String response = RESPONSE.replace(ACCEPT, "invalid");
 
-        assertThatThrownBy(() -> new WebSocketClientHandshaker("localhost").validateResponse(response, KEY))
+        assertThatThrownBy(() -> new WebSocketClientHandshaker("localhost", Protocol.STOMP)
+                .validateResponse(response, KEY))
                 .isInstanceOf(WebSocketHandshakeException.class)
                 .hasMessageContaining("Invalid Sec-WebSocket-Accept");
+    }
+
+    @Test
+    void validate_response_rejects_different_subprotocol() {
+        String response = RESPONSE.replace("v12.stomp", "v50.mqtt");
+
+        assertThatThrownBy(() -> new WebSocketClientHandshaker("localhost", Protocol.STOMP)
+                .validateResponse(response, KEY))
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Invalid Sec-WebSocket-Protocol");
     }
 
     @Test
@@ -94,7 +108,8 @@ class WebSocketClientHandshakerTest {
         assertThat(harness.promise.isDone()).isFalse();
 
         // terminating CRLF + CRLF split in the middle
-        harness.read("Sec-WebSocket-Accept: " + ACCEPT + "\r\n\r");
+        harness.read("Sec-WebSocket-Accept: " + ACCEPT
+                + "\r\nSec-WebSocket-Protocol: v12.stomp\r\n\r");
         assertThat(harness.promise.isDone()).isFalse();
 
         harness.read("\n");
@@ -149,7 +164,11 @@ class WebSocketClientHandshakerTest {
         private final Promise<NetChannel> promise = Promise.newPromise(new TaskEventLoop());
         private final CapturingChain chain = new CapturingChain();
         private final WebSocketUpgradeHandler handler =
-                new WebSocketUpgradeHandler(new WebSocketClientHandshaker("localhost"), KEY, promise);
+                new WebSocketUpgradeHandler(
+                        new WebSocketClientHandshaker("localhost", Protocol.STOMP),
+                        KEY,
+                        promise
+                );
 
         private void read(String data) {
             read(data.getBytes(ISO_8859_1));

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
@@ -66,6 +66,14 @@ class WebSocketServerHandshakerTest {
     }
 
     @Test
+    void parse_request_accepts_configured_path() {
+        HttpRequest request = new WebSocketServerHandshaker("/stomp")
+                .parseRequest(REQUEST.replace("GET /titan", "GET /stomp"));
+
+        assertThat(request.uri()).isEqualTo("/stomp");
+    }
+
+    @Test
     void create_response_returns_switching_protocols_response() {
         WebSocketServerHandshaker handshaker = new WebSocketServerHandshaker();
         HttpRequest request = handshaker.parseRequest(REQUEST);
@@ -87,6 +95,15 @@ class WebSocketServerHandshakerTest {
         assertThatThrownBy(() -> new WebSocketServerHandshaker().parseRequest(request))
                 .isInstanceOf(WebSocketHandshakeException.class)
                 .hasMessageContaining("Invalid WebSocket Upgrade header");
+    }
+
+    @Test
+    void parse_request_rejects_unexpected_path() {
+        WebSocketServerHandshaker handshaker = new WebSocketServerHandshaker("/stomp");
+
+        assertThatThrownBy(() -> handshaker.parseRequest(REQUEST))
+                .isInstanceOf(WebSocketHandshakeException.class)
+                .hasMessageContaining("Unexpected WebSocket path");
     }
 
     @Test

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -42,8 +42,7 @@ spring:
     auto-start: true
     auto-connect: true
     client: titan # titan or vertx
-    host: 127.0.0.1
-    port: 61613
+    endpoint: ws://127.0.0.1:8080/stomp
     login: guest
     passcode: guest
     virtual-host: guest
@@ -140,3 +139,11 @@ and connects the client before resolving operations.
 successfully. If listener invocation fails, the configured error handler is
 called and the frame is negatively acknowledged when a `message-id` header is
 available.
+`spring.titan.transport=websocket` upgrades the selected client connection at
+`spring.titan.websocket-path`. The host and port continue to come from
+`spring.titan.host` and `spring.titan.port`.
+
+`spring.titan.endpoint` is the preferred connection setting and accepts
+`tcp://host:port` or `ws://host:port/path`. When present, it takes precedence
+over the separate host, port, transport, and WebSocket path properties. The
+legacy properties remain available for compatibility.

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -1,5 +1,6 @@
 package org.traffichunter.titan.springframework.stomp;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -19,6 +20,12 @@ public final class TitanProperties {
     private boolean autoConnect = true;
 
     private Client client = Client.TITAN;
+
+    private @Nullable String endpoint;
+
+    private Transport transport = Transport.TCP;
+
+    private String websocketPath = "/stomp";
 
     private int primaryThreads = 1;
 
@@ -196,6 +203,30 @@ public final class TitanProperties {
         this.client = client;
     }
 
+    public @Nullable String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(@Nullable String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public Transport getTransport() {
+        return transport;
+    }
+
+    public void setTransport(Transport transport) {
+        this.transport = transport;
+    }
+
+    public String getWebsocketPath() {
+        return websocketPath;
+    }
+
+    public void setWebsocketPath(String websocketPath) {
+        this.websocketPath = websocketPath;
+    }
+
     public enum Client {
         TITAN("titan"),
         VERTX("vertx"),
@@ -210,6 +241,11 @@ public final class TitanProperties {
         public String getName() {
             return name;
         }
+    }
+
+    public enum Transport {
+        TCP,
+        WEBSOCKET,
     }
 
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.traffichunter.titan.springframework.stomp.autoconfigure;
 import java.time.Duration;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -11,6 +12,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
+import org.traffichunter.titan.core.transport.stomp.StompEndpoint;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClientProvider;
@@ -44,9 +47,10 @@ public class TitanStompClientAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public StompClientOption titanStompClientOption(TitanProperties properties) {
+        StompEndpoint endpoint = endpoint(properties);
         return StompClientOption.builder()
-                .host(properties.getHost())
-                .port(properties.getPort())
+                .host(endpoint == null ? properties.getHost() : endpoint.host())
+                .port(endpoint == null ? properties.getPort() : endpoint.port())
                 .login(properties.getLogin())
                 .passcode(properties.getPasscode())
                 .virtualHost(properties.getVirtualHost())
@@ -80,7 +84,7 @@ public class TitanStompClientAutoConfiguration {
             StompClientOption titanStompClientOption,
             TitanProperties properties
     ) {
-        return stompClientProviders.stream()
+        StompClient client = stompClientProviders.stream()
                 .filter(provider -> provider.supports(properties.getClient().getName(), titanStompClientOption.stompVersion().getVersion()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No STOMP client provider found for client: "
@@ -88,6 +92,30 @@ public class TitanStompClientAutoConfiguration {
                         + ", version: "
                         + titanStompClientOption.stompVersion().getVersion()))
                 .create(titanStompClientOption);
+
+        StompEndpoint endpoint = endpoint(properties);
+        boolean webSocket = endpoint == null
+                ? properties.getTransport() == TitanProperties.Transport.WEBSOCKET
+                : endpoint.isWebSocket();
+        if (webSocket) {
+            if (endpoint != null && endpoint.isSecure()) {
+                throw new IllegalStateException("Secure WebSocket transport is not supported yet");
+            }
+            String path = endpoint == null ? properties.getWebsocketPath() : endpoint.path();
+            if (client instanceof TitanStompClient titanClient) {
+                titanClient.upgradeWebsocket(path);
+            } else if (client instanceof VertxStompClient vertxClient) {
+                vertxClient.upgradeWebsocket(path);
+            } else {
+                throw new IllegalStateException("The selected STOMP client does not support WebSocket transport");
+            }
+        }
+        return client;
+    }
+
+    private static @Nullable StompEndpoint endpoint(TitanProperties properties) {
+        String value = properties.getEndpoint();
+        return value == null || value.isBlank() ? null : StompEndpoint.parse(value);
     }
 
     @Bean

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
@@ -2,6 +2,7 @@ package org.traffichunter.titan.springframework.stomp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,9 @@ class TitanPropertiesTest {
         assertTrue(properties.isAutoStart());
         assertTrue(properties.isAutoConnect());
         assertEquals(TitanProperties.Client.TITAN, properties.getClient());
+        assertNull(properties.getEndpoint());
+        assertEquals(TitanProperties.Transport.TCP, properties.getTransport());
+        assertEquals("/stomp", properties.getWebsocketPath());
         assertEquals("127.0.0.1", properties.getHost());
         assertEquals(61613, properties.getPort());
         assertEquals(5000L, properties.getConnectTimeoutMillis());

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
@@ -68,6 +68,88 @@ class TitanStompClientAutoConfigurationTest {
     }
 
     @Test
+    void configures_websocket_transport_for_titan_client() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
+        when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
+        StompClientProvider provider = configuration.titanStompClientProvider(eventLoopGroups);
+        TitanProperties properties = new TitanProperties();
+        properties.setTransport(TitanProperties.Transport.WEBSOCKET);
+        properties.setWebsocketPath("/titan");
+
+        StompClient client = configuration.titanStompClient(
+                List.of(provider),
+                StompClientOption.builder().build(),
+                properties
+        );
+
+        assertThat(client)
+                .isInstanceOf(TitanStompClient.class)
+                .extracting("webSocketPath")
+                .isEqualTo("/titan");
+    }
+
+    @Test
+    void configures_titan_client_from_websocket_endpoint() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
+        when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
+        TitanProperties properties = new TitanProperties();
+        properties.setEndpoint("ws://localhost:8080/titan");
+        StompClientOption option = configuration.titanStompClientOption(properties);
+
+        StompClient client = configuration.titanStompClient(
+                List.of(configuration.titanStompClientProvider(eventLoopGroups)),
+                option,
+                properties
+        );
+
+        assertThat(option.host()).isEqualTo("localhost");
+        assertThat(option.port()).isEqualTo(8080);
+        assertThat(client)
+                .isInstanceOf(TitanStompClient.class)
+                .extracting("webSocketPath")
+                .isEqualTo("/titan");
+    }
+
+    @Test
+    void rejects_secure_websocket_endpoint_until_tls_is_supported() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
+        when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
+        TitanProperties properties = new TitanProperties();
+        properties.setEndpoint("wss://localhost/stomp");
+
+        assertThatThrownBy(() -> configuration.titanStompClient(
+                List.of(configuration.titanStompClientProvider(eventLoopGroups)),
+                configuration.titanStompClientOption(properties),
+                properties
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Secure WebSocket transport is not supported yet");
+    }
+
+    @Test
+    void configures_websocket_transport_for_vertx_client() {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        TitanProperties properties = new TitanProperties();
+        properties.setClient(TitanProperties.Client.VERTX);
+        properties.setTransport(TitanProperties.Transport.WEBSOCKET);
+        properties.setWebsocketPath("/titan");
+
+        StompClient client = configuration.titanStompClient(
+                List.of(configuration.vertxStompClientProvider()),
+                StompClientOption.builder().build(),
+                properties
+        );
+
+        assertThat(client)
+                .isInstanceOf(VertxStompClient.class)
+                .extracting("webSocketPath")
+                .isEqualTo("/titan");
+    }
+
+    @Test
     void lifecycle_starts_and_connects_client_when_auto_start_and_auto_connect_are_enabled() {
         StompConnection connection = mock(StompConnection.class);
         StompClient client = lifecycleClient(connection);
@@ -144,6 +226,39 @@ class TitanStompClientAutoConfigurationTest {
 
                     assertThat(properties.getClient()).isEqualTo(TitanProperties.Client.VERTX);
                 });
+    }
+
+    @Test
+    void binds_websocket_transport_properties() {
+        StompClient client = lifecycleClient(mock(StompConnection.class));
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues(
+                        "spring.titan.auto-start=false",
+                        "spring.titan.transport=websocket",
+                        "spring.titan.websocket-path=/titan"
+                )
+                .run(context -> {
+                    TitanProperties properties = context.getBean(TitanProperties.class);
+
+                    assertThat(properties.getTransport()).isEqualTo(TitanProperties.Transport.WEBSOCKET);
+                    assertThat(properties.getWebsocketPath()).isEqualTo("/titan");
+                });
+    }
+
+    @Test
+    void binds_endpoint_property() {
+        StompClient client = lifecycleClient(mock(StompConnection.class));
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues(
+                        "spring.titan.auto-start=false",
+                        "spring.titan.endpoint=ws://localhost:8080/stomp"
+                )
+                .run(context -> assertThat(context.getBean(TitanProperties.class).getEndpoint())
+                        .isEqualTo("ws://localhost:8080/stomp"));
     }
 
     @Test

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannel.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.core.channel.stomp;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.traffichunter.titan.core.channel.ChannelHandShakeEventListener;
 import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
 import org.traffichunter.titan.core.codec.stomp.*;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
@@ -52,7 +53,7 @@ public interface StompClientChannel extends StompChannel {
             StompClientOption option,
             Handler<StompClientHandler> clientHandlerConfigurer
     ) throws IOException {
-        return new StompClientChannelImpl(handShakeEventListener, option, clientHandlerConfigurer);
+        return new StompClientTcpChannel(handShakeEventListener, option, clientHandlerConfigurer);
     }
 
     static StompClientChannel wrap(
@@ -67,7 +68,22 @@ public interface StompClientChannel extends StompChannel {
             StompClientOption option,
             Handler<StompClientHandler> clientHandlerConfigurer
     ) {
-        return new StompClientChannelImpl(netChannel, option, clientHandlerConfigurer);
+        return new StompClientTcpChannel(netChannel, option, clientHandlerConfigurer);
+    }
+
+    static StompClientChannel wrap(
+            WebSocketChannel webSocketChannel,
+            StompClientOption option
+    ) {
+        return wrap(webSocketChannel, option, handler -> { });
+    }
+
+    static StompClientChannel wrap(
+            WebSocketChannel webSocketChannel,
+            StompClientOption option,
+            Handler<StompClientHandler> clientHandlerConfigurer
+    ) {
+        return new StompClientWebSocketChannel(webSocketChannel, option, clientHandlerConfigurer);
     }
 
     @Override
@@ -154,10 +170,13 @@ public interface StompClientChannel extends StompChannel {
 
     void failConnect(Throwable error);
 
+    @CanIgnoreReturnValue
     StompClientChannel closeHandler(Handler<StompClientChannel> handler);
 
+    @CanIgnoreReturnValue
     StompClientChannel connectionDroppedHandler(Handler<StompClientChannel> handler);
 
+    @CanIgnoreReturnValue
     StompClientChannel exceptionHandler(Handler<Throwable> handler);
 
     Promise<Void> connectedPromise();

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
@@ -55,7 +55,7 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
  * @author yun
  */
 @Slf4j
-public class StompClientChannelImpl implements StompClientChannel {
+public class StompClientTcpChannel implements StompClientChannel {
 
     private final String sessionId = IdGenerator.randomId16("session");
     private final NetChannel netChannel;
@@ -77,14 +77,14 @@ public class StompClientChannelImpl implements StompClientChannel {
     private long pingTimer = -1;
     private long pongTimer = -1;
 
-    StompClientChannelImpl(
+    StompClientTcpChannel(
             ChannelHandShakeEventListener channelHandShakeEventListener,
             StompClientOption option
     ) throws IOException {
         this(NetChannel.open(channelHandShakeEventListener), option, handler -> {});
     }
 
-    StompClientChannelImpl(
+    StompClientTcpChannel(
             ChannelHandShakeEventListener channelHandShakeEventListener,
             StompClientOption option,
             Handler<StompClientHandler> clientHandlerConfigurer
@@ -92,11 +92,11 @@ public class StompClientChannelImpl implements StompClientChannel {
         this(NetChannel.open(channelHandShakeEventListener), option, clientHandlerConfigurer);
     }
 
-    StompClientChannelImpl(NetChannel netChannel, StompClientOption option) {
+    StompClientTcpChannel(NetChannel netChannel, StompClientOption option) {
         this(netChannel, option, handler -> {});
     }
 
-    StompClientChannelImpl(
+    StompClientTcpChannel(
             NetChannel netChannel,
             StompClientOption option,
             Handler<StompClientHandler> clientHandlerConfigurer
@@ -520,7 +520,7 @@ public class StompClientChannelImpl implements StompClientChannel {
         if (this == other) {
             return true;
         }
-        if (!(other instanceof StompClientChannelImpl that)) {
+        if (!(other instanceof StompClientTcpChannel that)) {
             return false;
         }
         return this.netChannel.id().equals(that.netChannel.id());

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientWebSocketChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientWebSocketChannel.java
@@ -1,0 +1,62 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.stomp;
+
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.core.util.Handler;
+
+/**
+ * STOMP client channel backed by an upgraded WebSocket connection.
+ *
+ * <p>The STOMP session, subscriptions, receipts, and heartbeat lifecycle are
+ * identical to the TCP implementation. The wrapped {@link WebSocketChannel}
+ * supplies the transport codec installed during the HTTP upgrade.</p>
+ *
+ * @author yun
+ */
+public final class StompClientWebSocketChannel extends StompClientTcpChannel {
+
+    public StompClientWebSocketChannel(
+            WebSocketChannel channel,
+            StompClientOption option
+    ) {
+        this(channel, option, handler -> { });
+    }
+
+    public StompClientWebSocketChannel(
+            WebSocketChannel channel,
+            StompClientOption option,
+            Handler<StompClientHandler> clientHandlerConfigurer
+    ) {
+        super(channel, option, clientHandlerConfigurer);
+    }
+
+    @Override
+    public WebSocketChannel channel() {
+        NetChannel channel = super.channel();
+        return (WebSocketChannel) channel;
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerChannel.java
@@ -43,11 +43,11 @@ public interface StompServerChannel extends StompChannel {
             ChannelHandShakeEventListener channelHandShakeEventListener,
             StompServerOption option
     ) {
-        return new StompServerChannelImpl(channelHandShakeEventListener, option);
+        return new StompServerTcpChannel(channelHandShakeEventListener, option);
     }
 
     static StompServerChannel wrap(NetServerChannel serverChannel, StompServerOption option) {
-        return new StompServerChannelImpl(serverChannel, option);
+        return new StompServerTcpChannel(serverChannel, option);
     }
 
     default Promise<Void> write(StompFrame frame) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
@@ -43,7 +43,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * @author yungwang-o
  */
-public class StompServerChannelImpl implements StompServerChannel {
+public class StompServerTcpChannel implements StompServerChannel {
 
     private final NetServerChannel serverChannel;
     private final StompServerOption option;
@@ -60,7 +60,7 @@ public class StompServerChannelImpl implements StompServerChannel {
         CLOSED
     }
 
-    StompServerChannelImpl(
+    StompServerTcpChannel(
             ChannelHandShakeEventListener channelHandShakeEventListener,
             StompServerOption option
     ) {
@@ -73,7 +73,7 @@ public class StompServerChannelImpl implements StompServerChannel {
         }
     }
 
-    StompServerChannelImpl(NetServerChannel serverChannel, StompServerOption option) {
+    StompServerTcpChannel(NetServerChannel serverChannel, StompServerOption option) {
         this.serverChannel = serverChannel;
         this.option = option;
         state.set(State.RUNNING);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
@@ -44,10 +44,20 @@ import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
  * {@link StompServerOption} and {@link InetServerOption}, then installs any externally supplied
  * channel handlers on accepted STOMP child channels.</p>
  */
-public final class StompServerEngineProvider implements NetworkServerEngineProvider {
+public class StompServerEngineProvider implements NetworkServerEngineProvider {
+
+    private final boolean webSocket;
 
     private final List<ChannelInBoundHandler> inboundHandlers = new ArrayList<>();
     private final List<ChannelOutBoundHandler> outboundHandlers = new ArrayList<>();
+
+    public StompServerEngineProvider() {
+        this(false);
+    }
+
+    protected StompServerEngineProvider(boolean webSocket) {
+        this.webSocket = webSocket;
+    }
 
     @Override
     @CanIgnoreReturnValue
@@ -69,8 +79,12 @@ public final class StompServerEngineProvider implements NetworkServerEngineProvi
         InetServerOption inetOption = buildInetOption(settings.resolvedTransportOptions());
         StompServerOption stompServerOption = buildOption(settings.resolvedProtocolOptions(), inetOption);
 
-        StompServer server = StompServer.open(groups, stompServerOption)
-                .onChannel(channel -> {
+        String path = settings.resolvedTransportOptions().getOrDefault("path", "/stomp");
+        StompServer server = StompServer.open(groups, stompServerOption);
+        if (webSocket) {
+            server.upgradeWebsocket(path);
+        }
+        server.onChannel(channel -> {
                     inboundHandlers.forEach(inboundHandler ->
                             channel.chain().add(inboundHandler)
                     );
@@ -84,7 +98,7 @@ public final class StompServerEngineProvider implements NetworkServerEngineProvi
 
     @Override
     public String transport() {
-        return "tcp";
+        return webSocket ? "websocket" : "tcp";
     }
 
     @Override

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompWebSocketServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompWebSocketServerEngineProvider.java
@@ -1,0 +1,36 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi;
+
+/**
+ * Service provider for STOMP over WebSocket servers.
+ *
+ * @author yun
+ */
+public final class StompWebSocketServerEngineProvider extends StompServerEngineProvider {
+
+    public StompWebSocketServerEngineProvider() {
+        super(true);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * @author yun
  */
 @Slf4j
-public final class VertxStompServerEngineProvider implements NetworkServerEngineProvider {
+public class VertxStompServerEngineProvider implements NetworkServerEngineProvider {
 
     @Override
     public String transport() {
@@ -89,7 +89,7 @@ public final class VertxStompServerEngineProvider implements NetworkServerEngine
         return new VertxStompManagedServer(stompServer, settings);
     }
 
-    private static StompServerOptions buildOption(Map<String, String> protocolOptions, Map<String, String> transportOptions) {
+    protected static StompServerOptions buildOption(Map<String, String> protocolOptions, Map<String, String> transportOptions) {
         StompServerOptions options = new StompServerOptions();
 
         int maxHeaderLength = intOption(protocolOptions, "max-header-length", options.getMaxHeaderLength());

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProvider.java
@@ -1,0 +1,61 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi.vertx;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.ext.stomp.StompServer;
+import io.vertx.ext.stomp.StompServerHandler;
+import io.vertx.ext.stomp.StompServerOptions;
+import org.traffichunter.titan.bootstrap.ServerSettings;
+import org.traffichunter.titan.core.spi.ManagedServer;
+
+/**
+ * @author yun
+ */
+public final class VertxStompWebSocketServerEngineProvider extends VertxStompServerEngineProvider {
+
+    @Override
+    public String transport() {
+        return "vertx-websocket";
+    }
+
+    @Override
+    public ManagedServer create(ServerSettings settings) {
+        Vertx vertx = Vertx.vertx(new VertxOptions()
+                .setEventLoopPoolSize(settings.primaryThreads())
+                .setWorkerPoolSize(settings.secondaryThreads()));
+        StompServerOptions stompServerOptions = buildOption(
+                settings.resolvedProtocolOptions(),
+                settings.resolvedTransportOptions()
+        ).setPort(settings.port())
+                .setHost(settings.host())
+                .setWebsocketBridge(true);
+
+        StompServer stompServer = StompServer.create(vertx, stompServerOptions)
+                .handler(StompServerHandler.create(vertx));
+
+        return new VertxStompManagedServer(stompServer, settings);
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompEndpoint.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompEndpoint.java
@@ -1,0 +1,167 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Address of a STOMP service and the transport used to reach it.
+ *
+ * <p>TCP endpoints carry only a host and port. WebSocket endpoints additionally
+ * carry the HTTP upgrade path. Authentication and STOMP virtual-host values do
+ * not belong to the endpoint and remain client options.</p>
+ *
+ * @author yun
+ */
+public record StompEndpoint(
+        Scheme scheme,
+        String host,
+        int port,
+        String path
+) {
+
+    public static final int DEFAULT_STOMP_PORT = 61613;
+    public static final int DEFAULT_WEBSOCKET_PORT = 8080;
+    public static final int DEFAULT_SECURE_WEBSOCKET_PORT = 443;
+
+    public StompEndpoint {
+        if (host.isBlank()) {
+            throw new IllegalArgumentException("Endpoint host cannot be blank");
+        }
+        if (port <= 0 || port > 65535) {
+            throw new IllegalArgumentException("Endpoint port must be in range 1..65535");
+        }
+
+        if (scheme.isWebSocket()) {
+            if (path.isBlank()) {
+                path = "/";
+            } else if (!path.startsWith("/")) {
+                throw new IllegalArgumentException("WebSocket endpoint path must start with '/'");
+            }
+        } else if (!path.isEmpty()) {
+            throw new IllegalArgumentException("TCP endpoint cannot have a path");
+        }
+    }
+
+    public static StompEndpoint parse(String endpoint) {
+        URI uri;
+        try {
+            uri = new URI(endpoint);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid STOMP endpoint: " + endpoint, e);
+        }
+
+        Scheme scheme = Scheme.from(uri.getScheme());
+        if (uri.getRawUserInfo() != null || uri.getRawQuery() != null || uri.getRawFragment() != null) {
+            throw new IllegalArgumentException("STOMP endpoint cannot contain user info, query, or fragment");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("STOMP endpoint must contain a host");
+        }
+
+        int port = uri.getPort() == -1 ? scheme.defaultPort() : uri.getPort();
+        String path = uri.getRawPath();
+        return new StompEndpoint(scheme, host, port, path == null ? "" : path);
+    }
+
+    public static StompEndpoint tcp(String host, int port) {
+        return new StompEndpoint(Scheme.TCP, host, port, "");
+    }
+
+    public static StompEndpoint webSocket(String host, int port, String path) {
+        return new StompEndpoint(Scheme.WS, host, port, path);
+    }
+
+    public InetSocketAddress socketAddress() {
+        return new InetSocketAddress(host, port);
+    }
+
+    public boolean isWebSocket() {
+        return scheme.isWebSocket();
+    }
+
+    public boolean isSecure() {
+        return scheme == Scheme.WSS;
+    }
+
+    public URI uri() {
+        try {
+            return new URI(scheme.value(), null, host, port, path, null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Failed to create STOMP endpoint URI", e);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return uri().toString();
+    }
+
+    public enum Scheme {
+        TCP("tcp", DEFAULT_STOMP_PORT),
+        WS("ws", DEFAULT_WEBSOCKET_PORT),
+        WSS("wss", DEFAULT_SECURE_WEBSOCKET_PORT),
+        ;
+
+        private final String value;
+        private final int defaultPort;
+
+        Scheme(String value, int defaultPort) {
+            this.value = value;
+            this.defaultPort = defaultPort;
+        }
+
+        public static Scheme from(@Nullable String value) {
+            if (value == null || value.isBlank()) {
+                throw new IllegalArgumentException("STOMP endpoint scheme is required");
+            }
+
+            String normalized = value.toLowerCase(Locale.ROOT);
+            for (Scheme scheme : values()) {
+                if (scheme.value.equals(normalized)) {
+                    return scheme;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported STOMP endpoint scheme: " + value);
+        }
+
+        public String value() {
+            return value;
+        }
+
+        public int defaultPort() {
+            return defaultPort;
+        }
+
+        public boolean isWebSocket() {
+            return this == WS || this == WSS;
+        }
+    }
+}

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -33,6 +33,7 @@ import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.*;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
 import org.traffichunter.titan.core.codec.stomp.StompChannelDecoder;
 import org.traffichunter.titan.core.codec.stomp.StompException;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
@@ -43,6 +44,7 @@ import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.Protocol;
 
 /**
  * @author yun
@@ -53,13 +55,18 @@ public final class StompServer {
     private final InetServer inetServer;
     private final StompServerChannel serverConnection;
     private final StompServerOption option;
+    private @Nullable String webSocketPath;
 
     private StompClientOption childOption = StompClientOption.DEFAULT_STOMP_CLIENT_OPTION;
     private Handler<StompServerHandler> stompServerHandler = handler -> {};
     private Handler<Channel> channelHandler = channel -> {};
     private @Nullable ScheduledPromise<?> inactiveConnectionCleanupTask;
 
-    private StompServer(EventLoopGroups groups, @Nullable InetServer inetServer, StompServerOption option) {
+    private StompServer(
+            EventLoopGroups groups,
+            @Nullable InetServer inetServer,
+            StompServerOption option
+    ) {
         this.option = option;
         if(inetServer == null) {
             inetServer = InetServer.open(groups);
@@ -74,6 +81,18 @@ public final class StompServer {
 
     public static StompServer open(EventLoopGroups groups, @Nullable InetServer inetServer, StompServerOption option) {
         return new StompServer(groups, inetServer, option);
+    }
+
+    @CanIgnoreReturnValue
+    public StompServer upgradeWebsocket(String path) {
+        if (inetServer.isStarted()) {
+            throw new IllegalStateException("Cannot change STOMP server transport after start");
+        }
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
+        this.webSocketPath = path;
+        return this;
     }
 
     @CanIgnoreReturnValue
@@ -111,15 +130,25 @@ public final class StompServer {
                         throw new IllegalArgumentException("Unsupported channel: " + channel);
                     }
 
-                    StompClientChannel stompConnection =
-                            StompClientChannel.wrap(netChannel, stompClientOption);
+                    StompClientChannel stompConnection;
+                    if (webSocketPath != null) {
+                        WebSocketChannel webSocketChannel = new WebSocketChannel(netChannel, Protocol.STOMP);
+                        stompConnection = StompClientChannel.wrap(webSocketChannel, stompClientOption);
+                    } else {
+                        stompConnection = StompClientChannel.wrap(netChannel, stompClientOption);
+                    }
                     serverConnection.register(stompConnection);
 
                     netChannel.chain()
                             .add(new StompChannelDecoder(option.maxBodyLength(), stompConnection, stompServerHandler));
 
-                    channelHandler.handle(netChannel);
+                    channelHandler.handle(stompConnection.channel());
                 });
+
+        String path = webSocketPath;
+        if (path != null) {
+            inetServer.upgradeWebsocket(path);
+        }
 
         inetServer.start();
         inactiveConnectionCleanupTask = serverConnection.channel().eventLoop().scheduleAtFixedRate(

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
@@ -38,6 +38,7 @@ import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
 import org.traffichunter.titan.core.channel.stomp.StompClientHandler;
 import org.traffichunter.titan.core.channel.stomp.StompNetChannelException;
@@ -48,11 +49,13 @@ import org.traffichunter.titan.core.resilience.retry.RetryExecutor;
 import org.traffichunter.titan.core.resilience.retry.RetryExecutors;
 import org.traffichunter.titan.core.resilience.retry.RetryResult;
 import org.traffichunter.titan.core.transport.InetClient;
+import org.traffichunter.titan.core.transport.websocket.WebSocketClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompConnection;
 import org.traffichunter.titan.core.transport.stomp.client.TitanStompConnection;
 import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
 import org.traffichunter.titan.core.util.Handler;
+import org.traffichunter.titan.core.util.Protocol;
 
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.HeartBeat;
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
@@ -69,6 +72,7 @@ public final class TitanStompClient implements StompClient {
     private final AtomicReference<Status> status;
 
     private Handler<StompClientHandler> stompClientHandler = handler -> {};
+    private @Nullable String webSocketPath;
     private volatile @Nullable StompClientChannel connection;
     private volatile @Nullable TitanStompConnection stompConnection;
     private final AtomicReference<@Nullable RetryResult> reconnectResult = new AtomicReference<>();
@@ -124,6 +128,18 @@ public final class TitanStompClient implements StompClient {
         return this;
     }
 
+    @CanIgnoreReturnValue
+    public TitanStompClient upgradeWebsocket(String path) {
+        if (status.get() != Status.INITIALIZED) {
+            throw new IllegalStateException("Cannot change STOMP client transport after start");
+        }
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
+        this.webSocketPath = path;
+        return this;
+    }
+
     public void start() {
         if (!status.compareAndSet(Status.INITIALIZED, Status.STARTING)) {
             throw new StompException("Client already started");
@@ -176,7 +192,7 @@ public final class TitanStompClient implements StompClient {
             return Promise.failedPromise(connection.channel().eventLoop(), new StompException("STOMP client is already connected"));
         }
 
-        return inetClient.connect(remoteAddress, timeOut, timeUnit)
+        return connectTransport(remoteAddress, timeOut, timeUnit)
                 .map(this::createConnection)
                 .thenCompose(conn -> {
                     StompFrame connectFrame = generateConnectFrame(remoteAddress.getHostString());
@@ -236,11 +252,27 @@ public final class TitanStompClient implements StompClient {
     }
 
     private StompClientChannel createConnection(NetChannel channel) {
-        StompClientChannel connection = StompClientChannel.wrap(channel, option);
+        StompClientChannel connection = channel instanceof WebSocketChannel webSocketChannel
+                ? StompClientChannel.wrap(webSocketChannel, option)
+                : StompClientChannel.wrap(channel, option);
         stompClientHandler.handle(connection.handler());
         channel.chain().add(new StompChannelDecoder(option.maxFrameLength(), connection, connection.handler()));
         this.connection = connection;
         return connection;
+    }
+
+    private Promise<? extends NetChannel> connectTransport(
+            InetSocketAddress remoteAddress,
+            long timeOut,
+            TimeUnit timeUnit
+    ) {
+        String path = webSocketPath;
+        if (path == null) {
+            return inetClient.connect(remoteAddress, timeOut, timeUnit);
+        }
+
+        WebSocketClient webSocketClient = inetClient.upgradeWebsocket(Protocol.STOMP, path);
+        return webSocketClient.connect(remoteAddress, timeOut, timeUnit);
     }
 
     private Promise<StompConnection> connectStompConnection() {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxStompClient.java
@@ -24,10 +24,20 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.transport.stomp;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.http.WebSocketClient;
+import io.vertx.core.http.WebSocketClientOptions;
+import io.vertx.core.http.WebSocketConnectOptions;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.stomp.Command;
+import io.vertx.ext.stomp.Frame;
 import io.vertx.ext.stomp.StompClient;
 import io.vertx.ext.stomp.StompClientOptions;
 import io.vertx.ext.stomp.StompClientConnection;
+import io.vertx.ext.stomp.impl.FrameParser;
+import io.vertx.ext.stomp.impl.StompClientConnectionImpl;
+import io.vertx.ext.stomp.utils.Headers;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.codec.stomp.StompException;
 import org.traffichunter.titan.core.resilience.retry.RetryExecutor;
@@ -63,6 +73,9 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
 
     private @Nullable Vertx vertx;
     private @Nullable StompClient client;
+    private @Nullable WebSocketClient webSocketClient;
+    private volatile @Nullable WebSocket webSocket;
+    private @Nullable String webSocketPath;
     private volatile @Nullable StompClientConnection connection;
     private volatile @Nullable VertxStompConnection stompConnection;
     private volatile boolean isShutdown;
@@ -98,6 +111,17 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
         return new VertxStompClient(client.vertx(), client, option, false);
     }
 
+    public VertxStompClient upgradeWebsocket(String path) {
+        if (status.get() != Status.INITIALIZED) {
+            throw new IllegalStateException("Cannot change STOMP client transport after start");
+        }
+        if (path.isBlank() || !path.startsWith("/")) {
+            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        }
+        this.webSocketPath = path;
+        return this;
+    }
+
     @Override
     public void start() {
         if (isShutdown) {
@@ -113,7 +137,11 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
                 vertx = Vertx.vertx();
                 this.vertx = vertx;
             }
-            client = StompClient.create(vertx, toVertxOptions(option));
+            if (webSocketPath == null) {
+                client = StompClient.create(vertx, toVertxOptions(option));
+            } else {
+                webSocketClient = vertx.createWebSocketClient(toWebSocketOptions(option));
+            }
             status.set(Status.STARTED);
         } catch (RuntimeException e) {
             status.set(Status.INITIALIZED);
@@ -144,13 +172,19 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
             );
         }
 
-        StompClient nativeClient = this.client;
-        if (nativeClient == null || nativeClient.isClosed()) {
-            return io.vertx.core.Future.failedFuture(new StompException("Client is not started"));
+        io.vertx.core.Future<StompClientConnection> connectionFuture;
+        String path = webSocketPath;
+        if (path == null) {
+            StompClient nativeClient = this.client;
+            if (nativeClient == null || nativeClient.isClosed()) {
+                return io.vertx.core.Future.failedFuture(new StompException("Client is not started"));
+            }
+            connectionFuture = nativeClient.connect(option.port(), option.host());
+        } else {
+            connectionFuture = connectWebSocket(path);
         }
 
-        return nativeClient
-                .connect(option.port(), option.host())
+        return connectionFuture
                 .map(conn -> {
                     VertxStompConnection stompConnection = createStompConnection(conn);
                     if (!status.compareAndSet(Status.CONNECTING, Status.CONNECTED)) {
@@ -179,7 +213,9 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
 
     @Override
     public boolean isStarted() {
-        return client != null && !client.isClosed();
+        StompClient client = this.client;
+        WebSocketClient webSocketClient = this.webSocketClient;
+        return client != null && !client.isClosed() || webSocketClient != null && !isShutdown;
     }
 
     @Override
@@ -200,6 +236,10 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
             reconnectExecutor.shutdown(timeout, unit);
             if (client != null && !client.isClosed()) {
                 client.close().await(timeout, unit);
+            }
+            WebSocketClient webSocketClient = this.webSocketClient;
+            if (webSocketClient != null) {
+                webSocketClient.shutdown(timeout, unit).await(timeout, unit);
             }
             Vertx vertx = this.vertx;
             if (managedVertx && vertx != null) {
@@ -242,6 +282,66 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
         );
     }
 
+    private io.vertx.core.Future<StompClientConnection> connectWebSocket(String path) {
+        Vertx vertx = this.vertx;
+        WebSocketClient client = this.webSocketClient;
+        if (vertx == null || client == null) {
+            return io.vertx.core.Future.failedFuture(new StompException("Client is not started"));
+        }
+
+        WebSocketConnectOptions connectOptions = new WebSocketConnectOptions()
+                .setHost(option.host())
+                .setPort(option.port())
+                .setURI(path)
+                .setConnectTimeout(option.connectTimeout().toMillis())
+                .addSubProtocol("v12.stomp");
+
+        return client.connect(connectOptions).compose(socket -> {
+            this.webSocket = socket;
+            VertxWebSocketNetSocket netSocket = new VertxWebSocketNetSocket(socket);
+            StompClientOptions stompOptions = toVertxOptions(option);
+            StompClientConnectionImpl connection = new StompClientConnectionImpl(
+                    (ContextInternal) vertx.getOrCreateContext(),
+                    netSocket,
+                    stompOptions
+            );
+
+            netSocket.write(connectFrame(stompOptions).toBuffer(stompOptions.isTrailingLine()));
+            long timer = vertx.setTimer(option.connectTimeout().toMillis(), ignored -> {
+                if (!connection.isConnected()) {
+                    connection.close();
+                }
+            });
+            return connection.connectFuture()
+                    .map(ignored -> (StompClientConnection) connection)
+                    .eventually(() -> {
+                        vertx.cancelTimer(timer);
+                        return io.vertx.core.Future.succeededFuture();
+                    });
+        });
+    }
+
+    private static Frame connectFrame(StompClientOptions options) {
+        Headers headers = Headers.create();
+        if (options.getAcceptedVersions() != null && !options.getAcceptedVersions().isEmpty()) {
+            headers.put(Frame.ACCEPT_VERSION, String.join(FrameParser.COMMA, options.getAcceptedVersions()));
+        }
+        if (!options.isBypassHostHeader()) {
+            headers.put(Frame.HOST, options.getHost());
+        }
+        if (options.getVirtualHost() != null) {
+            headers.put(Frame.HOST, options.getVirtualHost());
+        }
+        if (options.getLogin() != null) {
+            headers.put(Frame.LOGIN, options.getLogin());
+        }
+        if (options.getPasscode() != null) {
+            headers.put(Frame.PASSCODE, options.getPasscode());
+        }
+        headers.put(Frame.HEARTBEAT, Frame.Heartbeat.create(options.getHeartbeat()).toString());
+        return new Frame(options.isUseStompFrame() ? Command.STOMP : Command.CONNECT, headers, null);
+    }
+
     private void connectionLost() {
         if (!status.compareAndSet(Status.CONNECTED, Status.CONNECTING)) {
             return;
@@ -255,7 +355,7 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
             try {
                 connectStompConnection().toCompletionStage().toCompletableFuture().get();
             } catch (ExecutionException e) {
-                @Nullable Throwable cause = e.getCause();
+                Throwable cause = e.getCause();
                 if (cause instanceof Exception retryable) {
                     throw retryable;
                 }
@@ -326,7 +426,27 @@ public final class VertxStompClient implements org.traffichunter.titan.core.tran
         return vertxOptions;
     }
 
+    private static WebSocketClientOptions toWebSocketOptions(StompClientOption option) {
+        WebSocketClientOptions options = new WebSocketClientOptions()
+                .setDefaultHost(option.host())
+                .setDefaultPort(option.port())
+                .setConnectTimeout(Math.toIntExact(option.connectTimeout().toMillis()))
+                .setMaxMessageSize(option.maxFrameLength());
+        applyInetOptions(options, option.inetClientOption());
+        return options;
+    }
+
     private static void applyInetOptions(StompClientOptions vertxOptions, InetClientOption option) {
+        Map<SocketOption<?>, Object> socketOptions = option.socketOptions();
+        applyBoolean(socketOptions, StandardSocketOptions.TCP_NODELAY, vertxOptions::setTcpNoDelay);
+        applyBoolean(socketOptions, StandardSocketOptions.SO_KEEPALIVE, vertxOptions::setTcpKeepAlive);
+        applyBoolean(socketOptions, StandardSocketOptions.SO_REUSEADDR, vertxOptions::setReuseAddress);
+        applyInteger(socketOptions, StandardSocketOptions.SO_SNDBUF, vertxOptions::setSendBufferSize);
+        applyInteger(socketOptions, StandardSocketOptions.SO_RCVBUF, vertxOptions::setReceiveBufferSize);
+        applyInteger(socketOptions, StandardSocketOptions.SO_LINGER, vertxOptions::setSoLinger);
+    }
+
+    private static void applyInetOptions(WebSocketClientOptions vertxOptions, InetClientOption option) {
         Map<SocketOption<?>, Object> socketOptions = option.socketOptions();
         applyBoolean(socketOptions, StandardSocketOptions.TCP_NODELAY, vertxOptions::setTcpNoDelay);
         applyBoolean(socketOptions, StandardSocketOptions.SO_KEEPALIVE, vertxOptions::setTcpKeepAlive);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxWebSocketNetSocket.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/VertxWebSocketNetSocket.java
@@ -1,0 +1,203 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.WebSocket;
+import io.vertx.core.net.SSLOptions;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.SocketAddress;
+import org.jspecify.annotations.Nullable;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.security.cert.Certificate;
+import java.util.List;
+
+/**
+ * Adapts a Vert.x WebSocket data stream to the NetSocket contract consumed by
+ * the Vert.x STOMP connection implementation.
+ *
+ * @author yun
+ */
+final class VertxWebSocketNetSocket implements NetSocket {
+
+    private final WebSocket webSocket;
+
+    VertxWebSocketNetSocket(WebSocket webSocket) {
+        this.webSocket = webSocket;
+    }
+
+    @Override
+    public NetSocket exceptionHandler(Handler<Throwable> handler) {
+        webSocket.exceptionHandler(handler);
+        return this;
+    }
+
+    @Override
+    public NetSocket handler(Handler<Buffer> handler) {
+        webSocket.handler(handler);
+        return this;
+    }
+
+    @Override
+    public NetSocket pause() {
+        webSocket.pause();
+        return this;
+    }
+
+    @Override
+    public NetSocket resume() {
+        webSocket.resume();
+        return this;
+    }
+
+    @Override
+    public NetSocket fetch(long amount) {
+        webSocket.fetch(amount);
+        return this;
+    }
+
+    @Override
+    public NetSocket endHandler(Handler<Void> handler) {
+        webSocket.endHandler(handler);
+        return this;
+    }
+
+    @Override
+    public NetSocket setWriteQueueMaxSize(int maxSize) {
+        webSocket.setWriteQueueMaxSize(maxSize);
+        return this;
+    }
+
+    @Override
+    public boolean writeQueueFull() {
+        return webSocket.writeQueueFull();
+    }
+
+    @Override
+    public NetSocket drainHandler(Handler<Void> handler) {
+        webSocket.drainHandler(handler);
+        return this;
+    }
+
+    @Override
+    public Future<Void> write(Buffer data) {
+        return webSocket.writeBinaryMessage(data);
+    }
+
+    @Override
+    public String writeHandlerID() {
+        return webSocket.binaryHandlerID();
+    }
+
+    @Override
+    public Future<Void> write(String data) {
+        return write(Buffer.buffer(data));
+    }
+
+    @Override
+    public Future<Void> write(String data, String encoding) {
+        return write(Buffer.buffer(data, encoding));
+    }
+
+    @Override
+    public Future<Void> sendFile(String filename, long offset, long length) {
+        return Future.failedFuture(new UnsupportedOperationException("WebSocket transport does not support sendFile"));
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        return webSocket.remoteAddress();
+    }
+
+    @Override
+    public SocketAddress remoteAddress(boolean real) {
+        return webSocket.remoteAddress();
+    }
+
+    @Override
+    public SocketAddress localAddress() {
+        return webSocket.localAddress();
+    }
+
+    @Override
+    public SocketAddress localAddress(boolean real) {
+        return webSocket.localAddress();
+    }
+
+    @Override
+    public Future<Void> end() {
+        return webSocket.end();
+    }
+
+    @Override
+    public Future<Void> close() {
+        return webSocket.close();
+    }
+
+    @Override
+    public NetSocket closeHandler(Handler<Void> handler) {
+        webSocket.closeHandler(handler);
+        return this;
+    }
+
+    @Override
+    public NetSocket shutdownHandler(Handler<Void> handler) {
+        webSocket.shutdownHandler(handler);
+        return this;
+    }
+
+    @Override
+    public Future<Void> upgradeToSsl(SSLOptions options, String serverName, Buffer handshake) {
+        return Future.failedFuture(new UnsupportedOperationException("WebSocket SSL is configured during connect"));
+    }
+
+    @Override
+    public boolean isSsl() {
+        return webSocket.isSsl();
+    }
+
+    @Override
+    public SSLSession sslSession() {
+        return webSocket.sslSession();
+    }
+
+    @Override
+    public List<Certificate> peerCertificates() throws SSLPeerUnverifiedException {
+        return webSocket.peerCertificates();
+    }
+
+    @Override
+    public @Nullable String indicatedServerName() {
+        return null;
+    }
+
+    @Override
+    public String applicationLayerProtocol() {
+        return webSocket.subProtocol();
+    }
+}

--- a/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
+++ b/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
@@ -1,3 +1,4 @@
 org.traffichunter.titan.core.spi.StompServerEngineProvider
 org.traffichunter.titan.core.spi.StompWebSocketServerEngineProvider
 org.traffichunter.titan.core.spi.vertx.VertxStompServerEngineProvider
+org.traffichunter.titan.core.spi.vertx.VertxStompWebSocketServerEngineProvider

--- a/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
+++ b/titan-stomp/src/main/resources/META-INF/services/org.traffichunter.titan.core.spi.NetworkServerEngineProvider
@@ -1,2 +1,3 @@
 org.traffichunter.titan.core.spi.StompServerEngineProvider
+org.traffichunter.titan.core.spi.StompWebSocketServerEngineProvider
 org.traffichunter.titan.core.spi.vertx.VertxStompServerEngineProvider

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompClientWebSocketChannelTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompClientWebSocketChannelTest.java
@@ -1,0 +1,57 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.stomp;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.IOEventLoop;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.core.util.Protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author yun
+ */
+class StompClientWebSocketChannelTest {
+
+    @Test
+    void wrap_websocket_channel_as_stomp_client_channel() {
+        NetChannel delegate = mock(NetChannel.class);
+        when(delegate.eventLoop()).thenReturn(mock(IOEventLoop.class));
+        WebSocketChannel webSocketChannel = new WebSocketChannel(delegate, Protocol.STOMP);
+
+        StompClientChannel channel = StompClientChannel.wrap(
+                webSocketChannel,
+                StompClientOption.builder().build()
+        );
+
+        assertThat(channel).isInstanceOf(StompClientWebSocketChannel.class);
+        assertThat(channel.channel()).isSameAs(webSocketChannel);
+        assertThat(channel.version()).isEqualTo("1.2");
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/spi/StompWebSocketServerEngineProviderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/spi/StompWebSocketServerEngineProviderTest.java
@@ -1,0 +1,50 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+class StompWebSocketServerEngineProviderTest {
+
+    @Test
+    void expose_websocket_stomp_provider() {
+        StompWebSocketServerEngineProvider provider = new StompWebSocketServerEngineProvider();
+
+        assertThat(provider.transport()).isEqualTo("websocket");
+        assertThat(provider.protocol()).isEqualTo("stomp");
+    }
+
+    @Test
+    void discover_websocket_provider_with_service_loader() {
+        assertThat(ServiceLoader.load(NetworkServerEngineProvider.class))
+                .anyMatch(provider -> provider instanceof StompWebSocketServerEngineProvider);
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProviderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProviderTest.java
@@ -1,0 +1,51 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.spi.vertx;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.spi.NetworkServerEngineProvider;
+
+import java.util.ServiceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+class VertxStompWebSocketServerEngineProviderTest {
+
+    @Test
+    void expose_vertx_websocket_stomp_provider() {
+        VertxStompWebSocketServerEngineProvider provider = new VertxStompWebSocketServerEngineProvider();
+
+        assertThat(provider.transport()).isEqualTo("vertx-websocket");
+        assertThat(provider.protocol()).isEqualTo("stomp");
+    }
+
+    @Test
+    void discover_vertx_websocket_provider_with_service_loader() {
+        assertThat(ServiceLoader.load(NetworkServerEngineProvider.class))
+                .anyMatch(provider -> provider instanceof VertxStompWebSocketServerEngineProvider);
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompEndpointTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompEndpointTest.java
@@ -1,0 +1,81 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author yun
+ */
+class StompEndpointTest {
+
+    @Test
+    void parse_tcp_endpoint() {
+        StompEndpoint endpoint = StompEndpoint.parse("tcp://localhost:61613");
+
+        assertThat(endpoint.scheme()).isEqualTo(StompEndpoint.Scheme.TCP);
+        assertThat(endpoint.host()).isEqualTo("localhost");
+        assertThat(endpoint.port()).isEqualTo(61613);
+        assertThat(endpoint.path()).isEmpty();
+        assertThat(endpoint.isWebSocket()).isFalse();
+    }
+
+    @Test
+    void parse_websocket_endpoint() {
+        StompEndpoint endpoint = StompEndpoint.parse("ws://localhost:8080/stomp");
+
+        assertThat(endpoint.scheme()).isEqualTo(StompEndpoint.Scheme.WS);
+        assertThat(endpoint.port()).isEqualTo(8080);
+        assertThat(endpoint.path()).isEqualTo("/stomp");
+        assertThat(endpoint.isWebSocket()).isTrue();
+        assertThat(endpoint.toString()).isEqualTo("ws://localhost:8080/stomp");
+    }
+
+    @Test
+    void apply_default_ports_and_websocket_path() {
+        assertThat(StompEndpoint.parse("tcp://localhost").port()).isEqualTo(61613);
+
+        StompEndpoint secure = StompEndpoint.parse("wss://example.com");
+        assertThat(secure.port()).isEqualTo(443);
+        assertThat(secure.path()).isEqualTo("/");
+        assertThat(secure.isSecure()).isTrue();
+    }
+
+    @Test
+    void reject_tcp_endpoint_path() {
+        assertThatThrownBy(() -> StompEndpoint.parse("tcp://localhost:61613/stomp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot have a path");
+    }
+
+    @Test
+    void reject_unsupported_scheme() {
+        assertThatThrownBy(() -> StompEndpoint.parse("http://localhost:8080/stomp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported");
+    }
+}

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompWebSocketIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompWebSocketIntegrationTest.java
@@ -79,6 +79,40 @@ class StompWebSocketIntegrationTest {
 
     @Test
     @Timeout(10)
+    void connect_vertx_stomp_client_over_websocket() throws Exception {
+        StompServer server = StompServer.open(
+                EventLoopGroups.group(1, 1),
+                StompServerOption.builder().build()
+        ).upgradeWebsocket("/stomp");
+        try {
+            server.start();
+            server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+            int port = ((InetSocketAddress) server.connection().channel().localAddress()).getPort();
+            VertxStompClient client = VertxStompClient.open(
+                    StompClientOption.builder().host("localhost").port(port).build()
+            ).upgradeWebsocket("/stomp");
+
+            try {
+                client.start();
+                client.connect().get(5, TimeUnit.SECONDS);
+
+                assertThat(client.connection().isConnected()).isTrue();
+                assertThat(client.channel().isConnected()).isTrue();
+                assertThat(server.connection().connections()).hasSize(1);
+            } finally {
+                if (!client.isShutdown()) {
+                    client.shutdown(5, TimeUnit.SECONDS);
+                }
+            }
+        } finally {
+            if (!server.isShutdown()) {
+                server.shutdown();
+            }
+        }
+    }
+
+    @Test
+    @Timeout(10)
     void reject_client_using_different_websocket_path() throws Exception {
         StompServer server = StompServer.open(
                 EventLoopGroups.group(1, 1),

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompWebSocketIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompWebSocketIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.channel.stomp.StompClientWebSocketChannel;
+import org.traffichunter.titan.core.transport.stomp.option.StompClientOption;
+import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
+import org.traffichunter.titan.core.transport.websocket.WebSocketHandshakeException;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author yun
+ */
+class StompWebSocketIntegrationTest {
+
+    @Test
+    @Timeout(10)
+    void connect_stomp_client_over_websocket() throws Exception {
+        StompServer server = StompServer.open(
+                EventLoopGroups.group(1, 1),
+                StompServerOption.builder().build()
+        ).upgradeWebsocket("/stomp");
+        TitanStompClient client = TitanStompClient.open(
+                EventLoopGroups.group(1, 1),
+                StompClientOption.builder().build()
+        ).upgradeWebsocket("/stomp");
+
+        try {
+            server.start();
+            server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+            int port = ((InetSocketAddress) server.connection().channel().localAddress()).getPort();
+
+            client.start();
+            client.connect("localhost", port).get(5, TimeUnit.SECONDS);
+
+            assertThat(client.channel()).isInstanceOf(StompClientWebSocketChannel.class);
+            assertThat(client.channel().isConnected()).isTrue();
+            assertThat(server.connection().connections())
+                    .singleElement()
+                    .isInstanceOf(StompClientWebSocketChannel.class);
+        } finally {
+            if (!client.isShutdown()) {
+                client.shutdown();
+            }
+            if (!server.isShutdown()) {
+                server.shutdown();
+            }
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void reject_client_using_different_websocket_path() throws Exception {
+        StompServer server = StompServer.open(
+                EventLoopGroups.group(1, 1),
+                StompServerOption.builder().build()
+        ).upgradeWebsocket("/stomp");
+        TitanStompClient client = TitanStompClient.open(
+                EventLoopGroups.group(1, 1),
+                StompClientOption.builder().build()
+        ).upgradeWebsocket("/wrong");
+
+        try {
+            server.start();
+            server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+            int port = ((InetSocketAddress) server.connection().channel().localAddress()).getPort();
+            client.start();
+
+            assertThatThrownBy(() -> client.connect("localhost", port).get(5, TimeUnit.SECONDS))
+                    .hasRootCauseInstanceOf(WebSocketHandshakeException.class);
+            assertThat(server.connection().connections()).isEmpty();
+        } finally {
+            if (!client.isShutdown()) {
+                client.shutdown();
+            }
+            if (!server.isShutdown()) {
+                server.shutdown();
+            }
+        }
+    }
+
+    @Test
+    void reject_server_transport_change_after_start() {
+        StompServer server = StompServer.open(
+                EventLoopGroups.group(1, 1),
+                StompServerOption.builder().build()
+        );
+
+        try {
+            server.start();
+
+            assertThatThrownBy(() -> server.upgradeWebsocket("/stomp"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("after start");
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    @Test
+    void reject_client_transport_change_after_start() {
+        TitanStompClient client = TitanStompClient.open(
+                EventLoopGroups.group(1, 1),
+                StompClientOption.builder().build()
+        );
+
+        try {
+            client.start();
+
+            assertThatThrownBy(() -> client.upgradeWebsocket("/stomp"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("after start");
+        } finally {
+            client.shutdown();
+        }
+    }
+
+    @Test
+    void reject_invalid_websocket_paths() {
+        StompServer server = StompServer.open(
+                EventLoopGroups.group(1, 1),
+                StompServerOption.builder().build()
+        );
+        TitanStompClient client = TitanStompClient.open(
+                EventLoopGroups.group(1, 1),
+                StompClientOption.builder().build()
+        );
+
+        assertThatThrownBy(() -> server.upgradeWebsocket("stomp"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("start with '/'");
+        assertThatThrownBy(() -> client.upgradeWebsocket(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("start with '/'");
+    }
+}


### PR DESCRIPTION
## Motivation:

Titan STOMP connections only supported direct TCP transport, which prevented browser-compatible and HTTP-upgrade deployments. Spring users also had to configure host and port separately without a transport-aware endpoint.

## Modification:

- Add WebSocket channel lifecycle, frame handling, handshake path configuration, and transport integration tests.
- Support STOMP over WebSocket for both Titan and Vert.x clients using the `v12.stomp` subprotocol.
- Add native and Vert.x WebSocket server providers with ServiceLoader discovery.
- Add transport-aware `StompEndpoint` parsing for `tcp://` and `ws://` addresses.
- Add Spring Boot endpoint configuration and retain legacy host, port, transport, and path properties for compatibility.
- Reuse the Vert.x STOMP connection implementation through an internal WebSocket-to-NetSocket adapter.

## Result:

Titan and Vert.x STOMP clients can connect over WebSocket directly or through Spring configuration such as `spring.titan.endpoint=ws://localhost:8080/stomp`.

Validation:
- `./gradlew test --rerun-tasks --no-configuration-cache`
- `./gradlew :titan-stomp:test --tests '*VertxStompWebSocketServerEngineProviderTest' --no-configuration-cache`
