### PR TITLE
Correct GitBook branding and destination routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Spring Boot client integration.
 ## Highlights
 
 - STOMP over TCP server and client.
-- Destination-based routing with `/queue/...` and `/topic/...` style paths.
+- Exact destination matching with one FIFO dispatcher queue per destination.
 - Fanout delivery for publish-subscribe scenarios.
 - Pluggable runtime through SPI.
 - Local HTTP monitoring API with a terminal-first CLI.
@@ -131,9 +131,9 @@ go run . --addr http://localhost:7777 --no-color --once
 # queue management
 export TITAN_MONITOR_TOKEN=<monitor-token>
 go run . --addr http://localhost:7777 queue list
-go run . --addr http://localhost:7777 queue create /queue/orders --capacity 100
-go run . --addr http://localhost:7777 queue delete /queue/orders
-go run . --addr http://localhost:7777 queue delete /queue/orders --force
+go run . --addr http://localhost:7777 queue create /orders --capacity 100
+go run . --addr http://localhost:7777 queue delete /orders
+go run . --addr http://localhost:7777 queue delete /orders --force
 ```
 
 The monitor HTTP API is served under `/titan`.

--- a/docs/.gitbook/assets/titan-favicon.svg
+++ b/docs/.gitbook/assets/titan-favicon.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Titan</title>
+  <desc id="desc">A message route branching through a Titan dispatch junction.</desc>
+
+  <!-- Full-bleed background prevents light corners in browser tabs. -->
+  <rect width="256" height="256" fill="#FF6B35"/>
+
+  <path
+    d="M116 48V100M116 156V208"
+    fill="none"
+    stroke="#11151B"
+    stroke-width="16"
+    stroke-linecap="round"
+  />
+
+  <path
+    d="M36 128H218
+       M122 128
+       C139 128 145 111 154 94
+       L174 61
+       C179 53 187 51 197 51
+       H218
+       M122 128
+       C139 128 145 145 154 162
+       L174 195
+       C179 203 187 205 197 205
+       H218"
+    fill="none"
+    stroke="#F6F7F4"
+    stroke-width="16"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,8 +59,9 @@ Java and Spring Boot clients.
 
 ### Route
 
-Address live traffic with `/queue/...` and `/topic/...` destinations. Attach
-fanout when every active subscriber should receive the event.
+Address live traffic with opaque destination paths. Titan maps every exact
+destination to one FIFO dispatcher queue; path prefixes do not change delivery
+semantics.
 {% endcolumn %}
 
 {% column width="40%" %}
@@ -78,9 +79,9 @@ terminal-first Titan CLI.
 ```mermaid
 flowchart LR
     P[Producer] -->|SEND| T{Titan}
