### PR TITLE
Add Titan GitBook documentation

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./docs/
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,53 @@
+# Messages in motion
+
+Titan is a lightweight message dispatch platform for real-time applications,
+built around **STOMP over TCP**, destination routing, and observable in-memory
+delivery.
+
+```text
+CONNECT  ──  SEND  ──  ROUTE  ──  DELIVER
+                         │
+                         └──  OBSERVE
+```
+
+Use Titan when notifications, live interactions, telemetry, or chat-style
+traffic needs a small networked runtime without the operational weight of a
+durable message broker.
+
+## Start here
+
+| I want to… | Go to |
+| --- | --- |
+| See a message move through Titan | [Quickstart](quickstart.md) |
+| Understand where Titan fits | [Why Titan?](why-titan.md) |
+| Run a standalone server | [Run a server](examples/server.md) |
+| Connect a Java application | [Use the STOMP client](examples/client.md) |
+| Connect a Spring Boot application | [Integrate Spring Boot](examples/spring-client.md) |
+| Inspect a running node | [Monitoring and CLI](operate/monitoring.md) |
+
+## One runtime, three views
+
+### Build
+
+Start a server from `titan-env.yml`, embed the STOMP server API, or connect with
+the native Java and Spring Boot clients.
+
+### Route
+
+Address messages with familiar destinations such as `/queue/orders` and
+`/topic/notifications`. Optional fanout delivers a publication to matching
+subscribers.
+
+### Observe
+
+Inspect health, JVM state, connections, and dispatcher queues through the local
+monitoring API or the terminal-first Titan CLI.
+
+> Titan focuses on fast, real-time, in-memory dispatch. It is not currently a
+> durable queue or broker replacement. See [Project scope](reference/project-scope.md)
+> before choosing it for reliability-sensitive workloads.
+
+## Current release
+
+The examples in this documentation use Titan `0.7.3` and require JDK 21 or
+newer. Artifacts are published under `org.traffichunter.titan` on Maven Central.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,30 @@
+# Summary
+
+## Start
+
+* [Welcome](README.md)
+* [Why Titan?](why-titan.md)
+* [Quickstart](quickstart.md)
+
+## Learn
+
+* [How Titan works](concepts/how-titan-works.md)
+* [Destinations](concepts/destinations.md)
+* [Fanout](concepts/fanout.md)
+
+## Build
+
+* [Run a server](examples/server.md)
+* [Use the STOMP client](examples/client.md)
+* [Integrate Spring Boot](examples/spring-client.md)
+
+## Operate
+
+* [Monitoring and CLI](operate/monitoring.md)
+
+## Reference
+
+* [Configuration](reference/configuration.md)
+* [Modules](reference/modules.md)
+* [Project scope](reference/project-scope.md)
+* [Contributing](guide/CONTRIBUTING.md)

--- a/docs/concepts/destinations.md
+++ b/docs/concepts/destinations.md
@@ -1,0 +1,52 @@
+# Destinations
+
+A destination is the address shared by a producer and its consumers. Titan uses
+STOMP-style paths so routing intent is visible at every call site.
+
+## Queue-style paths
+
+Use `/queue/...` when the destination represents work or a named dispatch lane.
+
+```text
+Producer ── SEND /queue/orders ──▶ Titan ──▶ Consumer
+```
+
+Examples:
+
+* `/queue/orders`
+* `/queue/image-resize`
+* `/queue/tenant-42/events`
+
+## Topic-style paths
+
+Use `/topic/...` when a publication represents a live event that subscribers
+observe.
+
+```text
+                              ┌──▶ Subscriber A
+Producer ── /topic/news ──▶ Titan
+                              └──▶ Subscriber B
+```
+
+Examples:
+
+* `/topic/notifications`
+* `/topic/room/42`
+* `/topic/device/temperature`
+
+Topic-style naming communicates intent, while actual one-to-many delivery is
+provided by Titan's [fanout](fanout.md) module.
+
+## Naming destinations
+
+Prefer stable nouns and place variable identifiers after the domain:
+
+```text
+/queue/orders
+/topic/orders/created
+/topic/rooms/{roomId}/messages
+```
+
+Avoid placing deployment details, hostnames, or consumer implementation names
+in a destination. Those details change more frequently than the message's
+meaning.

