### PR TITLE
Define the internal channel transport boundary

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
@@ -66,8 +66,8 @@ import org.traffichunter.titan.core.util.channel.chain.HandlerChain;
  * }</pre>
  *
  * <p>Handlers continue propagation by calling the {@code spark*} method on the supplied chain
- * context. If an outbound event reaches the end of the outbound chain, the buffer is written
- * to the {@link NetChannel}.</p>
+ * context. If an outbound event reaches the end of the outbound chain, the fully transformed
+ * buffer is written through {@link NetChannel.Internal} without entering the pipeline again.</p>
  *
  * @author yun
  */

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
@@ -29,7 +29,6 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Executes public channel operations on their owning event loop.
@@ -41,27 +40,8 @@ final class ChannelTasks {
     private ChannelTasks() {
     }
 
-    static Promise<Void> connect(
-            NetChannel channel,
-            InetSocketAddress remote,
-            long timeout,
-            TimeUnit unit
-    ) {
-        return execute(channel.eventLoop(), () -> {
-            try {
-                channel.internal().connect(remote, timeout, unit);
-            } catch (IOException e) {
-                throw new ChannelException("Failed to connect to " + remote, e);
-            }
-        });
-    }
-
     static Promise<Void> disconnect(NetChannel channel) {
-        return execute(channel.eventLoop(), channel.internal()::disconnect);
-    }
-
-    static Promise<Integer> read(NetChannel channel, Buffer buffer) {
-        return execute(channel.eventLoop(), () -> channel.internal().read(buffer));
+        return execute(channel.eventLoop(), channel::close);
     }
 
     static Promise<Void> write(NetChannel channel, Buffer buffer) {
@@ -72,27 +52,6 @@ final class ChannelTasks {
         return execute(channel.eventLoop(), () -> {
             channel.chain().processChannelWrite(channel, buffer);
             channel.internal().flush();
-        });
-    }
-
-    static Promise<Void> flush(NetChannel channel) {
-        return execute(channel.eventLoop(), channel.internal()::flush);
-    }
-
-    static Promise<Void> onWritabilityChanged(NetChannel channel, boolean isWritable) {
-        return execute(
-                channel.eventLoop(),
-                () -> channel.internal().onWritabilityChanged(isWritable)
-        );
-    }
-
-    static Promise<Boolean> finishConnect(NetChannel channel) {
-        return execute(channel.eventLoop(), () -> {
-            try {
-                return channel.internal().finishConnect();
-            } catch (IOException e) {
-                throw new ChannelException("Failed to finish channel connection", e);
-            }
         });
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
@@ -171,17 +171,18 @@ public final class InMemoryNetChannel implements NetChannel {
 
     @Override
     public Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
-        return ChannelTasks.connect(this, remote, timeOut, timeUnit);
+        return ChannelTasks.execute(eventLoop(), () -> {
+            chain.processChannelConnecting(this);
+            remoteAddress = remote;
+            connected = true;
+            active = true;
+            chain.processChannelAfterConnected(this);
+        });
     }
 
     @Override
     public Promise<Void> disconnect() {
         return ChannelTasks.disconnect(this);
-    }
-
-    @Override
-    public Promise<Integer> read(Buffer buffer) {
-        return ChannelTasks.read(this, buffer);
     }
 
     @Override
@@ -192,21 +193,6 @@ public final class InMemoryNetChannel implements NetChannel {
     @Override
     public Promise<Void> writeAndFlush(Buffer buffer) {
         return ChannelTasks.writeAndFlush(this, buffer);
-    }
-
-    @Override
-    public Promise<Void> flush() {
-        return ChannelTasks.flush(this);
-    }
-
-    @Override
-    public Promise<Void> onWritabilityChanged(boolean isWritable) {
-        return ChannelTasks.onWritabilityChanged(this, isWritable);
-    }
-
-    @Override
-    public Promise<Boolean> finishConnect() {
-        return ChannelTasks.finishConnect(this);
     }
 
     @Override
@@ -233,19 +219,6 @@ public final class InMemoryNetChannel implements NetChannel {
     }
 
     private final class InMemoryInternal implements Internal {
-
-        @Override
-        public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
-            remoteAddress = remote;
-            connected = true;
-            active = true;
-        }
-
-        @Override
-        public void disconnect() {
-            connected = false;
-            active = false;
-        }
 
         @Override
         public int read(Buffer buffer) {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -35,10 +35,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Client-side or accepted server-side network connection.
  *
- * <p>{@code NetChannel} is the data-carrying channel type. It can initiate connects, read
- * bytes into {@link Buffer}, enqueue outbound buffers, and flush them through its owning
- * {@link IOEventLoop}. Server transports also use this same type for accepted child
- * connections after the listening {@link NetServerChannel} accepts them.</p>
+ * <p>{@code NetChannel} is the pipeline-facing data channel. It initiates connections and
+ * sends outbound data through its owning {@link IOEventLoop}. Raw reads, flushes, and selector
+ * operations remain behind {@link Internal}. Server transports also use this type for accepted
+ * child connections after the listening {@link NetServerChannel} accepts them.</p>
  *
  * @author yun
  */
@@ -54,8 +54,13 @@ public interface NetChannel extends Channel {
     Promise<Void> connect(String host, int port, long timeOut, TimeUnit timeUnit);
 
     /**
-     * Returns the synchronous transport operations used by the owning I/O event loop and
-     * protocol handlers that must bypass the outbound chain.
+     * Returns raw transport operations intended for Titan's internal channel machinery.
+     *
+     * <p>Internal operations bypass the channel pipeline. They are used by I/O event loops,
+     * pipeline terminals, and protocol handlers that already hold transport-ready bytes, such
+     * as an encoded WebSocket frame or encrypted TLS record. This distinction is independent
+     * of scheduling: an internal operation is not the synchronous counterpart of a public
+     * channel operation.</p>
      */
     Internal internal();
 
@@ -68,12 +73,6 @@ public interface NetChannel extends Channel {
     @CanIgnoreReturnValue
     Promise<Void> disconnect();
 
-    /**
-     * Reads available bytes without blocking.
-     */
-    @CanIgnoreReturnValue
-    Promise<Integer> read(Buffer buffer);
-
     @CanIgnoreReturnValue
     Promise<Void> write(Buffer buffer);
 
@@ -83,41 +82,46 @@ public interface NetChannel extends Channel {
     @CanIgnoreReturnValue
     Promise<Void> writeAndFlush(Buffer buffer);
 
-    @CanIgnoreReturnValue
-    Promise<Void> flush();
-
-    Promise<Void> onWritabilityChanged(boolean isWritable);
-
-    /**
-     * Completes a pending non-blocking connect from the owning event-loop thread.
-     */
-    Promise<Boolean> finishConnect();
-
     boolean isConnected();
 
     /**
-     * Synchronous low-level channel operations.
+     * Raw transport operations that bypass the inbound and outbound channel pipelines.
      *
-     * <p>These methods execute immediately and are intended for the channel's I/O event-loop
-     * thread. A successful call means the operation was attempted or queued; it does not mean
-     * that the peer received the bytes.</p>
+     * <p>Callers are responsible for invoking these operations from the appropriate channel
+     * execution context. A returned value or normal method completion only means that the
+     * transport operation was attempted or queued; it does not mean that network I/O has
+     * completed.</p>
      */
     interface Internal {
 
-        void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException;
-
-        void disconnect();
-
+        /**
+         * Reads raw bytes from the underlying transport.
+         */
         int read(Buffer buffer);
 
+        /**
+         * Queues transport-ready bytes without entering the outbound pipeline.
+         */
         void write(Buffer buffer);
 
+        /**
+         * Queues transport-ready bytes and attempts to flush them without entering the pipeline.
+         */
         void writeAndFlush(Buffer buffer);
 
+        /**
+         * Attempts to flush queued raw bytes to the underlying transport.
+         */
         void flush();
 
+        /**
+         * Updates write-readiness interest for the underlying transport.
+         */
         void onWritabilityChanged(boolean isWritable);
 
+        /**
+         * Completes a pending non-blocking connection on the underlying transport.
+         */
         boolean finishConnect() throws IOException;
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetServerChannel.java
@@ -51,7 +51,7 @@ public interface NetServerChannel extends Channel {
     Promise<Void> bind(String host, int port);
 
     /**
-     * Returns the synchronous transport operations used by the server I/O event loop.
+     * Returns raw server transport operations that bypass channel-level orchestration.
      */
     Internal internal();
 
@@ -66,7 +66,9 @@ public interface NetServerChannel extends Channel {
     Promise<NetChannel> accept();
 
     /**
-     * Synchronous low-level server socket operations for the owning I/O event-loop thread.
+     * Raw listening-socket operations used by Titan's server transport.
+     *
+     * <p>These operations do not schedule work or propagate channel pipeline events.</p>
      */
     interface Internal {
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -25,7 +25,6 @@ package org.traffichunter.titan.core.channel;
 
 import io.netty.buffer.ByteBuf;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.concurrent.Promise;
@@ -80,17 +79,12 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
 
     @Override
     public Promise<Void> connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
-        return ChannelTasks.connect(this, remote, timeOut, timeUnit);
+        return ChannelTasks.execute(eventLoop(), () -> connectTransport(remote, timeOut, timeUnit));
     }
 
     @Override
     public Promise<Void> disconnect() {
         return ChannelTasks.disconnect(this);
-    }
-
-    @Override
-    public Promise<Integer> read(Buffer buffer) {
-        return ChannelTasks.read(this, buffer);
     }
 
     @Override
@@ -101,21 +95,6 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
     @Override
     public Promise<Void> writeAndFlush(Buffer buffer) {
         return ChannelTasks.writeAndFlush(this, buffer);
-    }
-
-    @Override
-    public Promise<Void> flush() {
-        return ChannelTasks.flush(this);
-    }
-
-    @Override
-    public Promise<Void> onWritabilityChanged(boolean isWritable) {
-        return ChannelTasks.onWritabilityChanged(this, isWritable);
-    }
-
-    @Override
-    public Promise<Boolean> finishConnect() {
-        return ChannelTasks.finishConnect(this);
     }
 
     @Override
@@ -196,44 +175,65 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
         }
     }
 
-    private final class NewIOInternal implements Internal {
+    private void connectTransport(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) {
+        if(isClosed()) {
+            throw new ChannelException("Channel is closed");
+        }
 
-        @Override
-        public void connect(InetSocketAddress remote, long timeOut, TimeUnit timeUnit) throws IOException {
-            if(isClosed()) {
-                throw new ChannelException("Channel is closed");
-            }
+        ChannelPromise promise = eventLoop().newPromise(this);
+        connectPromise = promise;
 
-            ChannelPromise promise = eventLoop().newPromise(NewIONetChannel.this);
-            connectPromise = promise;
-
+        try {
             if(connect0(remote)) {
-                chain().processChannelConnecting(NewIONetChannel.this);
+                chain().processChannelConnecting(this);
                 completeConnect();
-                chain().processChannelAfterConnected(NewIONetChannel.this);
-                eventLoop().ioSelector().registerRead(NewIONetChannel.this);
-                accept(NewIONetChannel.this);
+                chain().processChannelAfterConnected(this);
+                eventLoop().ioSelector().registerRead(this);
+                accept(this);
                 return;
             }
+        } catch (IOException e) {
+            throw new ChannelException("Failed to connect to " + remote, e);
+        }
 
-            if(timeOut > 0) {
-                ScheduledPromise<?> timeoutPromise = eventLoop().schedule(
-                    () -> {
-                        if (promise.isDone()) {
-                            return;
-                        }
-                        promise.fail(new ChannelException("Connect timeout"));
-                        close();
-                    }, timeOut, timeUnit);
+        if(timeOut > 0) {
+            ScheduledPromise<?> timeoutPromise = eventLoop().schedule(
+                () -> {
+                    if (promise.isDone()) {
+                        return;
+                    }
+                    promise.fail(new ChannelException("Connect timeout"));
+                    close();
+                }, timeOut, timeUnit);
 
-                promise.addListener(f -> timeoutPromise.cancel());
+            promise.addListener(f -> timeoutPromise.cancel());
+        }
+    }
+
+    private boolean connect0(InetSocketAddress remote) throws IOException {
+        boolean connected = false;
+        try {
+            boolean connect = channel().connect(remote);
+            if(!connect) {
+                IOEventLoop eventLoop = eventLoop();
+                eventLoop.register(() -> {
+                    try {
+                        eventLoop.ioSelector().registerConnect(this);
+                    } catch (IOException e) {
+                        throw new ChannelException("Failed to register connect event", e);
+                    }
+                });
+            }
+            connected = true;
+            return connect;
+        } finally {
+            if(!connected) {
+                close();
             }
         }
+    }
 
-        @Override
-        public void disconnect() {
-            close();
-        }
+    private final class NewIOInternal implements Internal {
 
         @Override
         public int read(Buffer buffer) {
@@ -371,29 +371,6 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
                 failConnect(e);
                 close();
                 throw e;
-            }
-        }
-
-        private boolean connect0(InetSocketAddress remote) throws IOException {
-            boolean connected = false;
-            try {
-                boolean connect = channel().connect(remote);
-                if(!connect) {
-                    IOEventLoop eventLoop = eventLoop();
-                    eventLoop.register(() -> {
-                        try {
-                            eventLoop.ioSelector().registerConnect(NewIONetChannel.this);
-                        } catch (IOException e) {
-                            throw new ChannelException("Failed to register connect event", e);
-                        }
-                    });
-                }
-                connected = true;
-                return connect;
-            } finally {
-                if(!connected) {
-                    close();
-                }
             }
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
@@ -79,11 +79,6 @@ public final class WebSocketChannel implements NetChannel {
     }
 
     @Override
-    public Promise<Integer> read(Buffer buffer) {
-        return delegate.read(buffer);
-    }
-
-    @Override
     public Promise<Void> write(Buffer buffer) {
         return delegate.write(buffer);
     }
@@ -91,21 +86,6 @@ public final class WebSocketChannel implements NetChannel {
     @Override
     public Promise<Void> writeAndFlush(Buffer buffer) {
         return delegate.writeAndFlush(buffer);
-    }
-
-    @Override
-    public Promise<Void> flush() {
-        return delegate.flush();
-    }
-
-    @Override
-    public Promise<Void> onWritabilityChanged(boolean isWritable) {
-        return delegate.onWritabilityChanged(isWritable);
-    }
-
-    @Override
-    public Promise<Boolean> finishConnect() {
-        return delegate.finishConnect();
     }
 
     public Promise<Void> writeAndFlush(WebSocketFrame frame) {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -134,13 +134,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
         IOEventLoop loop = channel.eventLoop();
         Promise<NetChannel> connectResult = Promise.newPromise(loop);
 
-        Promise<Void> connectRequest = loop.submit(() -> {
-            try {
-                channel.internal().connect(remoteAddress, timeOut, timeUnit);
-            } catch (Exception e) {
-                throw new ClientException("Failed to connect to " + remoteAddress, e);
-            }
-        });
+        Promise<Void> connectRequest = channel.connect(remoteAddress, timeOut, timeUnit);
 
         connectRequest.addListener(promise -> {
             if (!promise.isSuccess()) {

--- a/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
@@ -24,9 +24,11 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import org.junit.jupiter.api.Test;
+import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.util.buffer.Buffer;
 
-import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,29 +39,51 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NetChannelInternalTest {
 
     @Test
-    void public_operation_completes_through_event_loop_and_internal_operation_runs_immediately() throws Exception {
+    void public_write_enters_pipeline_and_internal_write_bypasses_it() throws Exception {
         ChannelSecondaryIOEventLoop eventLoop = new ChannelSecondaryIOEventLoop("net-channel-internal-test");
         InMemoryNetChannel channel = new InMemoryNetChannel();
+        AtomicInteger pipelineWrites = new AtomicInteger();
+        channel.chain().add(new ChannelOutBoundHandler() {
+            @Override
+            public void sparkChannelWrite(
+                    NetChannel writtenChannel,
+                    Buffer buffer,
+                    ChannelOutBoundHandlerChainImpl chain
+            ) {
+                pipelineWrites.incrementAndGet();
+                chain.sparkChannelWrite(writtenChannel, buffer);
+            }
+        });
+
         eventLoop.start();
         channel.register(eventLoop);
 
         try {
-            Promise<Void> connect = channel.connect(
-                    new InetSocketAddress("127.0.0.1", 61613),
-                    1,
-                    TimeUnit.SECONDS
-            );
+            Buffer pipelineBuffer = Buffer.alloc("pipeline");
+            Promise<Void> publicWrite = channel.writeAndFlush(pipelineBuffer);
+            publicWrite.await(2, TimeUnit.SECONDS);
+            pipelineBuffer.release();
 
-            connect.await(2, TimeUnit.SECONDS);
-            assertThat(connect.isSuccess()).isTrue();
-            assertThat(channel.isConnected()).isTrue();
+            assertThat(publicWrite.isSuccess()).isTrue();
+            assertThat(pipelineWrites).hasValue(1);
+            release(channel.pollWritten());
 
-            channel.internal().disconnect();
+            Buffer internalBuffer = Buffer.alloc("internal");
+            channel.internal().writeAndFlush(internalBuffer);
+            internalBuffer.release();
 
-            assertThat(channel.isConnected()).isFalse();
+            assertThat(pipelineWrites).hasValue(1);
+            release(channel.pollWritten());
         } finally {
             channel.close();
             eventLoop.gracefullyShutdown(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void release(@Nullable Buffer buffer) {
+        assertThat(buffer).isNotNull();
+        if (buffer != null) {
+            buffer.release();
         }
     }
 }


### PR DESCRIPTION
## Motivation:

Clarify the boundary between pipeline-facing channel APIs and raw transport operations before integrating TLS. The previous `Internal` contract was described as synchronous and duplicated several public methods, which obscured whether an operation entered the channel pipeline.

## Modification:

- Define `NetChannel.Internal` as Titan's pipeline-bypassing raw transport API.
- Keep connection lifecycle and outbound pipeline entry points on `NetChannel`.
- Restrict raw reads, flushes, selector readiness, and connect completion to `Internal`.
- Remove duplicated raw operation delegates from channel implementations.
- Route `InetClient` connections through the public channel lifecycle API.
- Replace the execution-timing test with a pipeline entry and bypass contract test.

## Result:

Channel pipeline operations and raw transport operations now have distinct API boundaries, providing a stable foundation for writing pre-encoded WebSocket frames and encrypted TLS records without re-entering the pipeline.

Validation:

- `./gradlew :core:test`
- `./gradlew test`