-    T -->|/queue/orders| C1[Worker]
-    T -->|/topic/notifications| C2[Subscriber A]
-    T -->|/topic/notifications| C3[Subscriber B]
+    T -->|/orders| Q[DispatcherQueue /orders]
+    Q --> C1[Subscriber A]
+    Q --> C2[Subscriber B]
     T -.->|snapshot| M[Monitor & CLI]
 ```
 
@@ -96,7 +97,7 @@ before using Titan for reliability-sensitive workloads.
 <tr>
   <td><h3><i class="fa-route" style="color:$primary;">:route:</i></h3></td>
   <td><strong>Destinations</strong></td>
-  <td>Model routing intent with queue- and topic-style paths.</td>
+  <td>Map exact destination keys to FIFO dispatcher queues.</td>
   <td><a href="concepts/destinations.md">destinations</a></td>
 </tr>
 <tr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,8 +96,8 @@ before using Titan for reliability-sensitive workloads.
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody>
 <tr>
   <td><h3><i class="fa-route" style="color:$primary;">:route:</i></h3></td>
-  <td><strong>Destinations</strong></td>
-  <td>Map exact destination keys to FIFO dispatcher queues.</td>
+  <td><strong>Dispatch routing</strong></td>
+  <td>Trace exact destination keys through FIFO dispatcher queues.</td>
   <td><a href="concepts/destinations.md">destinations</a></td>
 </tr>
 <tr>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,7 +9,7 @@
 ## Learn
 
 * [How Titan works](concepts/how-titan-works.md)
-* [Destinations](concepts/destinations.md)
+* [Dispatch routing](concepts/destinations.md)
 * [Fanout](concepts/fanout.md)
 
 ## Build

--- a/docs/concepts/destinations.md
+++ b/docs/concepts/destinations.md
@@ -1,52 +1,81 @@
-# Destinations
+# Destinations and dispatcher queues
 
-A destination is the address shared by a producer and its consumers. Titan uses
-STOMP-style paths so routing intent is visible at every call site.
+A destination is an opaque path key that connects an inbound message to one
+Titan dispatcher queue. Titan does not interpret `/queue` and `/topic` prefixes
+as separate messaging models.
 
-## Queue-style paths
+{% hint style="info" icon="route" %}
+`/orders`, `/events/orders`, and `/topic/orders` are all ordinary destination
+keys to Titan. Their names communicate application intent only; they do not
+change routing behavior.
+{% endhint %}
 
-Use `/queue/...` when the destination represents work or a named dispatch lane.
+## The routing invariant
 
-```text
-Producer ── SEND /queue/orders ──▶ Titan ──▶ Consumer
+Every published message is placed into the queue for its exact destination.
+If that queue does not exist yet, the dispatcher creates it.
+
+```mermaid
+flowchart LR
+    S[STOMP SEND] --> D[Destination /orders/created]
+    D --> R{Dispatcher exact lookup}
+    R --> Q[One FIFO DispatcherQueue]
+    Q --> C[Destination consumer]
+    C --> E[Protocol exporter]
+    E --> M[Exact-match subscriptions]
 ```
 
-Examples:
+The default dispatcher stores destination queues in a trie, but publishing is
+an exact lookup. A message for `/orders/created` is not routed to `/orders` and
+does not inherit behavior from any path prefix.
 
-* `/queue/orders`
-* `/queue/image-resize`
-* `/queue/tenant-42/events`
+## Queue lifecycle
 
-## Topic-style paths
+The first publish or consumer startup for a destination calls `getOrPut` and
+creates its queue when necessary. Repeated calls for the same destination reuse
+the existing queue and preserve its configured capacity.
 
-Use `/topic/...` when a publication represents a live event that subscribers
-observe.
+Each queue:
+
+* belongs to exactly one destination;
+* preserves insertion order with FIFO delivery;
+* can be paused and resumed;
+* exposes its size and capacity to monitoring;
+* can be created or deleted through the monitoring API and Titan CLI.
+
+This is an internal dispatch queue. It is not a STOMP `/queue` destination with
+competing-consumer semantics, and the destination name does not turn it into
+one.
+
+## Subscription matching
+
+STOMP subscriptions are registered with a destination. During export, Titan
+selects subscriptions whose `Destination` value is exactly equal to the queue's
+destination. The subscription registry does not perform prefix or topic-pattern
+matching.
 
 ```text
-                              ┌──▶ Subscriber A
-Producer ── /topic/news ──▶ Titan
-                              └──▶ Subscriber B
+SEND      /events/orders
+SUBSCRIBE /events/orders     → match
+SUBSCRIBE /events            → no match
+SUBSCRIBE /events/payments   → no match
 ```
 
-Examples:
-
-* `/topic/notifications`
-* `/topic/room/42`
-* `/topic/device/temperature`
-
-Topic-style naming communicates intent, while actual one-to-many delivery is
-provided by Titan's [fanout](fanout.md) module.
+When fanout is enabled, the per-destination consumer drains one message from the
+dispatcher queue and the exporter writes that message to every exact-match
+subscription. Learn more in [Fanout](fanout.md).
 
 ## Naming destinations
 
-Prefer stable nouns and place variable identifiers after the domain:
+Choose names for domain meaning, not broker semantics:
 
 ```text
-/queue/orders
-/topic/orders/created
-/topic/rooms/{roomId}/messages
+/orders
+/orders/created
+/rooms/42/messages
+/devices/temperature
 ```
 
-Avoid placing deployment details, hostnames, or consumer implementation names
-in a destination. Those details change more frequently than the message's
-meaning.
+Use stable nouns and events. Avoid `/queue` or `/topic` unless those words are
+genuinely part of your application's domain language; Titan assigns them no
+special behavior.

