### PR TITLE
Separate asynchronous channel APIs from internal operations

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
@@ -45,7 +45,7 @@ public final class ChannelOutBoundHandlerChainImpl implements ChannelOutBoundHan
         ChannelOutBoundHandlerChainImpl chain = next;
         if(chain == null) {
             try {
-                channel.write(buffer);
+                channel.internal().write(buffer);
             } catch (RuntimeException e) {
                 buffer.release();
                 throw e;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoop.java
@@ -63,7 +63,7 @@ public class ChannelPrimaryIOEventLoop extends SingleThreadIOEventLoop {
                 try {
                     NetServerChannel serverChannel = (NetServerChannel) key.attachment();
                     NetChannel channel;
-                    while ((channel = serverChannel.accept()) != null) {
+                    while ((channel = serverChannel.internal().accept()) != null) {
                         // The server acceptor initializes the child and assigns its secondary I/O loop.
                         ((AbstractChannel) channel).accept(channel);
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
@@ -73,7 +73,7 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
             try {
                 if (key.isConnectable()) {
                     chain.processChannelConnecting(channel);
-                    if(channel.finishConnect()) {
+                    if(channel.internal().finishConnect()) {
                         if (channel instanceof NewIONetChannel nioNetChannel) {
                             nioNetChannel.completeConnect();
                         }
@@ -89,7 +89,7 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
                 } else if (key.isReadable()) {
                     processRead(channel, chain);
                 } else if (key.isWritable()) {
-                    channel.flush();
+                    channel.internal().flush();
                 }
             } catch (Exception e) {
                 if (channel.isClosed()) {
@@ -111,7 +111,7 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
         Buffer buffer = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, Buffers.DEFAULT_MAX_CAPACITY);
         final int read;
         try {
-            read = channel.read(buffer);
+            read = channel.internal().read(buffer);
         } catch (Exception e) {
             buffer.release();
             throw e;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.channel;
 
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -107,8 +106,23 @@ final class ChannelTasks {
         });
     }
 
-    static Promise<@Nullable NetChannel> accept(NetServerChannel channel) {
-        return execute(channel.eventLoop(), channel.internal()::accept);
+    static Promise<NetChannel> accept(NetServerChannel channel) {
+        IOEventLoop eventLoop = channel.eventLoop();
+        Promise<NetChannel> result = Promise.newPromise(eventLoop);
+        Runnable acceptTask = () -> {
+            try {
+                result.success(channel.internal().accept());
+            } catch (Throwable error) {
+                result.fail(error);
+            }
+        };
+
+        if (eventLoop.inEventLoop()) {
+            acceptTask.run();
+        } else {
+            eventLoop.register(acceptTask);
+        }
+        return result;
     }
 
     static Promise<Void> execute(IOEventLoop eventLoop, Runnable task) {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
@@ -1,0 +1,142 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel;
+
+import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes public channel operations on their owning event loop.
+ *
+ * @author yun
+ */
+final class ChannelTasks {
+
+    private ChannelTasks() {
+    }
+
+    static Promise<Void> connect(
+            NetChannel channel,
+            InetSocketAddress remote,
+            long timeout,
+            TimeUnit unit
+    ) {
+        return execute(channel.eventLoop(), () -> {
+            try {
+                channel.internal().connect(remote, timeout, unit);
+            } catch (IOException e) {
+                throw new ChannelException("Failed to connect to " + remote, e);
+            }
+        });
+    }
+
+    static Promise<Void> disconnect(NetChannel channel) {
+        return execute(channel.eventLoop(), channel.internal()::disconnect);
+    }
+
+    static Promise<Integer> read(NetChannel channel, Buffer buffer) {
+        return execute(channel.eventLoop(), () -> channel.internal().read(buffer));
+    }
+
+    static Promise<Void> write(NetChannel channel, Buffer buffer) {
+        return execute(channel.eventLoop(), () -> channel.chain().processChannelWrite(channel, buffer));
+    }
+
+    static Promise<Void> writeAndFlush(NetChannel channel, Buffer buffer) {
+        return execute(channel.eventLoop(), () -> {
+            channel.chain().processChannelWrite(channel, buffer);
+            channel.internal().flush();
+        });
+    }
+
+    static Promise<Void> flush(NetChannel channel) {
+        return execute(channel.eventLoop(), channel.internal()::flush);
+    }
+
+    static Promise<Void> onWritabilityChanged(NetChannel channel, boolean isWritable) {
+        return execute(
+                channel.eventLoop(),
+                () -> channel.internal().onWritabilityChanged(isWritable)
+        );
+    }
+
+    static Promise<Boolean> finishConnect(NetChannel channel) {
+        return execute(channel.eventLoop(), () -> {
+            try {
+                return channel.internal().finishConnect();
+            } catch (IOException e) {
+                throw new ChannelException("Failed to finish channel connection", e);
+            }
+        });
+    }
+
+    static Promise<Void> bind(NetServerChannel channel, InetSocketAddress address) {
+        return execute(channel.eventLoop(), () -> {
+            try {
+                channel.internal().bind(address);
+            } catch (IOException e) {
+                throw new ChannelException("Failed to bind to " + address, e);
+            }
+        });
+    }
+
+    static Promise<@Nullable NetChannel> accept(NetServerChannel channel) {
+        return execute(channel.eventLoop(), channel.internal()::accept);
+    }
+
+    static Promise<Void> execute(IOEventLoop eventLoop, Runnable task) {
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<Void> result = Promise.newPromise(eventLoop);
+        try {
+            task.run();
+            result.success();
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    static <T> Promise<T> execute(IOEventLoop eventLoop, Callable<T> task) {
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<T> result = Promise.newPromise(eventLoop);
+        try {
+            result.success(task.call());
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
@@ -25,6 +25,7 @@ package org.traffichunter.titan.core.channel;
 
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
+import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -161,6 +162,51 @@ public final class InMemoryNetChannel implements NetChannel {
     @Override
     public Internal internal() {
         return internal;
+    }
+
+    @Override
+    public Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
+        return connect(new InetSocketAddress(host, port), timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+        return ChannelTasks.connect(this, remote, timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> disconnect() {
+        return ChannelTasks.disconnect(this);
+    }
+
+    @Override
+    public Promise<Integer> read(Buffer buffer) {
+        return ChannelTasks.read(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> write(Buffer buffer) {
+        return ChannelTasks.write(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> writeAndFlush(Buffer buffer) {
+        return ChannelTasks.writeAndFlush(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> flush() {
+        return ChannelTasks.flush(this);
+    }
+
+    @Override
+    public Promise<Void> onWritabilityChanged(boolean isWritable) {
+        return ChannelTasks.onWritabilityChanged(this, isWritable);
+    }
+
+    @Override
+    public Promise<Boolean> finishConnect() {
+        return ChannelTasks.finishConnect(this);
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
@@ -49,6 +49,7 @@ public final class InMemoryNetChannel implements NetChannel {
     private final Queue<Buffer> inbound = new ArrayDeque<>();
     private final Queue<Buffer> pendingWrites = new ArrayDeque<>();
     private final Queue<Buffer> flushedWrites = new ArrayDeque<>();
+    private final Internal internal = new InMemoryInternal();
 
     private @Nullable IOEventLoop eventLoop;
     private @Nullable SocketAddress localAddress;
@@ -158,55 +159,8 @@ public final class InMemoryNetChannel implements NetChannel {
     }
 
     @Override
-    public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
-        remoteAddress = remote;
-        connected = true;
-        active = true;
-    }
-
-    @Override
-    public void disconnect() {
-        connected = false;
-        active = false;
-    }
-
-    @Override
-    public int read(Buffer buffer) {
-        Buffer inboundBuffer = inbound.poll();
-        if (inboundBuffer == null) {
-            return 0;
-        }
-        int readable = inboundBuffer.length();
-        buffer.accumulateBuffer(inboundBuffer);
-        inboundBuffer.release();
-        return readable;
-    }
-
-    @Override
-    public void write(Buffer buffer) {
-        pendingWrites.add(buffer.retain());
-    }
-
-    @Override
-    public void writeAndFlush(Buffer buffer) {
-        chain.processChannelWrite(this, buffer);
-        flush();
-    }
-
-    @Override
-    public void flush() {
-        while (!pendingWrites.isEmpty()) {
-            flushedWrites.add(pendingWrites.poll());
-        }
-    }
-
-    @Override
-    public void onWritabilityChanged(boolean isWritable) {
-    }
-
-    @Override
-    public boolean finishConnect() {
-        return connected;
+    public Internal internal() {
+        return internal;
     }
 
     @Override
@@ -229,6 +183,61 @@ public final class InMemoryNetChannel implements NetChannel {
     private void clearQueue(Queue<Buffer> queue) {
         while (!queue.isEmpty()) {
             queue.poll().release();
+        }
+    }
+
+    private final class InMemoryInternal implements Internal {
+
+        @Override
+        public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+            remoteAddress = remote;
+            connected = true;
+            active = true;
+        }
+
+        @Override
+        public void disconnect() {
+            connected = false;
+            active = false;
+        }
+
+        @Override
+        public int read(Buffer buffer) {
+            Buffer inboundBuffer = inbound.poll();
+            if (inboundBuffer == null) {
+                return 0;
+            }
+            int readable = inboundBuffer.length();
+            buffer.accumulateBuffer(inboundBuffer);
+            inboundBuffer.release();
+            return readable;
+        }
+
+        @Override
+        public void write(Buffer buffer) {
+            pendingWrites.add(buffer.retain());
+        }
+
+        @Override
+        public void writeAndFlush(Buffer buffer) {
+            write(buffer);
+            flush();
+        }
+
+        @Override
+        public void flush() {
+            while (!pendingWrites.isEmpty()) {
+                flushedWrites.add(pendingWrites.poll());
+            }
+        }
+
+        @Override
+        public void onWritabilityChanged(boolean isWritable) {
+        }
+
+        @Override
+        public boolean finishConnect() {
+            return connected;
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -24,12 +24,13 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import org.jspecify.annotations.NonNull;
+import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -51,43 +52,137 @@ public interface NetChannel extends Channel {
     @Override
     <T> NetChannel setOption(SocketOption<T> option, T value);
 
-    default void connect(String host, int port, long timeOut, TimeUnit timeUnit) throws IOException {
-        connect(new InetSocketAddress(host, port), timeOut, timeUnit);
+    default Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
+        return connect(new InetSocketAddress(host, port), timeOut, timeUnit);
     }
+
+    /**
+     * Returns the synchronous transport operations used by the owning I/O event loop and
+     * protocol handlers that must bypass the outbound chain.
+     */
+    Internal internal();
 
     /**
      * Starts or completes a non-blocking socket connection.
      */
     @CanIgnoreReturnValue
-    void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException;
+    default Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+        return execute(() -> {
+            try {
+                internal().connect(remote, timeOut, timeUnit);
+            } catch (IOException e) {
+                throw new ChannelException("Failed to connect to " + remote, e);
+            }
+        });
+    }
 
     @CanIgnoreReturnValue
-    void disconnect();
+    default Promise<Void> disconnect() {
+        return execute(internal()::disconnect);
+    }
 
     /**
      * Reads available bytes without blocking.
      */
     @CanIgnoreReturnValue
-    int read(Buffer buffer);
+    default Promise<Integer> read(Buffer buffer) {
+        return execute(() -> internal().read(buffer));
+    }
 
     @CanIgnoreReturnValue
-    void write(Buffer buffer);
+    default Promise<Void> write(Buffer buffer) {
+        return execute(() -> chain().processChannelWrite(this, buffer));
+    }
 
     /**
      * Queues the buffer and attempts to write queued bytes to the socket.
      */
     @CanIgnoreReturnValue
-    void writeAndFlush(Buffer buffer);
+    default Promise<Void> writeAndFlush(Buffer buffer) {
+        return execute(() -> {
+            chain().processChannelWrite(this, buffer);
+            internal().flush();
+        });
+    }
 
     @CanIgnoreReturnValue
-    void flush();
+    default Promise<Void> flush() {
+        return execute(internal()::flush);
+    }
 
-    void onWritabilityChanged(boolean isWritable);
+    default Promise<Void> onWritabilityChanged(boolean isWritable) {
+        return execute(() -> internal().onWritabilityChanged(isWritable));
+    }
 
     /**
      * Completes a pending non-blocking connect from the owning event-loop thread.
      */
-    boolean finishConnect() throws IOException;
+    default Promise<Boolean> finishConnect() {
+        return execute(() -> {
+            try {
+                return internal().finishConnect();
+            } catch (IOException e) {
+                throw new ChannelException("Failed to finish channel connection", e);
+            }
+        });
+    }
 
     boolean isConnected();
+
+    private Promise<Void> execute(Runnable task) {
+        IOEventLoop eventLoop = eventLoop();
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<Void> result = Promise.newPromise(eventLoop);
+        try {
+            task.run();
+            result.success();
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    private <T> Promise<T> execute(Callable<T> task) {
+        IOEventLoop eventLoop = eventLoop();
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<T> result = Promise.newPromise(eventLoop);
+        try {
+            result.success(task.call());
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    /**
+     * Synchronous low-level channel operations.
+     *
+     * <p>These methods execute immediately and are intended for the channel's I/O event-loop
+     * thread. A successful call means the operation was attempted or queued; it does not mean
+     * that the peer received the bytes.</p>
+     */
+    interface Internal {
+
+        void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException;
+
+        void disconnect();
+
+        int read(Buffer buffer);
+
+        void write(Buffer buffer);
+
+        void writeAndFlush(Buffer buffer);
+
+        void flush();
+
+        void onWritabilityChanged(boolean isWritable);
+
+        boolean finishConnect() throws IOException;
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -30,7 +30,6 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -52,9 +51,7 @@ public interface NetChannel extends Channel {
     @Override
     <T> NetChannel setOption(SocketOption<T> option, T value);
 
-    default Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
-        return connect(new InetSocketAddress(host, port), timeOut, timeUnit);
-    }
+    Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit);
 
     /**
      * Returns the synchronous transport operations used by the owning I/O event loop and
@@ -66,99 +63,37 @@ public interface NetChannel extends Channel {
      * Starts or completes a non-blocking socket connection.
      */
     @CanIgnoreReturnValue
-    default Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
-        return execute(() -> {
-            try {
-                internal().connect(remote, timeOut, timeUnit);
-            } catch (IOException e) {
-                throw new ChannelException("Failed to connect to " + remote, e);
-            }
-        });
-    }
+    Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit);
 
     @CanIgnoreReturnValue
-    default Promise<Void> disconnect() {
-        return execute(internal()::disconnect);
-    }
+    Promise<Void> disconnect();
 
     /**
      * Reads available bytes without blocking.
      */
     @CanIgnoreReturnValue
-    default Promise<Integer> read(Buffer buffer) {
-        return execute(() -> internal().read(buffer));
-    }
+    Promise<Integer> read(Buffer buffer);
 
     @CanIgnoreReturnValue
-    default Promise<Void> write(Buffer buffer) {
-        return execute(() -> chain().processChannelWrite(this, buffer));
-    }
+    Promise<Void> write(Buffer buffer);
 
     /**
      * Queues the buffer and attempts to write queued bytes to the socket.
      */
     @CanIgnoreReturnValue
-    default Promise<Void> writeAndFlush(Buffer buffer) {
-        return execute(() -> {
-            chain().processChannelWrite(this, buffer);
-            internal().flush();
-        });
-    }
+    Promise<Void> writeAndFlush(Buffer buffer);
 
     @CanIgnoreReturnValue
-    default Promise<Void> flush() {
-        return execute(internal()::flush);
-    }
+    Promise<Void> flush();
 
-    default Promise<Void> onWritabilityChanged(boolean isWritable) {
-        return execute(() -> internal().onWritabilityChanged(isWritable));
-    }
+    Promise<Void> onWritabilityChanged(boolean isWritable);
 
     /**
      * Completes a pending non-blocking connect from the owning event-loop thread.
      */
-    default Promise<Boolean> finishConnect() {
-        return execute(() -> {
-            try {
-                return internal().finishConnect();
-            } catch (IOException e) {
-                throw new ChannelException("Failed to finish channel connection", e);
-            }
-        });
-    }
+    Promise<Boolean> finishConnect();
 
     boolean isConnected();
-
-    private Promise<Void> execute(Runnable task) {
-        IOEventLoop eventLoop = eventLoop();
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
-        Promise<Void> result = Promise.newPromise(eventLoop);
-        try {
-            task.run();
-            result.success();
-        } catch (Throwable error) {
-            result.fail(error);
-        }
-        return result;
-    }
-
-    private <T> Promise<T> execute(Callable<T> task) {
-        IOEventLoop eventLoop = eventLoop();
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
-        Promise<T> result = Promise.newPromise(eventLoop);
-        try {
-            result.success(task.call());
-        } catch (Throwable error) {
-            result.fail(error);
-        }
-        return result;
-    }
 
     /**
      * Synchronous low-level channel operations.

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
@@ -29,7 +29,6 @@ import org.traffichunter.titan.core.concurrent.Promise;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
-import java.util.concurrent.Callable;
 
 /**
  * Listening server socket channel.
@@ -49,9 +48,7 @@ public interface NetServerChannel extends Channel {
     @Override
     <T> NetServerChannel setOption(SocketOption<T> option, T value);
 
-    default Promise<Void> bind(String host, int port) {
-        return bind(new InetSocketAddress(host, port));
-    }
+    Promise<Void> bind(String host, int port);
 
     /**
      * Returns the synchronous transport operations used by the server I/O event loop.
@@ -61,53 +58,12 @@ public interface NetServerChannel extends Channel {
     /**
      * Binds the listening socket to the given address.
      */
-    default Promise<Void> bind(InetSocketAddress address) {
-        return execute(() -> {
-            try {
-                internal().bind(address);
-            } catch (IOException e) {
-                throw new ChannelException("Failed to bind to " + address, e);
-            }
-        });
-    }
+    Promise<Void> bind(InetSocketAddress address);
 
     /**
      * Accepts one pending child connection, or returns {@code null} when no connection is ready.
      */
-    default Promise<@Nullable NetChannel> accept() {
-        return execute(internal()::accept);
-    }
-
-    private Promise<Void> execute(Runnable task) {
-        IOEventLoop eventLoop = eventLoop();
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
-        Promise<Void> result = Promise.newPromise(eventLoop);
-        try {
-            task.run();
-            result.success();
-        } catch (Throwable error) {
-            result.fail(error);
-        }
-        return result;
-    }
-
-    private <T> Promise<T> execute(Callable<T> task) {
-        IOEventLoop eventLoop = eventLoop();
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
-        Promise<T> result = Promise.newPromise(eventLoop);
-        try {
-            result.success(task.call());
-        } catch (Throwable error) {
-            result.fail(error);
-        }
-        return result;
-    }
+    Promise<@Nullable NetChannel> accept();
 
     /**
      * Synchronous low-level server socket operations for the owning I/O event-loop thread.

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
@@ -24,10 +24,12 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.concurrent.Promise;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketOption;
+import java.util.concurrent.Callable;
 
 /**
  * Listening server socket channel.
@@ -47,17 +49,73 @@ public interface NetServerChannel extends Channel {
     @Override
     <T> NetServerChannel setOption(SocketOption<T> option, T value);
 
-    default void bind(String host, int port) throws IOException {
-        bind(new InetSocketAddress(host, port));
+    default Promise<Void> bind(String host, int port) {
+        return bind(new InetSocketAddress(host, port));
     }
+
+    /**
+     * Returns the synchronous transport operations used by the server I/O event loop.
+     */
+    Internal internal();
 
     /**
      * Binds the listening socket to the given address.
      */
-    void bind(InetSocketAddress address) throws IOException;
+    default Promise<Void> bind(InetSocketAddress address) {
+        return execute(() -> {
+            try {
+                internal().bind(address);
+            } catch (IOException e) {
+                throw new ChannelException("Failed to bind to " + address, e);
+            }
+        });
+    }
 
     /**
      * Accepts one pending child connection, or returns {@code null} when no connection is ready.
      */
-    @Nullable NetChannel accept();
+    default Promise<@Nullable NetChannel> accept() {
+        return execute(internal()::accept);
+    }
+
+    private Promise<Void> execute(Runnable task) {
+        IOEventLoop eventLoop = eventLoop();
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<Void> result = Promise.newPromise(eventLoop);
+        try {
+            task.run();
+            result.success();
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    private <T> Promise<T> execute(Callable<T> task) {
+        IOEventLoop eventLoop = eventLoop();
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(task);
+        }
+
+        Promise<T> result = Promise.newPromise(eventLoop);
+        try {
+            result.success(task.call());
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    /**
+     * Synchronous low-level server socket operations for the owning I/O event-loop thread.
+     */
+    interface Internal {
+
+        void bind(InetSocketAddress address) throws IOException;
+
+        @Nullable NetChannel accept();
+    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
@@ -63,7 +63,7 @@ public interface NetServerChannel extends Channel {
     /**
      * Accepts one pending child connection, or returns {@code null} when no connection is ready.
      */
-    Promise<@Nullable NetChannel> accept();
+    Promise<NetChannel> accept();
 
     /**
      * Synchronous low-level server socket operations for the owning I/O event-loop thread.

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -118,159 +118,6 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         return ChannelTasks.finishConnect(this);
     }
 
-    private void connectInternal(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) throws IOException {
-        if(isClosed()) {
-            throw new ChannelException("Channel is closed");
-        }
-
-        ChannelPromise promise = eventLoop().newPromise(this);
-        connectPromise = promise;
-
-        if(connect0(remoteAddress)) {
-            chain().processChannelConnecting(this);
-            completeConnect();
-            chain().processChannelAfterConnected(this);
-            eventLoop().ioSelector().registerRead(this);
-            accept(this);
-            return;
-        }
-
-        if(timeOut > 0) {
-            ScheduledPromise<?> timeoutPromise = eventLoop().schedule(
-                () -> {
-                    if (promise.isDone()) {
-                        return;
-                    }
-                    promise.fail(new ChannelException("Connect timeout"));
-                    close();
-                }, timeOut, timeUnit);
-
-            promise.addListener(f -> timeoutPromise.cancel());
-        }
-    }
-
-    private void disconnectInternal() {
-        close();
-    }
-
-    private int readInternal(Buffer buffer) {
-        if(isClosed()) {
-            throw new ChannelException("Channel is closed");
-        }
-
-        ByteBuf byteBuf = buffer.byteBuf();
-        ByteBuffer dst = byteBuf.nioBuffer(byteBuf.writerIndex(), byteBuf.writableBytes());
-
-        try {
-            int read = channel().read(dst);
-
-            if(read > 0) {
-                byteBuf.writerIndex(byteBuf.writerIndex() + read);
-            } else if(read < 0) {
-                close();
-            }
-
-            return read;
-        } catch (IOException e) {
-            log.warn("Failed to read from socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
-            return -1;
-        }
-    }
-
-    private void writeInternal(Buffer buffer) {
-        if(isClosed()) {
-            throw new ChannelException("Already channel is closed");
-        }
-
-        channelWriteBuffer.add(buffer);
-    }
-
-    private void writeAndFlushInternal(Buffer buffer) {
-        try {
-            writeInternal(buffer);
-            flushInternal();
-        } catch (RuntimeException e) {
-            close();
-            throw e;
-        }
-    }
-
-    private void flushInternal() {
-        if(isClosed()) {
-            throw new ChannelException("Already channel is closed");
-        }
-
-        while (true) {
-            Buffer buffer = channelWriteBuffer.current();
-            if(buffer == null) {
-                break;
-            }
-
-            ByteBuf byteBuf = buffer.byteBuf();
-            ByteBuffer nioBuffer = byteBuf.nioBuffer(byteBuf.readerIndex(), byteBuf.readableBytes());
-
-            int written = write0(nioBuffer);
-            if(written < 0) {
-                throw new ChannelException("Failed to write to socket");
-            }
-            // socket buffer full
-            if(written == 0) {
-                onWriteabilityChanged(true);
-                break;
-            }
-
-            byteBuf.readerIndex(byteBuf.readerIndex() + written);
-
-            if(!byteBuf.isReadable()) {
-                Buffer consumed = channelWriteBuffer.poll();
-                if (consumed != null) {
-                    consumed.release();
-                }
-            }
-        }
-
-        if(channelWriteBuffer.isEmpty()) {
-            onWriteabilityChanged(false);
-        }
-    }
-
-    private void onWritabilityChangedInternal(boolean active) {
-        if (isClosed()) {
-            return;
-        }
-
-        IOEventLoop ioEventLoop = eventLoop();
-        if (ioEventLoop.isShuttingDown()) {
-            return;
-        }
-        IOSelector ioSelector = ioEventLoop.ioSelector();
-
-        Runnable updateWritability = () -> {
-            try {
-                if (active) {
-                    ioSelector.registerWrite(this);
-                } else {
-                    ioSelector.unregisterWrite(this);
-                }
-            } catch (IOException e) {
-                throw new ChannelException("Failed to register write event", e);
-            }
-        };
-
-        if (ioEventLoop.inEventLoop()) {
-            updateWritability.run();
-            return;
-        }
-
-        try {
-            ioEventLoop.register(updateWritability);
-        } catch (RejectedExecutionException e) {
-            if (!isClosed() && !ioEventLoop.isShuttingDown()) {
-                throw e;
-            }
-        }
-    }
-
     @Override
     public <T> NetChannel setOption(SocketOption<T> option, T value) {
         try {
@@ -308,21 +155,6 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    private boolean finishConnectInternal() throws IOException {
-        if(!eventLoop().inEventLoop()) {
-            throw new ChannelException("Should be called in event loop");
-        }
-
-        try {
-            return channel().finishConnect();
-        } catch (IOException e) {
-            log.warn("Failed to finish connect = {}", e.getMessage());
-            failConnect(e);
-            close();
-            throw e;
-        }
-    }
-
     @Override
     public boolean isConnected() {
         return channel().isConnected();
@@ -334,33 +166,8 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         super.close();
     }
 
-    private void onWriteabilityChanged(boolean isWritable) {
-        IOSelector ioSelector = eventLoop().ioSelector();
-        try {
-            if (isWritable) {
-                ioSelector.registerWrite(this);
-            } else {
-                ioSelector.unregisterWrite(this);
-            }
-        } catch (IOException e) {
-            throw new ChannelException("Failed to register write event", e);
-        }
-    }
-
     private SocketChannel channel() {
         return (SocketChannel) super.selectableChannel();
-    }
-
-    private int write0(ByteBuffer byteBuffer) {
-        int written;
-        try {
-            written = channel().write(byteBuffer);
-        } catch (IOException e) {
-            log.warn("Failed to write to socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
-            return -1;
-        }
-
-        return written;
     }
 
     void completeConnect() {
@@ -389,69 +196,227 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    private boolean connect0(InetSocketAddress remote) throws IOException {
-        boolean connected = false;
-        try {
-            boolean connect = channel().connect(remote);
-            if(!connect) {
-                IOEventLoop eventLoop = eventLoop();
-                eventLoop.register(() -> {
-                    try {
-                        eventLoop.ioSelector().registerConnect(this);
-                    } catch (IOException e) {
-                        throw new ChannelException("Failed to register connect event", e);
-                    }
-                });
-            }
-            connected = true;
-            return connect;
-        } finally {
-            if(!connected) {
-                close();
-            }
-        }
-    }
-
     private final class NewIOInternal implements Internal {
 
         @Override
         public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException {
-            connectInternal(remote, timeOut, timeUnit);
+            if(isClosed()) {
+                throw new ChannelException("Channel is closed");
+            }
+
+            ChannelPromise promise = eventLoop().newPromise(NewIONetChannel.this);
+            connectPromise = promise;
+
+            if(connect0(remote)) {
+                chain().processChannelConnecting(NewIONetChannel.this);
+                completeConnect();
+                chain().processChannelAfterConnected(NewIONetChannel.this);
+                eventLoop().ioSelector().registerRead(NewIONetChannel.this);
+                accept(NewIONetChannel.this);
+                return;
+            }
+
+            if(timeOut > 0) {
+                ScheduledPromise<?> timeoutPromise = eventLoop().schedule(
+                    () -> {
+                        if (promise.isDone()) {
+                            return;
+                        }
+                        promise.fail(new ChannelException("Connect timeout"));
+                        close();
+                    }, timeOut, timeUnit);
+
+                promise.addListener(f -> timeoutPromise.cancel());
+            }
         }
 
         @Override
         public void disconnect() {
-            disconnectInternal();
+            close();
         }
 
         @Override
         public int read(Buffer buffer) {
-            return readInternal(buffer);
+            if(isClosed()) {
+                throw new ChannelException("Channel is closed");
+            }
+
+            ByteBuf byteBuf = buffer.byteBuf();
+            ByteBuffer dst = byteBuf.nioBuffer(byteBuf.writerIndex(), byteBuf.writableBytes());
+
+            try {
+                int read = channel().read(dst);
+
+                if(read > 0) {
+                    byteBuf.writerIndex(byteBuf.writerIndex() + read);
+                } else if(read < 0) {
+                    close();
+                }
+
+                return read;
+            } catch (IOException e) {
+                log.warn("Failed to read from socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
+                return -1;
+            }
         }
 
         @Override
         public void write(Buffer buffer) {
-            writeInternal(buffer);
+            if(isClosed()) {
+                throw new ChannelException("Already channel is closed");
+            }
+
+            channelWriteBuffer.add(buffer);
         }
 
         @Override
         public void writeAndFlush(Buffer buffer) {
-            writeAndFlushInternal(buffer);
+            try {
+                write(buffer);
+                flush();
+            } catch (RuntimeException e) {
+                close();
+                throw e;
+            }
         }
 
         @Override
         public void flush() {
-            flushInternal();
+            if(isClosed()) {
+                throw new ChannelException("Already channel is closed");
+            }
+
+            while (true) {
+                Buffer buffer = channelWriteBuffer.current();
+                if(buffer == null) {
+                    break;
+                }
+
+                ByteBuf byteBuf = buffer.byteBuf();
+                ByteBuffer nioBuffer = byteBuf.nioBuffer(byteBuf.readerIndex(), byteBuf.readableBytes());
+
+                int written = write0(nioBuffer);
+                if(written < 0) {
+                    throw new ChannelException("Failed to write to socket");
+                }
+                // socket buffer full
+                if(written == 0) {
+                    onWriteabilityChanged(true);
+                    break;
+                }
+
+                byteBuf.readerIndex(byteBuf.readerIndex() + written);
+
+                if(!byteBuf.isReadable()) {
+                    Buffer consumed = channelWriteBuffer.poll();
+                    if (consumed != null) {
+                        consumed.release();
+                    }
+                }
+            }
+
+            if(channelWriteBuffer.isEmpty()) {
+                onWriteabilityChanged(false);
+            }
         }
 
         @Override
-        public void onWritabilityChanged(boolean isWritable) {
-            onWritabilityChangedInternal(isWritable);
+        public void onWritabilityChanged(boolean active) {
+            if (isClosed()) {
+                return;
+            }
+
+            IOEventLoop ioEventLoop = eventLoop();
+            if (ioEventLoop.isShuttingDown()) {
+                return;
+            }
+            IOSelector ioSelector = ioEventLoop.ioSelector();
+
+            Runnable updateWritability = () -> {
+                try {
+                    if (active) {
+                        ioSelector.registerWrite(NewIONetChannel.this);
+                    } else {
+                        ioSelector.unregisterWrite(NewIONetChannel.this);
+                    }
+                } catch (IOException e) {
+                    throw new ChannelException("Failed to register write event", e);
+                }
+            };
+
+            if (ioEventLoop.inEventLoop()) {
+                updateWritability.run();
+                return;
+            }
+
+            try {
+                ioEventLoop.register(updateWritability);
+            } catch (RejectedExecutionException e) {
+                if (!isClosed() && !ioEventLoop.isShuttingDown()) {
+                    throw e;
+                }
+            }
         }
 
         @Override
         public boolean finishConnect() throws IOException {
-            return finishConnectInternal();
+            if(!eventLoop().inEventLoop()) {
+                throw new ChannelException("Should be called in event loop");
+            }
+
+            try {
+                return channel().finishConnect();
+            } catch (IOException e) {
+                log.warn("Failed to finish connect = {}", e.getMessage());
+                failConnect(e);
+                close();
+                throw e;
+            }
+        }
+
+        private boolean connect0(InetSocketAddress remote) throws IOException {
+            boolean connected = false;
+            try {
+                boolean connect = channel().connect(remote);
+                if(!connect) {
+                    IOEventLoop eventLoop = eventLoop();
+                    eventLoop.register(() -> {
+                        try {
+                            eventLoop.ioSelector().registerConnect(NewIONetChannel.this);
+                        } catch (IOException e) {
+                            throw new ChannelException("Failed to register connect event", e);
+                        }
+                    });
+                }
+                connected = true;
+                return connect;
+            } finally {
+                if(!connected) {
+                    close();
+                }
+            }
+        }
+
+        private int write0(ByteBuffer byteBuffer) {
+            try {
+                return channel().write(byteBuffer);
+            } catch (IOException e) {
+                log.warn("Failed to write to socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
+                return -1;
+            }
+        }
+
+        private void onWriteabilityChanged(boolean isWritable) {
+            IOSelector ioSelector = eventLoop().ioSelector();
+            try {
+                if (isWritable) {
+                    ioSelector.registerWrite(NewIONetChannel.this);
+                } else {
+                    ioSelector.unregisterWrite(NewIONetChannel.this);
+                }
+            } catch (IOException e) {
+                throw new ChannelException("Failed to register write event", e);
+            }
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
+import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -70,6 +71,51 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
     @Override
     public Internal internal() {
         return internal;
+    }
+
+    @Override
+    public Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
+        return connect(new InetSocketAddress(host, port), timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+        return ChannelTasks.connect(this, remote, timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> disconnect() {
+        return ChannelTasks.disconnect(this);
+    }
+
+    @Override
+    public Promise<Integer> read(Buffer buffer) {
+        return ChannelTasks.read(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> write(Buffer buffer) {
+        return ChannelTasks.write(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> writeAndFlush(Buffer buffer) {
+        return ChannelTasks.writeAndFlush(this, buffer);
+    }
+
+    @Override
+    public Promise<Void> flush() {
+        return ChannelTasks.flush(this);
+    }
+
+    @Override
+    public Promise<Void> onWritabilityChanged(boolean isWritable) {
+        return ChannelTasks.onWritabilityChanged(this, isWritable);
+    }
+
+    @Override
+    public Promise<Boolean> finishConnect() {
+        return ChannelTasks.finishConnect(this);
     }
 
     private void connectInternal(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) throws IOException {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 public class NewIONetChannel extends AbstractChannel implements NetChannel {
 
     private final ChannelWriteBuffer channelWriteBuffer;
+    private final Internal internal = new NewIOInternal();
 
     private @Nullable volatile ChannelPromise connectPromise;
 
@@ -67,7 +68,11 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
     }
 
     @Override
-    public void connect(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) throws IOException {
+    public Internal internal() {
+        return internal;
+    }
+
+    private void connectInternal(InetSocketAddress remoteAddress, long timeOut, TimeUnit timeUnit) throws IOException {
         if(isClosed()) {
             throw new ChannelException("Channel is closed");
         }
@@ -98,13 +103,11 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    @Override
-    public void disconnect() {
+    private void disconnectInternal() {
         close();
     }
 
-    @Override
-    public int read(Buffer buffer) {
+    private int readInternal(Buffer buffer) {
         if(isClosed()) {
             throw new ChannelException("Channel is closed");
         }
@@ -128,8 +131,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    @Override
-    public void write(Buffer buffer) {
+    private void writeInternal(Buffer buffer) {
         if(isClosed()) {
             throw new ChannelException("Already channel is closed");
         }
@@ -137,19 +139,17 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         channelWriteBuffer.add(buffer);
     }
 
-    @Override
-    public void writeAndFlush(Buffer buffer) {
+    private void writeAndFlushInternal(Buffer buffer) {
         try {
-            chain().processChannelWrite(this, buffer);
-            flush();
+            writeInternal(buffer);
+            flushInternal();
         } catch (RuntimeException e) {
             close();
             throw e;
         }
     }
 
-    @Override
-    public void flush() {
+    private void flushInternal() {
         if(isClosed()) {
             throw new ChannelException("Already channel is closed");
         }
@@ -188,8 +188,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    @Override
-    public void onWritabilityChanged(boolean active) {
+    private void onWritabilityChangedInternal(boolean active) {
         if (isClosed()) {
             return;
         }
@@ -263,8 +262,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    @Override
-    public boolean finishConnect() throws IOException {
+    private boolean finishConnectInternal() throws IOException {
         if(!eventLoop().inEventLoop()) {
             throw new ChannelException("Should be called in event loop");
         }
@@ -365,6 +363,49 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
             if(!connected) {
                 close();
             }
+        }
+    }
+
+    private final class NewIOInternal implements Internal {
+
+        @Override
+        public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException {
+            connectInternal(remote, timeOut, timeUnit);
+        }
+
+        @Override
+        public void disconnect() {
+            disconnectInternal();
+        }
+
+        @Override
+        public int read(Buffer buffer) {
+            return readInternal(buffer);
+        }
+
+        @Override
+        public void write(Buffer buffer) {
+            writeInternal(buffer);
+        }
+
+        @Override
+        public void writeAndFlush(Buffer buffer) {
+            writeAndFlushInternal(buffer);
+        }
+
+        @Override
+        public void flush() {
+            flushInternal();
+        }
+
+        @Override
+        public void onWritabilityChanged(boolean isWritable) {
+            onWritabilityChangedInternal(isWritable);
+        }
+
+        @Override
+        public boolean finishConnect() throws IOException {
+            return finishConnectInternal();
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
@@ -50,6 +50,8 @@ import java.nio.channels.SocketChannel;
  */
 public class NewIONetServerChannel extends AbstractChannel implements NetServerChannel {
 
+    private final Internal internal = new NewIOInternal();
+
     NewIONetServerChannel(ChannelHandShakeEventListener initializer) throws IOException {
         this(ServerSocketChannel.open(), initializer);
     }
@@ -59,12 +61,11 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
     }
 
     @Override
-    public void bind(InetSocketAddress address) throws IOException {
-        channel().bind(address);
+    public Internal internal() {
+        return internal;
     }
 
-    @Override
-    public @Nullable NetChannel accept() {
+    private @Nullable NetChannel acceptInternal() {
         try {
             SocketChannel accept = channel().accept();
             if (accept == null) {
@@ -113,5 +114,18 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
 
     private ServerSocketChannel channel() {
         return (ServerSocketChannel) super.selectableChannel();
+    }
+
+    private final class NewIOInternal implements Internal {
+
+        @Override
+        public void bind(InetSocketAddress address) throws IOException {
+            channel().bind(address);
+        }
+
+        @Override
+        public @Nullable NetChannel accept() {
+            return acceptInternal();
+        }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
@@ -77,22 +77,8 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
     }
 
     @Override
-    public Promise<@Nullable NetChannel> accept() {
+    public Promise<NetChannel> accept() {
         return ChannelTasks.accept(this);
-    }
-
-    private @Nullable NetChannel acceptInternal() {
-        try {
-            SocketChannel accept = channel().accept();
-            if (accept == null) {
-                return null;
-            }
-
-            return new NewIONetChannel(accept, super.initializer());
-        } catch (IOException e) {
-            setState(getState(), ChannelState.INIT);
-            return null;
-        }
     }
 
     @Override
@@ -141,7 +127,17 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
 
         @Override
         public @Nullable NetChannel accept() {
-            return acceptInternal();
+            try {
+                SocketChannel accepted = channel().accept();
+                if (accepted == null) {
+                    return null;
+                }
+
+                return new NewIONetChannel(accepted, NewIONetServerChannel.super.initializer());
+            } catch (IOException e) {
+                setState(getState(), ChannelState.INIT);
+                return null;
+            }
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetServerChannel.java
@@ -24,6 +24,7 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.concurrent.Promise;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -63,6 +64,21 @@ public class NewIONetServerChannel extends AbstractChannel implements NetServerC
     @Override
     public Internal internal() {
         return internal;
+    }
+
+    @Override
+    public Promise<Void> bind(String host, int port) {
+        return bind(new InetSocketAddress(host, port));
+    }
+
+    @Override
+    public Promise<Void> bind(InetSocketAddress address) {
+        return ChannelTasks.bind(this, address);
+    }
+
+    @Override
+    public Promise<@Nullable NetChannel> accept() {
+        return ChannelTasks.accept(this);
     }
 
     private @Nullable NetChannel acceptInternal() {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
@@ -29,15 +29,13 @@ import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
+import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author yun
@@ -59,61 +57,42 @@ public final class WebSocketChannel implements NetChannel {
     }
 
     @Override
-    public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException {
-        delegate.connect(remote, timeOut, timeUnit);
+    public Internal internal() {
+        return delegate.internal();
     }
 
-    @Override
-    public void disconnect() {
-        delegate.disconnect();
-    }
-
-    @Override
-    public int read(Buffer buffer) {
-        return delegate.read(buffer);
-    }
-
-    @Override
-    public void write(Buffer buffer) {
-        delegate.write(buffer);
-    }
-
-    @Override
-    public void writeAndFlush(Buffer buffer) {
-        delegate.writeAndFlush(buffer);
-    }
-
-    public void writeAndFlush(WebSocketFrame frame) {
+    public Promise<Void> writeAndFlush(WebSocketFrame frame) {
         if (frame.subProtocol() != subProtocol) {
             throw new IllegalArgumentException("WebSocket frame subprotocol does not match channel subprotocol");
         }
 
         Buffer encoded = frame.encode();
+        IOEventLoop eventLoop = eventLoop();
+        if (!eventLoop.inEventLoop()) {
+            return eventLoop.submit(() -> writeEncoded(encoded));
+        }
+
+        Promise<Void> result = Promise.newPromise(eventLoop);
+        try {
+            writeEncoded(encoded);
+            result.success();
+        } catch (Throwable error) {
+            result.fail(error);
+        }
+        return result;
+    }
+
+    private void writeEncoded(Buffer encoded) {
         boolean accepted = false;
         try {
-            delegate.write(encoded);
+            delegate.internal().write(encoded);
             accepted = true;
-            delegate.flush();
+            delegate.internal().flush();
         } finally {
             if (!accepted) {
                 encoded.release();
             }
         }
-    }
-
-    @Override
-    public void flush() {
-        delegate.flush();
-    }
-
-    @Override
-    public void onWritabilityChanged(boolean isWritable) {
-        delegate.onWritabilityChanged(isWritable);
-    }
-
-    @Override
-    public boolean finishConnect() throws IOException {
-        return delegate.finishConnect();
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
@@ -33,9 +33,11 @@ import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketOption;
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author yun
@@ -59,6 +61,51 @@ public final class WebSocketChannel implements NetChannel {
     @Override
     public Internal internal() {
         return delegate.internal();
+    }
+
+    @Override
+    public Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit) {
+        return delegate.connect(host, port, timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+        return delegate.connect(remote, timeOut, timeUnit);
+    }
+
+    @Override
+    public Promise<Void> disconnect() {
+        return delegate.disconnect();
+    }
+
+    @Override
+    public Promise<Integer> read(Buffer buffer) {
+        return delegate.read(buffer);
+    }
+
+    @Override
+    public Promise<Void> write(Buffer buffer) {
+        return delegate.write(buffer);
+    }
+
+    @Override
+    public Promise<Void> writeAndFlush(Buffer buffer) {
+        return delegate.writeAndFlush(buffer);
+    }
+
+    @Override
+    public Promise<Void> flush() {
+        return delegate.flush();
+    }
+
+    @Override
+    public Promise<Void> onWritabilityChanged(boolean isWritable) {
+        return delegate.onWritabilityChanged(isWritable);
+    }
+
+    @Override
+    public Promise<Boolean> finishConnect() {
+        return delegate.finishConnect();
     }
 
     public Promise<Void> writeAndFlush(WebSocketFrame frame) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -136,7 +136,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
         Promise<Void> connectRequest = loop.submit(() -> {
             try {
-                channel.connect(remoteAddress, timeOut, timeUnit);
+                channel.internal().connect(remoteAddress, timeOut, timeUnit);
             } catch (Exception e) {
                 throw new ClientException("Failed to connect to " + remoteAddress, e);
             }
@@ -207,16 +207,9 @@ public class InetClient extends AbstractTransport<NetChannel> {
             return Promise.failedPromise(groups().secondaryGroup(), new ClientException("Not ready to connect"));
         }
 
-        IOEventLoop loop = channel.eventLoop();
-
-        return loop.submit(() -> {
-            try {
-                channel.writeAndFlush(buffer);
-            } catch (Exception e) {
-                log.error("Failed to send data = {}", buffer, e);
-                throw new ClientException("Failed to send data", e);
-            }
-        });
+        Promise<Void> result = channel.writeAndFlush(buffer);
+        result.onFailure(error -> log.error("Failed to send data = {}", buffer, error));
+        return result;
     }
 
     public <C> Promise<C> failedPromise(Throwable error) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -179,7 +179,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
                 continue;
             }
 
-            return netChannel.eventLoop().submit(() -> netChannel.writeAndFlush(buffer));
+            return netChannel.writeAndFlush(buffer);
         }
     }
 
@@ -258,7 +258,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
     private Promise<Void> bind(InetSocketAddress address) {
         return groups().primaryGroup().submit(() -> {
             try {
-                channel.bind(address);
+                channel.internal().bind(address);
             } catch (IOException e) {
                 throw new ServerException("Failed to bind to " + channel.localAddress(), e);
             }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -94,7 +94,7 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
         channel.chain().add(new WebSocketUpgradeHandler(this, key, upgradeResult));
 
         channel.eventLoop().submit(() -> {
-            channel.writeAndFlush(Buffer.alloc(request.toString()));
+            channel.internal().writeAndFlush(Buffer.alloc(request.toString()));
             return channel;
         }).addListener(result -> {
             if (result.isFailed() && !upgradeResult.isDone()) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -177,7 +177,7 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
         @Override
         protected void handleHead(NetChannel channel, String head) {
             HttpRequest parsed = handshaker.parseRequest(head);
-            channel.writeAndFlush(Buffer.alloc(handshaker.createResponse(parsed)));
+            channel.internal().writeAndFlush(Buffer.alloc(handshaker.createResponse(parsed)));
             installWebSocketCodec(channel, WebSocketSide.SERVER, handshaker.subProtocol());
             request = parsed;
         }

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
@@ -83,7 +83,7 @@ class ChannelInBoundHandlerChainImplTest {
         chain.addFirst(new RecordingOutboundHandler("first", order));
 
         chain.processChannelWrite(channel, buf);
-        channel.flush();
+        channel.internal().flush();
 
         assertThat(order).containsExactly("first", "second");
         Buffer written = channel.pollWritten();

--- a/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
@@ -1,0 +1,65 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.concurrent.Promise;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+class NetChannelInternalTest {
+
+    @Test
+    void public_operation_completes_through_event_loop_and_internal_operation_runs_immediately() throws Exception {
+        ChannelSecondaryIOEventLoop eventLoop = new ChannelSecondaryIOEventLoop("net-channel-internal-test");
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        eventLoop.start();
+        channel.register(eventLoop);
+
+        try {
+            Promise<Void> connect = channel.connect(
+                    new InetSocketAddress("127.0.0.1", 61613),
+                    1,
+                    TimeUnit.SECONDS
+            );
+
+            connect.await(2, TimeUnit.SECONDS);
+            assertThat(connect.isSuccess()).isTrue();
+            assertThat(channel.isConnected()).isTrue();
+
+            channel.internal().disconnect();
+
+            assertThat(channel.isConnected()).isFalse();
+        } finally {
+            channel.close();
+            eventLoop.gracefullyShutdown(1, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
@@ -24,6 +24,8 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.IOEventLoop;
+import org.traffichunter.titan.core.channel.NetChannel.Internal;
 import org.mockito.ArgumentCaptor;
 import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
 import org.traffichunter.titan.core.codec.websocket.WebSocketFrame;
@@ -35,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author yun
@@ -44,6 +47,11 @@ class WebSocketChannelTest {
     @Test
     void write_frame_directly_to_underlying_channel() {
         NetChannel delegate = mock(NetChannel.class);
+        Internal internal = mock(Internal.class);
+        IOEventLoop eventLoop = mock(IOEventLoop.class);
+        when(delegate.internal()).thenReturn(internal);
+        when(delegate.eventLoop()).thenReturn(eventLoop);
+        when(eventLoop.inEventLoop()).thenReturn(true);
         WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
         Buffer payload = Buffer.alloc("OK");
         WebSocketFrame frame = new WebSocketFrame(
@@ -58,8 +66,8 @@ class WebSocketChannelTest {
         channel.writeAndFlush(frame);
 
         ArgumentCaptor<Buffer> encoded = ArgumentCaptor.forClass(Buffer.class);
-        verify(delegate).write(encoded.capture());
-        verify(delegate).flush();
+        verify(internal).write(encoded.capture());
+        verify(internal).flush();
         assertThat(encoded.getValue().getBytes()).containsExactly((byte) 0x81, 0x02, 'O', 'K');
 
         encoded.getValue().release();

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
@@ -453,9 +453,18 @@ public class StompClientTcpChannel implements StompClientChannel {
         }
 
         try {
-            netChannel.writeAndFlush(frame.toBuffer());
+            Promise<Void> write = netChannel.writeAndFlush(frame.toBuffer());
+            write.onFailure(error -> {
+                if (receiptId != null && !receiptId.isBlank()) {
+                    receiptMap.remove(receiptId);
+                }
+                log.error("Failed to write STOMP frame. session={}, command={}", sessionId, frame.getCommand(), error);
+                exceptionHandler.handle(error);
+                close();
+                receiptPromise.fail(new StompNetChannelException("Failed to write STOMP frame", error));
+            });
             if (receiptId == null || receiptId.isBlank()) {
-                receiptPromise.success(frame);
+                write.onSuccess(ignored -> receiptPromise.success(frame));
             }
         } catch (Exception e) {
             if (receiptId != null && !receiptId.isBlank()) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
@@ -100,7 +100,7 @@ public class StompServerTcpChannel implements StompServerChannel {
         }
 
         NetChannel netChannel = asNetChannel(connection);
-        return netChannel.eventLoop().submit(() -> netChannel.writeAndFlush(buffer));
+        return netChannel.writeAndFlush(buffer);
     }
 
     @Override


### PR DESCRIPTION
## Motivation:

Channel APIs currently mix caller-facing operations with synchronous transport access. TLS and WebSocket handlers need a deliberate way to bypass protocol chains while selector operations must remain synchronous on their owning event loop.

## Modification:

- Change NetChannel and NetServerChannel operations to return event-loop-backed Promise results while preserving existing method names.
- Add synchronous Internal APIs for selector processing and raw transport writes.
- Update NewIO, in-memory, WebSocket, Inet transport, and STOMP integrations to use the appropriate API boundary.
- Add coverage for public asynchronous operations and immediate Internal operations.

## Result:

Channel callers use asynchronous APIs while transport internals retain deterministic synchronous access. WebSocket upgrade and encoded frame paths can bypass the outbound chain without exposing raw writes through the public API.

Validation: `./gradlew test`