### PR TITLE
Sync 0.7.4 buffer ownership hotfix to main

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
@@ -33,6 +33,7 @@ import org.traffichunter.titan.core.util.IdGenerator;
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
 import java.time.Instant;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
@@ -187,6 +188,23 @@ public abstract class AbstractChannel implements Channel {
             sc.close();
         } catch (IOException e) {
             throw new ChannelException("Failed to close channel");
+        } finally {
+            closeHandlerChain();
+        }
+    }
+
+    private void closeHandlerChain() {
+        IOEventLoop owner = eventLoop;
+        if (!registered || owner == null || owner.inEventLoop()) {
+            chain.close();
+            return;
+        }
+
+        try {
+            owner.register(chain::close);
+        } catch (RejectedExecutionException e) {
+            // The owner no longer executes channel work, so direct cleanup cannot race decoding.
+            chain.close();
         }
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
@@ -24,10 +24,12 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.Noop;
 import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.core.util.channel.chain.HandlerChain;
 
 /**
  * Owns the inbound and outbound handler pipelines for a channel.
@@ -72,13 +74,14 @@ import org.traffichunter.titan.core.util.channel.chain.HandlerChain;
  * @author yun
  */
 @Slf4j
-public class ChannelHandlerChain {
+public class ChannelHandlerChain implements AutoCloseable {
 
     private final ChannelOutBoundHandlerChainImpl outHead;
     private ChannelOutBoundHandlerChainImpl outTail;
 
     private final ChannelInBoundHandlerChainImpl inHead;
     private ChannelInBoundHandlerChainImpl inTail;
+    private boolean closed;
 
     public ChannelHandlerChain() {
         inHead = inTail = new ChannelInBoundHandlerChainImpl(new ChannelInBoundHandlerHead());
@@ -202,6 +205,42 @@ public class ChannelHandlerChain {
         } catch (Exception e) {
             log.error("Failed to process write", e);
             channel.close();
+        }
+    }
+
+    /**
+     * Closes stateful handlers once, including handlers installed in both pipelines.
+     */
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        Set<Object> closedHandlers = Collections.newSetFromMap(new IdentityHashMap<>());
+        ChannelInBoundHandlerChainImpl inbound = inHead.next;
+        while (inbound != null) {
+            closeHandler(inbound.handler, closedHandlers);
+            inbound = inbound.next;
+        }
+
+        ChannelOutBoundHandlerChainImpl outbound = outHead.next;
+        while (outbound != null) {
+            closeHandler(outbound.handler, closedHandlers);
+            outbound = outbound.next;
+        }
+    }
+
+    private static void closeHandler(Object handler, Set<Object> closedHandlers) {
+        if (!(handler instanceof AutoCloseable closeable) || !closedHandlers.add(handler)) {
+            return;
+        }
+
+        try {
+            closeable.close();
+        } catch (Exception e) {
+            log.warn("Failed to close channel handler {}", handler.getClass().getName(), e);
         }
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
@@ -37,6 +37,7 @@ import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -157,6 +158,21 @@ public final class InMemoryNetChannel implements NetChannel {
         clearQueue(inbound);
         clearQueue(pendingWrites);
         clearQueue(flushedWrites);
+        closeHandlerChain();
+    }
+
+    private void closeHandlerChain() {
+        IOEventLoop owner = eventLoop;
+        if (!registered || owner == null || owner.inEventLoop()) {
+            chain.close();
+            return;
+        }
+
+        try {
+            owner.register(chain::close);
+        } catch (RejectedExecutionException e) {
+            chain.close();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
@@ -39,7 +39,7 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  * @author yun
  */
 @Slf4j
-public abstract class ChannelDecoder implements ChannelInBoundHandler {
+public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoCloseable {
 
     /**
      * Combines a previously retained buffer with newly received bytes.
@@ -103,6 +103,20 @@ public abstract class ChannelDecoder implements ChannelInBoundHandler {
         if (!pending.isReadable()) {
             pending.release();
             mergeBuffer = null;
+        }
+    }
+
+    /**
+     * Releases bytes retained while waiting for a complete frame.
+     *
+     * <p>Channel lifecycle code invokes this method on the owning event-loop thread.</p>
+     */
+    @Override
+    public void close() {
+        Buffer pending = mergeBuffer;
+        mergeBuffer = null;
+        if (pending != null && pending.byteBuf().refCnt() > 0) {
+            pending.release();
         }
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsHandler.java
@@ -369,6 +369,7 @@ class JdkTlsHandler extends TlsHandler {
     private Buffer wrapCloseNotify() throws SSLException {
         Buffer source = Buffer.empty();
         Buffer encrypted = Buffer.alloc(sslEngine.getSession().getPacketBufferSize());
+        boolean success = false;
 
         try {
 
@@ -395,9 +396,13 @@ class JdkTlsHandler extends TlsHandler {
                 }
             }
 
+            success = true;
             return encrypted;
         } finally {
             source.release();
+            if (!success) {
+                encrypted.release();
+            }
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/AutoManagedByteBufAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/AutoManagedByteBufAllocator.java
@@ -35,6 +35,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.Assert;
 
 /**
+ * <h3>
+ * DEPRECATED
+ * </h3>
+ *
  * ByteBuf allocator that wraps allocated buffers with a cleaner-backed release guard.
  *
  * <p>The wrapper does not replace normal reference-count ownership. Callers should still
@@ -43,6 +47,7 @@ import org.traffichunter.titan.core.util.Assert;
  *
  * @author yungwang-o
  */
+@Deprecated(forRemoval = true)
 public class AutoManagedByteBufAllocator extends AbstractByteBufAllocator {
 
     private final ByteBufAllocator delegate;
@@ -147,10 +152,10 @@ public class AutoManagedByteBufAllocator extends AbstractByteBufAllocator {
         public void run() {
             if (cleaned.compareAndSet(false, true)) {
                 try {
-                    int rc = buf.refCnt();
-                    if (rc > 0) {
-                        // release all outstanding references
-                        buf.release(rc);
+                    if (buf.refCnt() > 0) {
+                        // Release only the reference owned by this wrapper. Retained derived
+                        // buffers own their references independently.
+                        buf.release();
                     }
                 } catch (Throwable t) {
                     // swallow errors to avoid exceptions from cleaner thread

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
@@ -37,7 +37,7 @@ import org.traffichunter.titan.core.util.Clearable;
  * @author yun
  */
 @NullMarked
-@Deprecated(since = "0.7.2")
+@Deprecated(since = "0.7.2", forRemoval = true)
 public final class BufferAccumulator implements Clearable {
 
     private @Nullable Buffer accumulator;
@@ -137,7 +137,7 @@ public final class BufferAccumulator implements Clearable {
             );
         }
 
-        return accumulator.readSlice(length);
+        return accumulator.readRetainedSlice(length);
     }
 
     /**
@@ -149,7 +149,7 @@ public final class BufferAccumulator implements Clearable {
         if(accumulator == null) {
             throw new IllegalStateException("Accumulator is empty");
         }
-        Buffer result = accumulator.slice();
+        Buffer result = accumulator.retainSlice();
         clear();
         return result;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
@@ -28,6 +28,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+
+import io.netty.buffer.ByteBufAllocator;
 import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.Assert;
 
@@ -61,15 +63,15 @@ public class InternalBuffer implements Buffer {
     }
 
     public InternalBuffer(final int initialCapacity, final int maxCapacity) {
-        this.buf = AutoManagedByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
+        this.buf = ByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
     }
 
     public InternalBuffer(final int initialCapacity) {
-        this.buf = AutoManagedByteBufAllocator.DEFAULT.directBuffer(initialCapacity);
+        this.buf = ByteBufAllocator.DEFAULT.directBuffer(initialCapacity);
     }
 
     public InternalBuffer(final byte[] bytes) {
-        this.buf = AutoManagedByteBufAllocator.DEFAULT.directBuffer(bytes.length).writeBytes(bytes);
+        this.buf = ByteBufAllocator.DEFAULT.directBuffer(bytes.length).writeBytes(bytes);
     }
 
     public InternalBuffer(final ByteBuf buf) {
@@ -432,7 +434,7 @@ public class InternalBuffer implements Buffer {
 
     @Override
     public Buffer copy() {
-        return buf.isReadOnly() ? this : new InternalBuffer(buf.copy());
+        return new InternalBuffer(buf.copy());
     }
 
     @Override
@@ -565,8 +567,19 @@ public class InternalBuffer implements Buffer {
     }
 
     private void reAlloc(final int capacity) {
-        ByteBuf temp = buf.alloc().directBuffer(capacity);
-        temp.writeBytes(buf);
-        buf = temp;
+        ByteBuf previous = buf;
+        ByteBuf replacement = previous.alloc().directBuffer(capacity);
+        boolean replaced = false;
+        try {
+            replacement.writeBytes(previous, previous.readerIndex(), previous.readableBytes());
+            buf = replacement;
+            replaced = true;
+        } finally {
+            if (replaced) {
+                previous.release();
+            } else {
+                replacement.release();
+            }
+        }
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
@@ -5,15 +5,22 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
+import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DisplayNameGenerator.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author yun
@@ -51,6 +58,60 @@ class ChannelDecoderTest {
 
         assertThat(chain.frames).isEmpty();
         assertThat(in.byteBuf().refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    void release_pending_buffer_when_channel_closes() {
+        Buffer input = Buffer.alloc("partial");
+        ChannelDecoder decoder = new ChannelDecoder() {
+            @Override
+            protected Buffer decode(@NonNull NetChannel channel, @NonNull Buffer buffer) {
+                return null;
+            }
+        };
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        channel.chain().add(decoder);
+
+        decoder.sparkChannelRead(channel, input, new CollectingChain());
+        assertThat(input.byteBuf().refCnt()).isOne();
+
+        channel.close();
+
+        assertThat(input.byteBuf().refCnt()).isZero();
+    }
+
+    @Test
+    void schedule_decoder_cleanup_on_channel_event_loop() {
+        AtomicReference<Runnable> cleanup = new AtomicReference<>();
+        IOEventLoop eventLoop = mock(IOEventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doAnswer(invocation -> {
+            cleanup.set(invocation.getArgument(0));
+            return null;
+        }).when(eventLoop).register(any(Runnable.class));
+
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        channel.register(eventLoop, mock(ChannelPromise.class));
+
+        ChannelDecoder decoder = new ChannelDecoder() {
+            @Override
+            protected Buffer decode(@NonNull NetChannel channel, @NonNull Buffer buffer) {
+                return null;
+            }
+        };
+        channel.chain().add(decoder);
+
+        Buffer input = Buffer.alloc("partial");
+        decoder.sparkChannelRead(channel, input, new CollectingChain());
+
+        channel.close();
+
+        assertThat(input.byteBuf().refCnt()).isOne();
+        assertThat(cleanup.get()).isNotNull();
+
+        cleanup.get().run();
+
+        assertThat(input.byteBuf().refCnt()).isZero();
     }
 
     private static final class CollectingChain implements ChannelInBoundHandlerChain {

--- a/core/src/test/java/org/traffichunter/titan/core/util/buffer/BufferOwnershipTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/util/buffer/BufferOwnershipTest.java
@@ -1,0 +1,78 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author yun
+ */
+class BufferOwnershipTest {
+
+    @Test
+    void release_previous_buffer_after_reallocation() {
+        Buffer buffer = Buffer.alloc(1, 1);
+        ByteBuf previous = buffer.byteBuf();
+
+        buffer.accumulateString("12");
+
+        assertThat(previous.refCnt()).isZero();
+        assertThat(buffer.toString()).isEqualTo("12");
+
+        buffer.release();
+    }
+
+    @Test
+    void copy_read_only_buffer_into_independent_storage() {
+        Buffer source = Buffer.buffer(Unpooled.wrappedBuffer(new byte[] {1, 2}).asReadOnly());
+        Buffer copy = source.copy();
+
+        source.release();
+
+        assertThat(copy.byteBuf().refCnt()).isOne();
+        assertThat(copy.getBytes()).containsExactly((byte) 1, (byte) 2);
+
+        copy.release();
+    }
+
+    @SuppressWarnings("removal")
+    @Test
+    void keep_read_all_result_alive_after_accumulator_is_cleared() {
+        BufferAccumulator accumulator = new BufferAccumulator();
+        Buffer input = Buffer.alloc("data");
+        accumulator.accumulate(input);
+        input.release();
+
+        Buffer result = accumulator.readAll();
+
+        assertThat(result.byteBuf().refCnt()).isOne();
+        assertThat(result.toString()).isEqualTo("data");
+
+        result.release();
+    }
+}

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
@@ -38,6 +38,7 @@ import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 
@@ -72,12 +73,18 @@ public final class StompSendToFanoutHandler implements StompServerCommandHandler
             return;
         }
 
-        Message message = Message.builder()
-                .destination(Destination.create(destination))
-                .createdAt(Instant.now())
-                .producerId(connection.session())
-                .body(sf.getBody())
-                .build();
+        Buffer body = Buffer.alloc(sf.body());
+        Message message;
+        try {
+            message = Message.builder()
+                    .destination(Destination.create(destination))
+                    .createdAt(Instant.now())
+                    .producerId(connection.session())
+                    .body(body)
+                    .build();
+        } finally {
+            body.release();
+        }
 
         try {
             CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
@@ -75,12 +75,18 @@ public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame>
         }
 
         io.vertx.core.buffer.Buffer body = frame.getBody();
-        Message message = Message.builder()
-                .destination(Destination.create(destination))
-                .createdAt(Instant.now())
-                .producerId(serverFrame.connection().session())
-                .body(Buffer.alloc(body == null ? new byte[]{} : body.getBytes()))
-                .build();
+        Buffer payload = Buffer.alloc(body == null ? new byte[]{} : body.getBytes());
+        Message message;
+        try {
+            message = Message.builder()
+                    .destination(Destination.create(destination))
+                    .createdAt(Instant.now())
+                    .producerId(serverFrame.connection().session())
+                    .body(payload)
+                    .build();
+        } finally {
+            payload.release();
+        }
 
         try {
             CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/DispatchExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/DispatchExporter.java
@@ -44,14 +44,31 @@ public interface DispatchExporter {
 
     @CanIgnoreReturnValue
     default AggregationResult export(Destination destination, Frame<?, ?> payload) {
-        return export(destination, payload.toBuffer());
+        Buffer buffer = payload.toBuffer();
+        try {
+            return export(destination, buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @CanIgnoreReturnValue
     default AggregationResult export(Destination destination, Message payload) {
-        return export(destination, Buffer.alloc(payload.getBody()));
+        Buffer buffer = Buffer.alloc(payload.getBody());
+        try {
+            return export(destination, buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
+    /**
+     * Exports a borrowed payload buffer.
+     *
+     * <p>The buffer is valid only for the duration of this invocation. Implementations that
+     * retain the payload asynchronously must copy or retain it and release that reference when
+     * delivery completes.</p>
+     */
     @CanIgnoreReturnValue
     AggregationResult export(Destination destination, Buffer payload);
 }

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/StompDispatchExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/StompDispatchExporter.java
@@ -73,7 +73,7 @@ public class StompDispatchExporter implements DispatchExporter {
         );
 
         subscriptions.forEach(subscription -> {
-            StompFrame frame = StompFrame.create(StompHeaders.create(), StompCommand.MESSAGE, message.copy());
+            StompFrame frame = StompFrame.create(StompHeaders.create(), StompCommand.MESSAGE, message.getBytes());
             frame.addHeader(StompHeaders.Elements.DESTINATION, destination.path());
             frame.addHeader(StompHeaders.Elements.SUBSCRIPTION, subscription.id());
             frame.addHeader(StompHeaders.Elements.MESSAGE_ID, IdGenerator.uuid());

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/DispatchExporterTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/DispatchExporterTest.java
@@ -36,7 +36,9 @@ import io.vertx.ext.stomp.Command;
 import io.vertx.ext.stomp.Frame;
 import io.vertx.ext.stomp.StompServer;
 import io.vertx.ext.stomp.StompServerHandler;
+import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -51,6 +53,7 @@ import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompServerSubscription;
 import org.traffichunter.titan.core.codec.stomp.StompServerSubscriptions;
 import org.traffichunter.titan.core.concurrent.Promise;
+import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
@@ -95,6 +98,41 @@ class DispatchExporterTest {
         assertThat(result.succeeded()).isEqualTo(1);
         assertThat(result.failed()).isEqualTo(1);
         assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    void default_message_export_releases_temporary_buffer() {
+        Buffer source = Buffer.alloc("payload");
+        Message message;
+        try {
+            message = Message.builder()
+                    .destination(Destination.create("/topic/test"))
+                    .createdAt(Instant.now())
+                    .producerId("producer")
+                    .body(source)
+                    .build();
+        } finally {
+            source.release();
+        }
+
+        AtomicReference<Buffer> exported = new AtomicReference<>();
+        DispatchExporter exporter = new DispatchExporter() {
+            @Override
+            public String name() {
+                return "test";
+            }
+
+            @Override
+            public AggregationResult export(Destination destination, Buffer payload) {
+                assertThat(payload.byteBuf().refCnt()).isOne();
+                exported.set(payload);
+                return AggregationResult.completed(List.of(destination), 0, 0, 0);
+            }
+        };
+
+        exporter.export(message.getDestination(), message);
+
+        assertThat(exported.get().byteBuf().refCnt()).isZero();
     }
 
     @Test

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
@@ -93,14 +93,14 @@ class TitanFanoutSmokeTest {
             StompHeaders firstSubscribeHeaders = StompHeaders.create();
             firstSubscribeHeaders.put(ID, "smoke-fanout-first");
             firstConsumerConnection.subscribe(FANOUT_DESTINATION, firstSubscribeHeaders, frame -> {
-                firstPayload.set(frame.getBody().toString(StandardCharsets.UTF_8));
+                firstPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
                 received.countDown();
             }).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
             StompHeaders secondSubscribeHeaders = StompHeaders.create();
             secondSubscribeHeaders.put(ID, "smoke-fanout-second");
             secondConsumerConnection.subscribe(FANOUT_DESTINATION, secondSubscribeHeaders, frame -> {
-                secondPayload.set(frame.getBody().toString(StandardCharsets.UTF_8));
+                secondPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
                 received.countDown();
             }).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
@@ -434,9 +434,9 @@ public class StompClientTcpChannel implements StompClientChannel {
             return;
         }
 
-        Buffer body = frame.getBody();
-        if (body.length() > 0 && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
-            frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length()));
+        byte[] body = frame.body();
+        if (body.length > 0 && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
+            frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length));
         }
 
         String receiptId = frame.getHeader(Elements.RECEIPT);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
@@ -375,7 +375,7 @@ public final class StompServerHandlerImpl implements StompServerHandler {
                 int success = 0;
                 for (StompServerSubscription subscription : subscriptions) {
                     try {
-                        StompFrame messageFrame = create(StompHeaders.create(), StompCommand.MESSAGE, sf.getBody());
+                        StompFrame messageFrame = create(StompHeaders.create(), StompCommand.MESSAGE, sf.body());
                         messageFrame.addHeader(StompHeaders.Elements.DESTINATION, destination);
                         messageFrame.addHeader(StompHeaders.Elements.SUBSCRIPTION, subscription.id());
                         messageFrame.addHeader(StompHeaders.Elements.MESSAGE_ID, IdGenerator.uuid());

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -117,11 +117,12 @@ public class StompChannelDecoder extends ChannelDecoder {
             buffer.skipBytes(1);
 
             Buffer stompFrame = Buffer.alloc(sliceBuffer.length() + 1);
-            stompFrame.accumulateBuffer(sliceBuffer)
-                    .accumulateByte(StompDelimiter.LF.getHex());
-
-            List<Buffer> frames = lineFrameDecoder.decodes(channel, stompFrame);
+            List<Buffer> frames = List.of();
             try {
+                stompFrame.accumulateBuffer(sliceBuffer)
+                        .accumulateByte(StompDelimiter.LF.getHex());
+                frames = lineFrameDecoder.decodes(channel, stompFrame);
+
                 StompCommand stompCommand = StompCommand.valueOf(frames.getFirst().toString());
 
                 int bodyLength = -1;
@@ -183,14 +184,18 @@ public class StompChannelDecoder extends ChannelDecoder {
 
         List<Buffer> decodes(NetChannel channel, Buffer buffer) {
             List<Buffer> buffers = new LinkedList<>();
-            while (buffer.isReadable()) {
-                Buffer decode = decode(channel, buffer);
-                if (decode != null) {
-                    buffers.add(decode);
+            try {
+                while (buffer.isReadable()) {
+                    Buffer decode = decode(channel, buffer);
+                    if (decode != null) {
+                        buffers.add(decode);
+                    }
                 }
+                return buffers;
+            } catch (RuntimeException e) {
+                buffers.forEach(Buffer::release);
+                throw e;
             }
-
-            return buffers;
         }
 
         @Override

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
@@ -51,32 +51,45 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
             new StompFrame(new StompHeaders(StompVersion.STOMP_1_2), StompCommand.ERROR);
 
     public static final StompFrame PING =
-            new StompFrame(new StompHeaders(StompVersion.STOMP_1_2), StompCommand.PING, Buffer.alloc(StompDelimiter.LF.getString()));
+            new StompFrame(
+                    new StompHeaders(StompVersion.STOMP_1_2),
+                    StompCommand.PING,
+                    StompDelimiter.LF.getString().getBytes(StandardCharsets.UTF_8)
+            );
 
     private final StompHeaders headers;
 
     private final StompCommand command;
 
-    private final Buffer body;
+    private final byte[] body;
 
     private StompFrame(final StompHeaders headers, final StompCommand command) {
         this(headers, command, new byte[] {});
     }
 
     private StompFrame(final StompHeaders headers, final StompCommand command, final byte [] body) {
-        this(headers, command, Buffer.alloc(body));
+        this.headers = headers;
+        this.command = command;
+        this.body = body.clone();
     }
 
     private StompFrame(final StompHeaders headers, final StompCommand command, final Buffer body) {
         this.headers = headers;
         this.command = command;
-        this.body = body;
+        try {
+            this.body = body.getBytes();
+        } finally {
+            body.release();
+        }
     }
 
     public static StompFrame create(final StompHeaders headers, final StompCommand command) {
         return new StompFrame(headers, command);
     }
 
+    /**
+     * Creates a frame by copying the body and consuming the supplied buffer reference.
+     */
     public static StompFrame create(final StompHeaders headers,
                                     final StompCommand command,
                                     final Buffer body) {
@@ -103,7 +116,17 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
 
     @Override
     public byte[] body() {
-        return body.getBytes();
+        return body.clone();
+    }
+
+    /**
+     * Returns an independently owned copy of the frame body.
+     *
+     * <p>The caller must release the returned buffer. New transport-neutral code should prefer
+     * {@link #body()} when a byte array is sufficient.</p>
+     */
+    public Buffer getBody() {
+        return Buffer.alloc(body);
     }
 
     @Override
@@ -132,7 +155,7 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
         );
         buffer.accumulateString(StompDelimiter.CR.getString()).accumulateString(StompDelimiter.LF.getString());
 
-        buffer.accumulateBuffer(body);
+        buffer.accumulateBytes(body);
         buffer.accumulateString(StompDelimiter.NUL.getString());
 
         return buffer;
@@ -293,14 +316,15 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
     }
 
     private void logging(boolean isLogging, StringBuilder sb) {
-        if (isLogging && body.length() >= 100) {
-            String loggingStr = body.toString();
+        String bodyText = new String(body, StandardCharsets.UTF_8);
+        if (isLogging && bodyText.length() >= 100) {
+            String loggingStr = bodyText;
 
             String pre = loggingStr.substring(0, 30);
-            String post = loggingStr.substring(body.length() - 30);
+            String post = loggingStr.substring(loggingStr.length() - 30);
             sb.append(pre).append(".............").append(post);
         } else {
-            sb.append(body);
+            sb.append(bodyText);
         }
     }
 

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompFrameTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompFrameTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
+import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
  * @author yungwang-o
@@ -39,7 +40,21 @@ class StompFrameTest {
         headers.keySet().forEach(key ->
                 Assertions.assertEquals(stompFrame.getHeaders().get(key), parseFrame.getHeaders().get(key))
         );
-        Assertions.assertEquals(parseFrame.getBody(), stompFrame.getBody());
+        Assertions.assertArrayEquals(parseFrame.body(), stompFrame.body());
+    }
+
+    @Test
+    void consume_buffer_and_keep_copied_body() {
+        Buffer body = Buffer.alloc("body");
+
+        StompFrame frame = StompFrame.create(
+                StompHeaders.create(),
+                StompCommand.SEND,
+                body
+        );
+
+        assertEquals(0, body.byteBuf().refCnt());
+        assertArrayEquals("body".getBytes(StandardCharsets.UTF_8), frame.body());
     }
 
     private static StompFrame getStompFrame() {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/StompIntegrationTest.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.core.transport.stomp;
 import static org.awaitility.Awaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -139,8 +140,8 @@ class StompIntegrationTest {
 
             assertThat(result).isNotNull();
             assertThat(result.getCommand()).isEqualTo(StompCommand.SEND);
-            assertThat(result.getBody()).isNotNull();
-            assertThat(result.getBody().toString()).isEqualTo("Hello STOMP!");
+            assertThat(result.body()).isNotNull();
+            assertThat(new String(result.body(), StandardCharsets.UTF_8)).isEqualTo("Hello STOMP!");
         } finally {
             client.shutdown();
             dispatcher.remove(key);


### PR DESCRIPTION
## Motivation:

The buffer ownership hotfix was applied to `release/0.7.4` first. The same fix must be carried forward so ongoing development on `main` does not regress the corrected reference-count and cleanup behavior.

## Modification:

- Forward-merge the `release/0.7.4` buffer ownership hotfix into `main`.
- Preserve the original hotfix commits and release branch history without cherry-picking or rewriting shared commits.

## Result:

`main` includes the deterministic buffer cleanup, STOMP frame ownership, and fanout payload release fixes delivered through #105.