--- a/docs/concepts/destinations.md
+++ b/docs/concepts/destinations.md
@@ -1,81 +1,170 @@
-# Destinations and dispatcher queues
+# Dispatch routing
 
-A destination is an opaque path key that connects an inbound message to one
-Titan dispatcher queue. Titan does not interpret `/queue` and `/topic` prefixes
-as separate messaging models.
-
-{% hint style="info" icon="route" %}
-`/orders`, `/events/orders`, and `/topic/orders` are all ordinary destination
-keys to Titan. Their names communicate application intent only; they do not
-change routing behavior.
-{% endhint %}
-
-## The routing invariant
-
-Every published message is placed into the queue for its exact destination.
-If that queue does not exist yet, the dispatcher creates it.
-
-```mermaid
-flowchart LR
-    S[STOMP SEND] --> D[Destination /orders/created]
-    D --> R{Dispatcher exact lookup}
-    R --> Q[One FIFO DispatcherQueue]
-    Q --> C[Destination consumer]
-    C --> E[Protocol exporter]
-    E --> M[Exact-match subscriptions]
-```
-
-The default dispatcher stores destination queues in a trie, but publishing is
-an exact lookup. A message for `/orders/created` is not routed to `/orders` and
-does not inherit behavior from any path prefix.
-
-## Queue lifecycle
-
-The first publish or consumer startup for a destination calls `getOrPut` and
-creates its queue when necessary. Repeated calls for the same destination reuse
-the existing queue and preserve its configured capacity.
-
-Each queue:
-
-* belongs to exactly one destination;
-* preserves insertion order with FIFO delivery;
-* can be paused and resumed;
-* exposes its size and capacity to monitoring;
-* can be created or deleted through the monitoring API and Titan CLI.
-
-This is an internal dispatch queue. It is not a STOMP `/queue` destination with
-competing-consumer semantics, and the destination name does not turn it into
-one.
-
-## Subscription matching
-
-STOMP subscriptions are registered with a destination. During export, Titan
-selects subscriptions whose `Destination` value is exactly equal to the queue's
-destination. The subscription registry does not perform prefix or topic-pattern
-matching.
-
-```text
-SEND      /events/orders
-SUBSCRIBE /events/orders     → match
-SUBSCRIBE /events            → no match
-SUBSCRIBE /events/payments   → no match
-```
-
-When fanout is enabled, the per-destination consumer drains one message from the
-dispatcher queue and the exporter writes that message to every exact-match
-subscription. Learn more in [Fanout](fanout.md).
-
-## Naming destinations
-
-Choose names for domain meaning, not broker semantics:
+Titan's fanout runtime routes messages by **exact destination identity**. A
+destination is a validated path stored in `Destination`; it is not classified
+as a queue or topic from its prefix.
 
 ```text
 /orders
 /orders/created
-/rooms/42/messages
-/devices/temperature
+/events/notifications
 ```
 