--- a/docs/concepts/fanout.md
+++ b/docs/concepts/fanout.md
@@ -1,0 +1,35 @@
+# Fanout
+
+Fanout takes one publication and dispatches it to every matching subscriber.
+It is useful for notifications, live rooms, and telemetry streams where each
+active observer should receive the event.
+
+```text
+                           ┌──▶ subscription 1
+SEND /topic/updates ──▶ gateway ──▶ subscription 2
+                           └──▶ subscription 3
+```
+
+## Enable fanout
+
+Set `fanout-mode` in the server's protocol options:
+
+```yaml
+titan:
+  servers:
+    - name: stomp-dispatch
+      protocol: stomp
+      protocol-options:
+        fanout-mode: "virtual"
+```
+
+The `titan-fanout` module supplies the gateway and exporter that connect STOMP
+`SEND` frames to matching subscriptions. The `virtual` mode uses virtual-thread
+based dispatch workers.
+
+## Operational boundary
+
+Fanout is live delivery, not durable retention. A subscriber that is offline
+does not gain replay merely because the destination is a topic. If consumers
+must recover historical events after reconnecting, provide persistence outside
+Titan or choose a durable messaging system.

--- a/docs/concepts/how-titan-works.md
+++ b/docs/concepts/how-titan-works.md
@@ -1,0 +1,44 @@
+# How Titan works
+
+Titan turns a network frame into a routed message through a short, explicit
+pipeline.
+
+```text
+Client
+  │  STOMP frame
+  ▼
+Transport → Channel pipeline → Destination routing → Subscriber
+     │                                      │
+     └── Event loops                        └── Optional fanout
+```
+
+## Runtime startup
+
+1. `TitanBootstrap` reads `titan-env.yml`.
+2. `TitanApplication` discovers protocol and transport engines with
+   `ServiceLoader`.
+3. Each configured server binds its network transport.
+4. Optional launchers attach fanout and monitoring behavior.
+
+This separation lets the bootstrap layer assemble a runtime without coupling
+the core event loop and channel primitives to a single protocol.
+
+## Message path
+
+After a client connects, Titan decodes STOMP frames in a channel pipeline. A
+`SEND` frame carries a destination. Routing selects the matching subscription
+or dispatch path, and the resulting `MESSAGE` frame is written to the target
+connection.
+
+Heartbeats belong to the connection lifecycle rather than the application
+payload. The server and client negotiate them during STOMP connection setup.
+
+## Runtime views
+
+Titan exposes the same system from three useful angles:
+
+* **Protocol:** STOMP commands, headers, subscriptions, and acknowledgements
+* **Runtime:** event loops, channels, dispatchers, and promises
+* **Operations:** JVM, connection, server, and queue snapshots
+
+Next, learn how [destinations](destinations.md) define routing intent.

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -1,0 +1,61 @@
+# Monitoring and CLI
+
+Titan exposes a local HTTP monitor and a terminal-first CLI for inspecting a
+running node.
+
+## Enable the monitor
+
+```yaml
+titan:
+  monitor:
+    enabled: true
+    host: 127.0.0.1
+    port: 7777
+    # token: change-me
+```
+
+Keep the monitor bound to a private or loopback interface unless you have added
+appropriate network controls and authentication.
+
+## HTTP endpoints
+
+```bash
+curl http://localhost:7777/titan/monitor/health
+curl http://localhost:7777/titan/monitor/snapshot
+curl http://localhost:7777/titan/monitor/queues
+```
+
+Use the health endpoint for a lightweight availability check. Use snapshots for
+the broader runtime view and the queues endpoint when investigating dispatcher
+capacity or pressure.
+
+## Terminal dashboard
+
+Prebuilt releases include `titan-cli-<version>-<os>-<arch>.tar.gz` archives.
+
+```bash
+tar -xzf titan-cli-0.7.3-linux-amd64.tar.gz
+./titan --addr http://localhost:7777
+```
+
+Select a view or produce automation-friendly output:
+
+```bash
+./titan --addr http://localhost:7777 --view queues
+./titan --addr http://localhost:7777 --view jvm --interval 1s --timeout 3s
+./titan --addr http://localhost:7777 --no-color --once
+```
+
+## Manage queues
+
+When the monitor is protected, provide its token through the environment:
+
+```bash
+export TITAN_MONITOR_TOKEN=<monitor-token>
+./titan --addr http://localhost:7777 queue list
+./titan --addr http://localhost:7777 queue create /queue/orders --capacity 100
+./titan --addr http://localhost:7777 queue delete /queue/orders
+```
+
+Deleting a queue affects live runtime state. Inspect it first and reserve
+`--force` for cases where dropping active state is intentional.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart
+
+Run a Titan server and verify it from the monitoring API.
+
+## Requirements
+
+* JDK 21 or newer
+* A Titan `0.7.3` standalone server JAR from GitHub Releases
+
+## 1. Create the environment
+
+Create `titan-env.yml` next to the server JAR:
+
+```yaml
+titan:
+  monitor:
+    enabled: true
+    host: 127.0.0.1
+    port: 7777
+  servers:
+    - name: stomp-dispatch
+      protocol: stomp
+      host: 0.0.0.0
+      port: 61613
+      transport-options:
+        reuse-address: "true"
+        child-tcp-no-delay: "true"
+      protocol-options:
+        supported-versions: "1.2"
+        max-body-length: "1048576"
+        heartbeat-x: "1000"
+        heartbeat-y: "1000"
+        fanout-mode: "virtual"
+```
+
+## 2. Start Titan
+
+```bash
+java -Dtitan.environment.path=./titan-env.yml \
+  -jar titan-server-0.7.3.jar
+```
+
+Titan now accepts STOMP connections on `61613` and exposes its local monitor on
+`127.0.0.1:7777`.
+
+## 3. Verify the node
+
+```bash
+curl http://localhost:7777/titan/monitor/health
+curl http://localhost:7777/titan/monitor/snapshot
+```
+
+## 4. Send your first message
+
+Choose the client path that matches your application:
+
+* [Native STOMP client](examples/client.md) for direct lifecycle control
+* [Spring Boot](examples/spring-client.md) for `TitanTemplate` and
+  `@TitanListener`
+
+Use `/topic/notifications` in both the subscriber and publisher examples to see
+a message travel through the same destination.
+
+## Next steps
+
+* Learn [how Titan works](concepts/how-titan-works.md).
+* Decide between [queue and topic destinations](concepts/destinations.md).
+* Add terminal visibility with [Monitoring and CLI](operate/monitoring.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,54 @@
+# Configuration
+
+Titan reads its standalone runtime configuration from `titan-env.yml`. Pass the
+path with the `titan.environment.path` system property.
+
+```bash
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
+```
+
+## Server
+
+| Key | Purpose | Example |
+| --- | --- | --- |
+| `name` | Runtime server name | `stomp-dispatch` |
+| `protocol` | Protocol engine | `stomp` |
+| `host` | Bind address | `0.0.0.0` |
+| `port` | Bind port | `61613` |
+| `transport-options` | TCP and channel settings | See below |
+| `protocol-options` | STOMP and fanout settings | See below |
+
+## Common transport options
+
+| Key | Purpose |
+| --- | --- |
+| `reuse-address` | Allow address reuse on the server socket |
+| `child-tcp-no-delay` | Disable Nagle's algorithm on accepted connections |
+
+Configuration option values are represented as strings in the current YAML
+format.
+
+## Common protocol options
+
+| Key | Purpose | Example |
+| --- | --- | --- |
+| `supported-versions` | Accepted STOMP versions | `"1.2"` |
+| `max-body-length` | Maximum frame body size in bytes | `"1048576"` |
+| `heartbeat-x` | Outgoing heartbeat interval in milliseconds | `"1000"` |
+| `heartbeat-y` | Expected incoming heartbeat interval in milliseconds | `"1000"` |
+| `fanout-mode` | Optional fanout implementation | `"virtual"` |
+
+Heartbeat values must be zero or greater. A zero value disables that heartbeat
+direction.
+
+## Monitor
+
+| Key | Purpose | Example |
+| --- | --- | --- |
+| `enabled` | Start the monitoring service | `true` |
+| `host` | Monitor bind address | `127.0.0.1` |
+| `port` | Monitor HTTP port | `7777` |
+| `token` | Optional access token | `change-me` |
+
+See [Monitoring and CLI](../operate/monitoring.md) for endpoint and client
+examples.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,0 +1,29 @@
+# Modules
+
+Titan is published as focused Maven artifacts so applications can depend on the
+runtime layers they actually use.
+
+| Artifact | Responsibility |
+| --- | --- |
+| `titan-bootstrap` | Environment loading and runtime startup |
+| `titan-core` | Event loops, channels, transport, dispatch, and concurrency primitives |
+| `titan-stomp` | STOMP codec, server, client, and engine integration |
+| `titan-fanout` | One-to-many dispatch gateways and exporters |
+| `titan-monitor` | JVM and dispatcher monitoring snapshots and HTTP endpoints |
+| `titan-spring-client` | Spring Boot auto-configuration, `TitanTemplate`, and `@TitanListener` |
+
+## Maven coordinates
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.traffichunter.titan:titan-stomp:0.7.3")
+}
+```
+
+Replace the artifact name with the module required by your application. A
+standalone distribution typically combines bootstrap, core, STOMP, and the
+optional fanout and monitoring modules.

--- a/docs/reference/project-scope.md
+++ b/docs/reference/project-scope.md
@@ -1,0 +1,36 @@
+# Project scope
+
+Titan's production focus is real-time STOMP dispatch over TCP.
+
+## In scope
+
+* STOMP server and client connections
+* TCP and WebSocket client transport
+* Queue- and topic-style destination routing
+* In-memory fanout delivery
+* Native Java and Spring Boot clients
+* Local JVM, connection, server, and dispatcher visibility
+* Embeddable runtime and SPI-based engine discovery
+
+## Not a current promise
+
+Titan does not currently promise:
+
+* Durable message storage across node restarts
+* Historical replay or long-term retention
+* A drop-in replacement for a mature message broker
+* Fully evolved retry, nack, and listener error policies in every client path
+* Multi-node consensus or replicated queue state
+
+These boundaries are intentional documentation, not hidden caveats. Evaluate
+delivery and recovery requirements before placing Titan on a critical message
+path.
+
+## Compatibility baseline
+
+* JDK 21 or newer
+* STOMP 1.2 as the primary configured protocol version
+* Go 1.22 or newer when building `titan-cli` from source
+
+For project development and test commands, see the repository's root README and
+[Contributing](../guide/CONTRIBUTING.md).

--- a/docs/why-titan.md
+++ b/docs/why-titan.md
@@ -1,0 +1,43 @@
+# Why Titan?
+
+Titan is designed for the space between an in-process event bus and a full
+durable broker: messages must cross the network, routing must remain explicit,
+and the runtime should stay small enough to understand and operate directly.
+
+## A good fit
+
+Titan is a good fit when your system needs:
+
+* Real-time delivery over STOMP and TCP
+* Queue- and topic-style destination paths
+* Publish-subscribe fanout
+* Java or Spring Boot integration
+* Local operational visibility from HTTP or a terminal
+* An embeddable runtime with pluggable protocol and transport engines
+
+Common examples include notifications, chat-style messaging, telemetry fanout,
+live interaction backends, and development environments that need a compact
+STOMP endpoint.
+
+## A deliberate boundary
+
+Titan keeps messages in memory and prioritizes live dispatch. It does not
+currently position itself as a durable queue or a general-purpose broker.
+
+Choose a durable messaging system when the primary requirement is persisted
+delivery across restarts, long-term retention, replay, or mature broker-level
+delivery guarantees. Choose Titan when the primary requirement is lightweight,
+observable real-time dispatch.
+
+## Design principles
+
+1. **Destinations are the API.** Producers and consumers meet at explicit
+   `/queue/...` and `/topic/...` paths.
+2. **The hot path stays small.** NIO event loops, channels, and pipelines move
+   frames without hiding the transport lifecycle.
+3. **Optional features remain optional.** Fanout and monitoring attach as
+   runtime modules instead of defining the core.
+4. **Operations are part of the product.** Health and queue state are available
+   through both HTTP and the Titan CLI.
+
+Continue with the [Quickstart](quickstart.md) to run your first node.


### PR DESCRIPTION
## Motivation:

Titan needs a documentation foundation that can be synchronized with GitBook and guides readers from product orientation to development and operations.

## Modification:

- Configure GitBook Git Sync to use the repository's `docs/` directory.
- Add a structured navigation covering Start, Learn, Build, Operate, and Reference.
- Add initial pages for quickstart, architecture, destinations, fanout, monitoring, configuration, modules, and project scope.
- Reuse the existing server, STOMP client, Spring Boot, and contributing guides in the GitBook navigation.

## Result:

The repository can now serve as the source for a Titan GitBook space with a complete initial documentation journey.

Validation:

- Parsed `.gitbook.yaml` successfully.
- Verified every local Markdown link across 15 documentation files.
- Ran `git diff --check`.
