### PR TITLE
Prepare Titan 0.7.4 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           go-version: "1.22"
 
+      - name: Verify release documentation
+        run: |
+          ./gradlew --no-daemon updateReleaseDocsVersion \
+            -PreleaseVersion="${GITHUB_REF_NAME}" \
+            --no-configuration-cache
+          git diff --exit-code -- README.md docs
+
       - name: Test Go CLI
         working-directory: titan-cli
         run: go test ./...
@@ -95,7 +102,15 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${GITHUB_REF_NAME}" release-assets/* --verify-tag --title "Release ${GITHUB_REF_NAME}" --generate-notes
+        run: |
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" release-assets/* --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" release-assets/* \
+              --verify-tag \
+              --title "Release ${GITHUB_REF_NAME}" \
+              --generate-notes
+          fi
 
       - name: Publish to Maven Central
         env:

--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@
 [![Maven Central](https://img.shields.io/maven-central/v/org.traffichunter.titan/titan-stomp)](https://central.sonatype.com/artifact/org.traffichunter.titan/titan-stomp)
 [![CI](https://github.com/traffic-hunter/titan/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/traffic-hunter/titan/actions/workflows/ci.yml)
 
-Titan is a lightweight message dispatch platform focused on STOMP over TCP.
+Titan is a lightweight message dispatch platform focused on STOMP over TCP and
+WebSocket.
 It provides a custom NIO transport, destination routing, fanout delivery, and
 Spring Boot client integration.
 
 ## Highlights
 
 - STOMP over TCP server and client.
+- STOMP over WebSocket for native, Vert.x, and Spring clients.
+- TLS transport support through PKCS12 or JKS key stores.
 - Exact destination matching with one FIFO dispatcher queue per destination.
 - Fanout delivery for publish-subscribe scenarios.
 - Pluggable runtime through SPI.
@@ -39,32 +42,32 @@ repositories {
 Spring client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.3")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.4")
 ```
 
 STOMP client/server:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.3")
+implementation("org.traffichunter.titan:titan-stomp:0.7.4")
 ```
 
 Fanout support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-fanout:0.7.3")
+implementation("org.traffichunter.titan:titan-fanout:0.7.4")
 ```
 
 Monitoring support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-monitor:0.7.3")
+implementation("org.traffichunter.titan:titan-monitor:0.7.4")
 ```
 
 Bootstrap/runtime support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.3")
-implementation("org.traffichunter.titan:titan-core:0.7.3")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.4")
+implementation("org.traffichunter.titan:titan-core:0.7.4")
 ```
 
 ## Standalone Server
@@ -74,15 +77,15 @@ Download the executable server jar from GitHub Releases.
 Using `curl`:
 
 ```bash
-curl -L -o titan-server-0.7.3.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.3/titan-server-0.7.3.jar
+curl -L -o titan-server-0.7.4.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.4/titan-server-0.7.4.jar
 ```
 
 Using `wget`:
 
 ```bash
-wget -O titan-server-0.7.3.jar \
-  https://github.com/traffic-hunter/titan/releases/download/0.7.3/titan-server-0.7.3.jar
+wget -O titan-server-0.7.4.jar \
+  https://github.com/traffic-hunter/titan/releases/download/0.7.4/titan-server-0.7.4.jar
 ```
 
 Create `titan-env.yml`.
@@ -110,10 +113,32 @@ titan:
         fanout-mode: "virtual"
 ```
 
+To expose STOMP over WebSocket, set `transport: websocket` and configure the
+upgrade path under `transport-options`.
+
+```yaml
+      transport: websocket
+      port: 8080
+      transport-options:
+        path: "/stomp"
+```
+
+TLS is configured separately from transport and protocol options.
+
+```yaml
+      tls:
+        side: server
+        client-auth: none
+        path: /etc/titan/server.p12
+        type: PKCS12
+        store-password: store-secret
+        key-password: key-secret
+```
+
 Run Titan.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.4.jar
 ```
 
 Inspect the running server from a terminal. The release page provides
@@ -122,7 +147,7 @@ CLI from source while developing.
 
 ```bash
 # prebuilt archive example
-tar -xzf titan-cli-0.7.3-linux-amd64.tar.gz
+tar -xzf titan-cli-0.7.4-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 
 # source checkout example
@@ -213,7 +238,7 @@ Build the standalone server jar:
 
 ## Scope
 
-- Primary production focus is STOMP over TCP.
+- Primary production focus is STOMP over TCP and WebSocket.
 - Titan is a networked dispatch/fanout runtime, not an in-process event bus.
 - Reliability strategies such as nack/retry/error-policy in Spring listener container are still evolving.
 - Monitoring currently focuses on local JVM and dispatcher queue visibility.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,11 +37,11 @@ tasks.register("updateReleaseDocsVersion") {
         .orElse(providers.environmentVariable("GITHUB_REF_NAME"))
         .map { it.removePrefix("refs/tags/") }
 
-    val docs = listOf(
+    val docs = files(
         layout.projectDirectory.file("README.md"),
-        layout.projectDirectory.file("docs/examples/client.md"),
-        layout.projectDirectory.file("docs/examples/server.md"),
-        layout.projectDirectory.file("docs/examples/spring-client.md"),
+        fileTree(layout.projectDirectory.dir("docs")) {
+            include("**/*.md")
+        },
     )
 
     inputs.property("releaseVersion", releaseVersion)