-Use stable nouns and events. Avoid `/queue` or `/topic` unless those words are
-genuinely part of your application's domain language; Titan assigns them no
-special behavior.
+All three are ordinary routing keys. `/queue/orders` and `/topic/orders` are
+also valid strings, but `queue` and `topic` have no reserved meaning inside the
+dispatcher.
+
+## The publish path
+
+With `fanout-mode` enabled, Titan replaces the STOMP server's default `SEND`
+handler with `StompSendToFanoutHandler`. One inbound frame then follows this
+path:
+
+```mermaid
+sequenceDiagram
+    participant P as STOMP producer
+    participant H as StompSendToFanoutHandler
+    participant G as DispatchGateway
+    participant D as Dispatcher
+    participant Q as DispatcherQueue
+    participant C as Destination consumer
+    participant E as StompDispatchExporter
+
+    P->>H: SEND destination=/orders
+    H->>G: publish(Message{/orders})
+    G->>D: getOrPut(/orders)
+    D-->>G: exact queue for /orders
+    G->>Q: enqueue(message)
+    G->>C: ensure one consumer for /orders
+    C->>Q: dispatch with timeout
+    Q-->>C: next FIFO message
+    C->>E: export(/orders, payload)
+    E->>E: find subscriptions equal to /orders
+```
+
+The implementation divides this into two handler-chain stages:
+
+1. `RouteDispatchChainHandler` invokes `DispatchGateway.route(message)`.
+2. `FanoutDispatchChainHandler` ensures that the destination consumer is
+   running.
+
+Custom handlers are inserted between those stages. This allows backup,
+validation, or metrics work after routing and before consumer startup without
+putting protocol logic inside the queue.
+
+## How a queue is selected
+
+`DispatchGateway.route` does not search for the nearest path, a topic pattern,
+or every matching prefix. It performs this operation:
+
+```java
+Destination destination = message.getDestination();
+DispatcherQueue queue = dispatcher.getOrPut(destination);
+queue.enqueue(message);
+```
+
+Consequently:
+
+| Published destination | Selected dispatcher queue |
+| --- | --- |
+| `/orders` | `/orders` |
+| `/orders/created` | `/orders/created` |
+| `/orders/cancelled` | `/orders/cancelled` |
+
+Even though these keys share a trie prefix, they are three independent queues.
+Publishing to `/orders/created` never falls back to the `/orders` queue.
+
+{% hint style="warning" icon="asterisk" %}
+`Dispatcher.searchAll("/orders/*")` is a queue discovery operation that returns
+descendant queues. The publish path never calls `searchAll`; wildcard lookup is
+not message routing. Do not use a wildcard destination in `SEND` expecting
+broadcast behavior.
+{% endhint %}
+
+## Queue creation and capacity
+
+`getOrPut` atomically returns the existing queue or creates one for the exact
+destination. A queue created by normal publishing uses
+`DispatcherQueue.DEFAULT_CAPACITY`, currently `11` messages.
+
+You can create the queue before traffic arrives and choose its capacity:
+
+```bash
+titan --addr http://localhost:7777 queue create /orders --capacity 100
+```
+
+Queue creation is idempotent. If `/orders` already exists, a later create call
+returns that queue and does not replace its original capacity.
+
+The queue is a bounded FIFO `LinkedBlockingQueue` and is the handoff point
+between producers and the destination consumer:
+
+* enqueue preserves insertion order;
+* pause blocks new enqueue attempts until resume;
+* size and capacity are exposed through monitoring and JMX;
+* non-empty deletion is rejected unless force deletion is requested;
+* force deletion clears pending messages and stops the current consumer;
+* publishing after deletion creates a new queue instance.
+
+`enqueue` can refuse a message when a bounded queue is full. Titan's current
+fanout path does not provide durable retry or persistence for that refusal, so
+capacity and queue pressure must be monitored.
+
+## One consumer per destination
+
+`DispatchGateway` keeps a concurrent map of destination to consumer task.
+`computeIfAbsent` guarantees at most one active queue-draining task for each
+destination inside that gateway.
+
+The consumer polls its queue and invokes the configured `DispatchExporter` one
+message at a time. This preserves FIFO processing within one destination while
+allowing different destination consumers to progress independently on the
+gateway executor.
+
+The `publish()` future represents completion of the dispatch handler chain and
+consumer-start request. It does **not** mean that every remote subscriber has
+received or acknowledged the message.
+
+## How subscriptions match
+
+After a message leaves the queue, `StompDispatchExporter` asks the server's
+subscription registry for subscriptions whose `Destination` is exactly equal
+to the message destination.
+
+```text
+Message destination       Subscription destination       Result
+/orders                    /orders                        match
+/orders/created            /orders                        no match
+/orders                    /orders/*                      no match
+```
+
+For every exact match, the exporter creates a separate STOMP `MESSAGE` frame
+and copies the subscription id into its headers. This is the fanout step: one
+message drained from one dispatcher queue can be written to multiple matching
+subscriptions.
+
+If there are no exact-match subscriptions, the exporter has no recipients. The
+message has already been removed from the in-memory queue; Titan does not retain
+it for a future subscriber.
+
+## Fanout mode versus the default STOMP handler
+
+The dispatcher-queue path described above is installed when `fanout-mode` is
+configured. Without that adapter, Titan's default STOMP `SEND` handler looks up
+exact-match subscriptions and writes to them directly; it does not pass the
+frame through `DispatchGateway` or a `DispatcherQueue`.
+
+For the standalone configuration documented here, enable fanout explicitly:
+
+```yaml
+titan:
+  servers:
+    - name: stomp-dispatch
+      protocol: stomp
+      protocol-options:
+        fanout-mode: "virtual"
+```
+
+This distinction matters when embedding the STOMP server: installing
+`StompSendToFanoutHandler` is what connects inbound `SEND` frames to Titan's
+dispatcher routing pipeline.

