### PR TITLE
Rename the GitBook home page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Start
 
-* [Welcome](README.md)
+* [Titan](README.md)
 * [Why Titan?](why-titan.md)
 * [Quickstart](quickstart.md)
 


### PR DESCRIPTION
## Motivation:

The published GitBook browser tab currently uses `Welcome` as the homepage title alongside the Titan site name.

## Modification:

Rename the GitBook homepage navigation title from `Welcome` to `Titan`.

## Result:

The homepage and browser tab use the Titan product name instead of the generic Welcome label.

Validation:

- Confirmed the diff changes only the homepage entry in `docs/SUMMARY.md`.
- Ran `git diff --check`.