@@ -59,15 +59,16 @@ tasks.register("updateReleaseDocsVersion") {
         val releasePathPattern = Regex("""(releases/download/)\d+\.\d+\.\d+""")
         val serverJarPattern = Regex("""(titan-server-)\d+\.\d+\.\d+(\.jar)""")
         val cliArchivePattern = Regex("""(titan-cli-)\d+\.\d+\.\d+(-[a-z]+-[a-z0-9]+)\.(tar\.gz|zip)""")
+        val documentedVersionPattern = Regex("""(Titan `)\d+\.\d+\.\d+(`)""")
 
-        docs.forEach { doc ->
-            val file = doc.asFile
+        docs.files.sortedBy { it.path }.forEach { file ->
             val text = file.readText()
             val updated = text
                 .replace(dependencyPattern) { match -> match.groupValues[1] + version }
                 .replace(releasePathPattern) { match -> match.groupValues[1] + version }
                 .replace(serverJarPattern) { match -> match.groupValues[1] + version + match.groupValues[2] }
                 .replace(cliArchivePattern) { match -> match.groupValues[1] + version + match.groupValues[2] + "." + match.groupValues[3] }
+                .replace(documentedVersionPattern) { match -> match.groupValues[1] + version + match.groupValues[2] }
 
             if (updated != text) {
                 file.writeText(updated)

--- a/core/src/main/java/org/traffichunter/titan/core/spi/TcpServerEngineProvider.java
+++ b/core/src/main/java/org/traffichunter/titan/core/spi/TcpServerEngineProvider.java
@@ -34,6 +34,7 @@ import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
 import org.traffichunter.titan.core.codec.LineFrameChannelDecoder;
+import org.traffichunter.titan.core.net.TlsContextFactory;
 import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 
@@ -74,8 +75,11 @@ public final class TcpServerEngineProvider implements NetworkServerEngineProvide
     public ManagedServer create(final ServerSettings settings) {
         EventLoopGroups groups = EventLoopGroups.group(settings.primaryThreads(), settings.secondaryThreads());
         InetServerOption inetOption = buildOption(settings.resolvedTransportOptions());
-        InetServer server = InetServer.open(groups)
-                .option(inetOption)
+        InetServer server = InetServer.open(groups).option(inetOption);
+        if (settings.tls().enabled()) {
+            server.tls(TlsContextFactory.create(settings.tls()));
+        }
+        server
                 .onChannel(channel -> {
                     channel.chain().add(new LineFrameChannelDecoder());
                     inboundHandlers.forEach(inboundHandler ->

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,4 +114,4 @@ before using Titan for reliability-sensitive workloads.
 </tr>
 </tbody></table>
 
-<sub>Documentation examples target Titan `0.7.3` and JDK 21 or newer.</sub>
+<sub>Documentation examples target Titan `0.7.4` and JDK 21 or newer.</sub>

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.3")
+implementation("org.traffichunter.titan:titan-stomp:0.7.4")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.3")
-implementation("org.traffichunter.titan:titan-core:0.7.3")
-implementation("org.traffichunter.titan:titan-stomp:0.7.3")
-implementation("org.traffichunter.titan:titan-fanout:0.7.3")
+implementation("org.traffichunter.titan:titan-bootstrap:0.7.4")
+implementation("org.traffichunter.titan:titan-core:0.7.4")
+implementation("org.traffichunter.titan:titan-stomp:0.7.4")
+implementation("org.traffichunter.titan:titan-fanout:0.7.4")
 ```
 
 ### `titan-env.yml`
@@ -43,6 +43,19 @@ titan:
         heartbeat-y: "1000"
         fanout-mode: "virtual"
 ```
+
+For STOMP over WebSocket, change the transport and port and add an upgrade
+path:
+
+```yaml
+      transport: websocket
+      port: 8080
+      transport-options:
+        path: "/stomp"
+```
+
+See [Configuration](../reference/configuration.md) for TLS key-store settings.
+Custom WebSocket clients must request the `v12.stomp` subprotocol.
 
 ### Start
 

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.3")
+implementation("org.traffichunter.titan:titan-spring-client:0.7.4")
 ```
 
 ## Enable Titan

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -34,7 +34,7 @@ capacity or pressure.
 Prebuilt releases include `titan-cli-<version>-<os>-<arch>.tar.gz` archives.
 
 ```bash
-tar -xzf titan-cli-0.7.3-linux-amd64.tar.gz
+tar -xzf titan-cli-0.7.4-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Run a Titan server and verify it from the monitoring API.
 ## Requirements
 
 * JDK 21 or newer
-* A Titan `0.7.3` standalone server JAR from GitHub Releases
+* A Titan `0.7.4` standalone server JAR from GitHub Releases
 
 ## 1. Create the environment
 
@@ -37,7 +37,7 @@ titan:
 
 ```bash
 java -Dtitan.environment.path=./titan-env.yml \
-  -jar titan-server-0.7.3.jar
+  -jar titan-server-0.7.4.jar
 ```
 
 Titan now accepts STOMP connections on `61613` and exposes its local monitor on
@@ -66,3 +66,4 @@ a message travel through the same destination.
 * Learn [how Titan works](concepts/how-titan-works.md).
 * Understand [dispatch routing](concepts/destinations.md).
 * Add terminal visibility with [Monitoring and CLI](operate/monitoring.md).
+* Configure [WebSocket or TLS transport](reference/configuration.md).

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,7 +4,7 @@ Titan reads its standalone runtime configuration from `titan-env.yml`. Pass the
 path with the `titan.environment.path` system property.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.4.jar
 ```
 
 ## Server
@@ -15,6 +15,7 @@ java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
 | `protocol` | Protocol engine | `stomp` |
 | `host` | Bind address | `0.0.0.0` |
 | `port` | Bind port | `61613` |
+| `transport` | Network transport | `tcp` or `websocket` |
 | `transport-options` | TCP and channel settings | See below |
 | `protocol-options` | STOMP and fanout settings | See below |
 
@@ -24,6 +25,7 @@ java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.3.jar
 | --- | --- |
 | `reuse-address` | Allow address reuse on the server socket |
 | `child-tcp-no-delay` | Disable Nagle's algorithm on accepted connections |
+| `path` | WebSocket HTTP upgrade path | `/stomp` |
 
 Configuration option values are represented as strings in the current YAML
 format.
@@ -40,6 +42,63 @@ format.
 
 Heartbeat values must be zero or greater. A zero value disables that heartbeat
 direction.
+
+## WebSocket
+
+Use the `websocket` transport to carry STOMP frames through an HTTP upgrade.
+The configured port accepts WebSocket connections at the selected path.
+
+```yaml
+titan:
+  servers:
+    - name: stomp-websocket
+      transport: websocket
+      protocol: stomp
+      host: 0.0.0.0
+      port: 8080
+      transport-options:
+        path: "/stomp"
+      protocol-options:
+        supported-versions: "1.2"
+```
+
+Native and Vert.x clients use the same STOMP behavior after the WebSocket
+upgrade. Spring clients can connect with
+`spring.titan.endpoint=ws://localhost:8080/stomp`.
+Custom WebSocket clients must negotiate the `v12.stomp` subprotocol.
+
+## TLS
+
+TLS settings are declared in the dedicated `tls` section. The key store must be
+readable by the Titan process.
+
+```yaml
+titan:
+  servers:
+    - name: secure-stomp
+      transport: tcp
+      protocol: stomp
+      host: 0.0.0.0
+      port: 61614
+      tls:
+        side: server
+        client-auth: none
+        path: /etc/titan/server.p12
+        type: PKCS12
+        store-password: store-secret
+        key-password: key-secret
+        verify-hostname: false
+```
+
+| Key | Purpose | Default |
+| --- | --- | --- |
+| `side` | TLS endpoint role | `server` |
+| `client-auth` | Client certificate policy: `none`, `want`, or `need` | `none` |
+| `path` | PKCS12 or JKS key-store path | Required |
+| `type` | Key-store format | `PKCS12` |
+| `store-password` | Password used to open the key store | Empty |
+| `key-password` | Password used to access the private key | Empty |
+| `verify-hostname` | Enable endpoint identification where applicable | `false` |
 
 ## Monitor
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -6,8 +6,8 @@ runtime layers they actually use.
 | Artifact | Responsibility |
 | --- | --- |
 | `titan-bootstrap` | Environment loading and runtime startup |
-| `titan-core` | Event loops, channels, transport, dispatch, and concurrency primitives |
-| `titan-stomp` | STOMP codec, server, client, and engine integration |
+| `titan-core` | Event loops, channels, TCP/WebSocket/TLS transport, dispatch, and concurrency primitives |
+| `titan-stomp` | STOMP codec, TCP/WebSocket server, clients, and engine integration |
 | `titan-fanout` | One-to-many dispatch gateways and exporters |
 | `titan-monitor` | JVM and dispatcher monitoring snapshots and HTTP endpoints |
 | `titan-spring-client` | Spring Boot auto-configuration, `TitanTemplate`, and `@TitanListener` |
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.traffichunter.titan:titan-stomp:0.7.3")
+    implementation("org.traffichunter.titan:titan-stomp:0.7.4")
 }
 ```
 

--- a/docs/reference/project-scope.md
+++ b/docs/reference/project-scope.md
@@ -1,11 +1,12 @@
 # Project scope
 
-Titan's production focus is real-time STOMP dispatch over TCP.
+Titan's production focus is real-time STOMP dispatch over TCP and WebSocket.
 
 ## In scope
 
 * STOMP server and client connections
-* TCP and WebSocket client transport
+* TCP and WebSocket server and client transport
+* TLS-protected transport
 * Exact destination routing through per-destination FIFO dispatcher queues
 * In-memory fanout delivery
 * Native Java and Spring Boot clients

--- a/docs/why-titan.md
+++ b/docs/why-titan.md
@@ -8,7 +8,7 @@ and the runtime should stay small enough to understand and operate directly.
 
 Titan is a good fit when your system needs:
 
-* Real-time delivery over STOMP and TCP
+* Real-time delivery over STOMP using TCP or WebSocket
 * Exact destination matching backed by a FIFO dispatcher queue
 * Publish-subscribe fanout
 * Java or Spring Boot integration

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
@@ -33,6 +33,8 @@ import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.net.TlsContextFactory;
+import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 import org.traffichunter.titan.core.transport.stomp.StompServer;
 import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
@@ -80,7 +82,11 @@ public class StompServerEngineProvider implements NetworkServerEngineProvider {
         StompServerOption stompServerOption = buildOption(settings.resolvedProtocolOptions(), inetOption);
 
         String path = settings.resolvedTransportOptions().getOrDefault("path", "/stomp");
-        StompServer server = StompServer.open(groups, stompServerOption);
+        InetServer inetServer = InetServer.open(groups);
+        if (settings.tls().enabled()) {
+            inetServer.tls(TlsContextFactory.create(settings.tls()));
+        }
+        StompServer server = StompServer.open(groups, inetServer, stompServerOption);
         if (webSocket) {
             server.upgradeWebsocket(path);
         }


### PR DESCRIPTION
## Motivation:

Prepare Titan 0.7.4 for release with accurate documentation and a verified standalone runtime. Bootstrap TLS settings were bound from YAML but were not applied to the underlying TCP and STOMP servers.

## Modification:

- Apply configured TLS contexts to bootstrap-managed TCP and STOMP servers.
- Update README and GitBook examples to 0.7.4.
- Document WebSocket, `v12.stomp`, and TLS key-store configuration.
- Expand the documentation version task to cover all GitBook Markdown files.
- Verify documentation versions during release and make GitHub Release asset uploads repeatable.

## Result:

Titan 0.7.4 documentation matches the published artifact names, and standalone TCP, WebSocket, TLS, and monitoring paths are release-ready.

Validated with:

- `go test ./...`
- `./gradlew --no-daemon -PversionName=0.7.4 clean build --stacktrace`
- Standalone TCP STOMP `CONNECTED`
- WebSocket `101 Switching Protocols`
- TLS 1.3 and STOMP-over-TLS `CONNECTED`
- Monitor health `UP`