--- a/docs/concepts/fanout.md
+++ b/docs/concepts/fanout.md
@@ -6,7 +6,7 @@ active observer should receive the event.
 
 ```text
                            ┌──▶ subscription 1
-SEND /topic/updates ──▶ gateway ──▶ subscription 2
+SEND /events/updates ──▶ gateway ──▶ subscription 2
                            └──▶ subscription 3
 ```
 
@@ -30,6 +30,6 @@ based dispatch workers.
 ## Operational boundary
 
 Fanout is live delivery, not durable retention. A subscriber that is offline
-does not gain replay merely because the destination is a topic. If consumers
-must recover historical events after reconnecting, provide persistence outside
-Titan or choose a durable messaging system.
+does not gain replay from its destination name. If consumers must recover
+historical events after reconnecting, provide persistence outside Titan or
+choose a durable messaging system.

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -59,10 +59,10 @@ public class StompClientExample {
             StompHeaders subscribeHeaders = StompHeaders.create();
             subscribeHeaders.put(StompHeaders.Elements.ID, "notifications");
 
-            connection.subscribe("/topic/notifications", subscribeHeaders)
+            connection.subscribe("/notifications", subscribeHeaders)
                     .get(30, TimeUnit.SECONDS);
 
-            connection.send("/topic/notifications", Buffer.alloc("hello titan"))
+            connection.send("/notifications", Buffer.alloc("hello titan"))
                     .get(30, TimeUnit.SECONDS);
         } finally {
             client.shutdown(30, TimeUnit.SECONDS);
@@ -103,7 +103,7 @@ public class AsyncStompClientExample {
         client.start();
 
         client.connect("127.0.0.1", 61613, 30, TimeUnit.SECONDS)
-                .thenCompose(connection -> sendAsync(connection, "/topic/notifications", "hello titan"))
+                .thenCompose(connection -> sendAsync(connection, "/notifications", "hello titan"))
                 .addListener(result -> {
                     if (result.isSuccess()) {
                         System.out.println("message sent");
@@ -127,5 +127,5 @@ public class AsyncStompClientExample {
 Use `future()` when integration code needs a JDK `Future`.
 
 ```java
-var future = connection.send("/topic/notifications", Buffer.alloc("hello titan")).future();
+var future = connection.send("/notifications", Buffer.alloc("hello titan")).future();
 ```

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -76,7 +76,7 @@ public class NotificationPublisher {
     }
     
     public void publish(String payload) throws Exception {
-        titanTemplate.send("/topic/notifications", payload);
+        titanTemplate.send("/notifications", payload);
     }
 }
 ```
@@ -99,7 +99,7 @@ public class AsyncNotificationPublisher {
     }
 
     public Future<StompFrames> publish(String payload) throws Exception {
-        return titanTemplate.async().send("/topic/notifications", payload);
+        return titanTemplate.async().send("/notifications", payload);
     }
 }
 ```
@@ -113,7 +113,7 @@ import org.traffichunter.titan.springframework.stomp.annotation.TitanListener;
 @Component
 public class NotificationListener {
 
-    @TitanListener(destination = "/topic/notifications")
+    @TitanListener(destination = "/notifications")
     public void onMessage(String payload) {
         System.out.println(payload);
     }

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -53,8 +53,8 @@ When the monitor is protected, provide its token through the environment:
 ```bash
 export TITAN_MONITOR_TOKEN=<monitor-token>
 ./titan --addr http://localhost:7777 queue list
-./titan --addr http://localhost:7777 queue create /queue/orders --capacity 100
-./titan --addr http://localhost:7777 queue delete /queue/orders
+./titan --addr http://localhost:7777 queue create /orders --capacity 100
+./titan --addr http://localhost:7777 queue delete /orders
 ```
 
 Deleting a queue affects live runtime state. Inspect it first and reserve

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,5 +64,5 @@ a message travel through the same destination.
 ## Next steps
 
 * Learn [how Titan works](concepts/how-titan-works.md).
-* Understand [destinations and dispatcher queues](concepts/destinations.md).
+* Understand [dispatch routing](concepts/destinations.md).
 * Add terminal visibility with [Monitoring and CLI](operate/monitoring.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,11 +58,11 @@ Choose the client path that matches your application:
 * [Spring Boot](examples/spring-client.md) for `TitanTemplate` and
   `@TitanListener`
 
-Use `/topic/notifications` in both the subscriber and publisher examples to see
+Use `/notifications` in both the subscriber and publisher examples to see
 a message travel through the same destination.
 
 ## Next steps
 
 * Learn [how Titan works](concepts/how-titan-works.md).
-* Decide between [queue and topic destinations](concepts/destinations.md).
+* Understand [destinations and dispatcher queues](concepts/destinations.md).
 * Add terminal visibility with [Monitoring and CLI](operate/monitoring.md).

--- a/docs/reference/project-scope.md
+++ b/docs/reference/project-scope.md
@@ -6,7 +6,7 @@ Titan's production focus is real-time STOMP dispatch over TCP.
 
 * STOMP server and client connections
 * TCP and WebSocket client transport
-* Queue- and topic-style destination routing
+* Exact destination routing through per-destination FIFO dispatcher queues
 * In-memory fanout delivery
 * Native Java and Spring Boot clients
 * Local JVM, connection, server, and dispatcher visibility

--- a/docs/why-titan.md
+++ b/docs/why-titan.md
@@ -9,7 +9,7 @@ and the runtime should stay small enough to understand and operate directly.
 Titan is a good fit when your system needs:
 
 * Real-time delivery over STOMP and TCP
-* Queue- and topic-style destination paths
+* Exact destination matching backed by a FIFO dispatcher queue
 * Publish-subscribe fanout
 * Java or Spring Boot integration
 * Local operational visibility from HTTP or a terminal
@@ -31,8 +31,9 @@ observable real-time dispatch.
 
 ## Design principles
 
-1. **Destinations are the API.** Producers and consumers meet at explicit
-   `/queue/...` and `/topic/...` paths.
+1. **Destinations are the API.** Every destination is an opaque path key. Titan
+   maps it to one FIFO dispatcher queue; prefixes such as `/queue` and `/topic`
+   do not select different delivery semantics.
 2. **The hot path stays small.** NIO event loops, channels, and pipelines move
    frames without hiding the transport lifecycle.
 3. **Optional features remain optional.** Fanout and monitoring attach as


### PR DESCRIPTION
## Motivation:

The published docs describe destinations using conventional STOMP queue/topic semantics, but Titan routes every message through the FIFO dispatcher queue for its exact destination. The current rounded favicon also exposes light corners in browser tabs.

## Modification:

- Add a full-bleed Titan favicon with no transparent outer corners.
- Rewrite the destination guide around exact destination matching and per-destination FIFO dispatcher queues.
- Map the publish flow to `StompSendToFanoutHandler`, the dispatch handler chain, `Dispatcher`, the queue consumer, and `StompDispatchExporter`.
- Explain queue creation, bounded capacity, lifecycle, exact subscription equality, and fanout delivery from the implementation.
- Distinguish wildcard queue discovery from publish routing and the fanout adapter from the default STOMP send handler.
- Replace `/queue` and `/topic` examples that implied special prefix semantics across the README, quickstart, concepts, operations, scope, and client guides.

## Result:

The documentation now reflects Titan's actual routing model: publish resolves or creates one dispatcher queue for the exact destination, a destination consumer drains it in order, and exporters deliver to exact-match subscriptions.

Validation:

- `./gradlew :core:test :fanout:test :titan-stomp:test`
- Parsed the favicon SVG with `xmllint` and rendered it to verify full-bleed color.
- Verified all local Markdown links across 15 docs files.
- `git diff --check`
