### PR TITLE
Support TLS in the Spring STOMP client

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/net/JdkKeyManager.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/JdkKeyManager.java
@@ -30,6 +30,7 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 
@@ -43,7 +44,11 @@ public final class JdkKeyManager {
 
     public JdkKeyManager(TlsOptions options) {
         this.keyStore = load(options);
-        this.keyPassword = options.keyPassword();
+        String configuredKeyPassword = options.keyPassword();
+        if (configuredKeyPassword == null) {
+            throw new NetSecureException("TLS key password is required");
+        }
+        this.keyPassword = configuredKeyPassword;
     }
 
     public KeyManager[] keyManagers() {
@@ -71,14 +76,21 @@ public final class JdkKeyManager {
     }
 
     private static KeyStore load(TlsOptions options) {
+        Path path = options.path();
+        String type = options.type();
+        String storePassword = options.storePassword();
+        if (path == null || type == null || storePassword == null) {
+            throw new NetSecureException("Incomplete TLS key store configuration");
+        }
+
         try {
-            KeyStore keyStore = KeyStore.getInstance(options.type());
-            try (InputStream input = Files.newInputStream(options.path())) {
-                keyStore.load(input, options.storePassword().toCharArray());
+            KeyStore keyStore = KeyStore.getInstance(type);
+            try (InputStream input = Files.newInputStream(path)) {
+                keyStore.load(input, storePassword.toCharArray());
             }
             return keyStore;
         } catch (GeneralSecurityException | IOException e) {
-            throw new NetSecureException("Failed to load TLS key store: " + options.path(), e);
+            throw new NetSecureException("Failed to load TLS key store: " + path, e);
         }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsContext.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsContext.java
@@ -37,11 +37,44 @@ import java.security.SecureRandom;
 public final class JdkTlsContext implements TlsContext {
 
     private final SSLContext sslContext;
-    private final TlsOptions options;
+    private final TlsSide side;
+    private final String[] enabledProtocols;
+    private final String[] enabledCiphers;
+    private final TlsClientAuth clientAuth;
+    private final boolean verifyHostname;
 
     public JdkTlsContext(TlsOptions options) {
-        this.sslContext = createSslContext(options);
-        this.options = options;
+        this(
+                createSslContext(options),
+                options.side(),
+                TlsVersion.values(options.versions()),
+                options.ciphers(),
+                options.clientAuth(),
+                options.verifyHostname()
+        );
+    }
+
+    private JdkTlsContext(
+            SSLContext sslContext,
+            TlsSide side,
+            String[] enabledProtocols,
+            String[] enabledCiphers,
+            TlsClientAuth clientAuth,
+            boolean verifyHostname
+    ) {
+        if (enabledProtocols.length == 0) {
+            throw new NetSecureException("At least one TLS version is required");
+        }
+        if (side == TlsSide.CLIENT && clientAuth != TlsClientAuth.NONE) {
+            throw new NetSecureException("TLS client cannot configure server-side client authentication");
+        }
+
+        this.sslContext = sslContext;
+        this.side = side;
+        this.enabledProtocols = enabledProtocols.clone();
+        this.enabledCiphers = enabledCiphers.clone();
+        this.clientAuth = clientAuth;
+        this.verifyHostname = verifyHostname;
     }
 
     @Override
@@ -53,20 +86,22 @@ public final class JdkTlsContext implements TlsContext {
     public TlsHandler newHandler(String peerHost, int peerPort, TlsTaskExecutor taskExecutor) {
         SSLEngine engine = sslContext.createSSLEngine(peerHost, peerPort);
 
-        TlsSide tlsSide = options.side();
-        boolean isClient = tlsSide == TlsSide.CLIENT;
+        boolean isClient = side == TlsSide.CLIENT;
         engine.setUseClientMode(isClient);
-        engine.setEnabledProtocols(TlsVersion.values(options.versions()));
+        engine.setEnabledProtocols(enabledProtocols);
+        if (enabledCiphers.length > 0) {
+            engine.setEnabledCipherSuites(enabledCiphers);
+        }
 
         SSLParameters sslParameters = engine.getSSLParameters();
 
-        if (isClient && options.verifyHostname()) {
+        if (isClient && verifyHostname) {
             sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
         }
 
         // server
         if (!isClient) {
-            switch (options.clientAuth()) {
+            switch (clientAuth) {
                 case NONE -> {
                     sslParameters.setWantClientAuth(false);
                     sslParameters.setNeedClientAuth(false);
@@ -81,8 +116,8 @@ public final class JdkTlsContext implements TlsContext {
     }
 
     @Override
-    public TlsOptions options() {
-        return options;
+    public TlsSide side() {
+        return side;
     }
 
     @Override
@@ -94,9 +129,16 @@ public final class JdkTlsContext implements TlsContext {
         validate(options);
 
         try {
-            JdkKeyManager manager = new JdkKeyManager(options);
-            KeyManager[] keyManagers = manager.keyManagers();
-            TrustManager[] trustManagers = manager.trustManagers();
+            KeyManager[] keyManagers;
+            TrustManager[] trustManagers;
+            if (options.usesManagers()) {
+                keyManagers = options.keyManagers();
+                trustManagers = options.trustManagers();
+            } else {
+                JdkKeyManager manager = new JdkKeyManager(options);
+                keyManagers = manager.keyManagers();
+                trustManagers = manager.trustManagers();
+            }
 
             SSLContext context = SSLContext.getInstance("TLS");
             context.init(keyManagers, trustManagers, new SecureRandom());

--- a/core/src/main/java/org/traffichunter/titan/core/net/TlsContext.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/TlsContext.java
@@ -36,7 +36,10 @@ public interface TlsContext {
 
     TlsHandler newHandler(String peerHost, int peerPort, TlsTaskExecutor taskExecutor);
 
-    TlsOptions options();
+    /**
+     * Returns the local role used by handlers created from this context.
+     */
+    TlsSide side();
 
     SSLContext sslContext();
 }

--- a/core/src/main/java/org/traffichunter/titan/core/net/TlsContextFactory.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/TlsContextFactory.java
@@ -34,18 +34,18 @@ import java.util.Locale;
 public final class TlsContextFactory {
 
     public static TlsContext create(ServerSettings.TlsSettings settings) {
-        TlsOptions options = new TlsOptions(
-                TlsSide.valueOf(settings.side().toUpperCase(Locale.ROOT)),
-                TlsVersion.values(),
-                TlsClientAuth.valueOf(
-                        settings.clientAuth().toUpperCase(Locale.ROOT)
-                ),
-                Path.of(settings.path()),
-                settings.type(),
-                settings.storePassword(),
-                settings.keyPassword(),
-                settings.verifyHostname()
-        );
+        TlsOptions options = TlsOptions.builder()
+                .side(TlsSide.valueOf(settings.side().toUpperCase(Locale.ROOT)))
+                .versions(TlsVersion.values())
+                .clientAuth(TlsClientAuth.valueOf(settings.clientAuth().toUpperCase(Locale.ROOT)))
+                .keyStore(
+                        Path.of(settings.path()),
+                        settings.type(),
+                        settings.storePassword(),
+                        settings.keyPassword()
+                )
+                .verifyHostname(settings.verifyHostname())
+                .build();
 
         return new JdkTlsContext(options);
     }

--- a/core/src/main/java/org/traffichunter/titan/core/net/TlsOptions.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/TlsOptions.java
@@ -23,39 +23,170 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.net;
 
+import org.jspecify.annotations.Nullable;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.TrustManager;
 import java.nio.file.Path;
 
 /**
- * Configuration for creating a JDK TLS context.
- *
- * @param side local endpoint role during the TLS handshake
- * @param versions TLS protocol versions enabled on each engine
- * @param clientAuth server policy for requesting or requiring client certificates
- * @param path path to the key store containing identity and trust material
- * @param type JDK key store type, such as {@code PKCS12} or {@code JKS}
- * @param storePassword password used to open the key store
- * @param keyPassword password used to recover private keys from the key store
- * @param verifyHostname whether a client verifies the peer hostname against the certificate
+ * Immutable configuration for creating a JDK TLS context. Key and trust material can be
+ * supplied through a key store or as managers prepared by an external configuration system.
  *
  * @author yun
  */
-public record TlsOptions(
-        TlsSide side,
-        TlsVersion[] versions,
-        TlsClientAuth clientAuth,
-        Path path,
-        String type,
-        String storePassword,
-        String keyPassword,
-        boolean verifyHostname
-) {
+public final class TlsOptions {
 
-    public TlsOptions {
-        versions = versions.clone();
+    private final TlsSide side;
+    private final TlsVersion[] versions;
+    private final String[] ciphers;
+    private final TlsClientAuth clientAuth;
+    private final @Nullable Path path;
+    private final @Nullable String type;
+    private final @Nullable String storePassword;
+    private final @Nullable String keyPassword;
+    private final KeyManager[] keyManagers;
+    private final TrustManager[] trustManagers;
+    private final boolean managed;
+    private final boolean verifyHostname;
+
+    private TlsOptions(Builder builder) {
+        if (builder.side == null) {
+            throw new IllegalStateException("TLS side is required");
+        }
+        if (!builder.managed && builder.path == null) {
+            throw new IllegalStateException("TLS key store or managers are required");
+        }
+        if (builder.managed && builder.path != null) {
+            throw new IllegalStateException("TLS key store and managers cannot be configured together");
+        }
+
+        this.side = builder.side;
+        this.versions = builder.versions.clone();
+        this.ciphers = builder.ciphers.clone();
+        this.clientAuth = builder.clientAuth;
+        this.path = builder.path;
+        this.type = builder.type;
+        this.storePassword = builder.storePassword;
+        this.keyPassword = builder.keyPassword;
+        this.keyManagers = builder.keyManagers.clone();
+        this.trustManagers = builder.trustManagers.clone();
+        this.managed = builder.managed;
+        this.verifyHostname = builder.verifyHostname;
     }
 
-    @Override
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public TlsSide side() {
+        return side;
+    }
+
     public TlsVersion[] versions() {
         return versions.clone();
+    }
+
+    public String[] ciphers() {
+        return ciphers.clone();
+    }
+
+    public TlsClientAuth clientAuth() {
+        return clientAuth;
+    }
+
+    public @Nullable Path path() {
+        return path;
+    }
+
+    public @Nullable String type() {
+        return type;
+    }
+
+    public @Nullable String storePassword() {
+        return storePassword;
+    }
+
+    public @Nullable String keyPassword() {
+        return keyPassword;
+    }
+
+    public KeyManager[] keyManagers() {
+        return keyManagers.clone();
+    }
+
+    public TrustManager[] trustManagers() {
+        return trustManagers.clone();
+    }
+
+    public boolean usesManagers() {
+        return managed;
+    }
+
+    public boolean verifyHostname() {
+        return verifyHostname;
+    }
+
+    public static final class Builder {
+
+        private @Nullable TlsSide side;
+        private TlsVersion[] versions = TlsVersion.values();
+        private String[] ciphers = new String[0];
+        private TlsClientAuth clientAuth = TlsClientAuth.NONE;
+        private @Nullable Path path;
+        private @Nullable String type;
+        private @Nullable String storePassword;
+        private @Nullable String keyPassword;
+        private KeyManager[] keyManagers = new KeyManager[0];
+        private TrustManager[] trustManagers = new TrustManager[0];
+        private boolean managed;
+        private boolean verifyHostname;
+
+        private Builder() {
+        }
+
+        public Builder side(TlsSide side) {
+            this.side = side;
+            return this;
+        }
+
+        public Builder versions(TlsVersion... versions) {
+            this.versions = versions.clone();
+            return this;
+        }
+
+        public Builder ciphers(String... ciphers) {
+            this.ciphers = ciphers.clone();
+            return this;
+        }
+
+        public Builder clientAuth(TlsClientAuth clientAuth) {
+            this.clientAuth = clientAuth;
+            return this;
+        }
+
+        public Builder keyStore(Path path, String type, String storePassword, String keyPassword) {
+            this.path = path;
+            this.type = type;
+            this.storePassword = storePassword;
+            this.keyPassword = keyPassword;
+            return this;
+        }
+
+        public Builder managers(KeyManager[] keyManagers, TrustManager[] trustManagers) {
+            this.keyManagers = keyManagers.clone();
+            this.trustManagers = trustManagers.clone();
+            this.managed = true;
+            return this;
+        }
+
+        public Builder verifyHostname(boolean verifyHostname) {
+            this.verifyHostname = verifyHostname;
+            return this;
+        }
+
+        public TlsOptions build() {
+            return new TlsOptions(this);
+        }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -111,7 +111,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
         if (isStarted()) {
             throw new IllegalStateException("TLS context already started");
         }
-        if (tlsContext.options().side() != TlsSide.CLIENT) {
+        if (tlsContext.side() != TlsSide.CLIENT) {
             throw new IllegalStateException("InetClient requires a client-side TLS context");
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -111,7 +111,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         if (isStarted()) {
             throw new IllegalStateException("Cannot configure TLS after server start");
         }
-        if (tlsContext.options().side() != TlsSide.SERVER) {
+        if (tlsContext.side() != TlsSide.SERVER) {
             throw new IllegalStateException("InetServer requires a server-side TLS context");
         }
 
@@ -262,7 +262,8 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
         bind(address).addListener(future -> {
             if (!future.isSuccess()) {
                 state.compareAndSet(State.LISTENING, State.STARTED);
-                resultPromise.fail(future.error());
+                Throwable error = future.error();
+                resultPromise.fail(error != null ? error : new ServerException("Server bind failed without error"));
                 return;
             }
 

--- a/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsContextTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsContextTest.java
@@ -48,16 +48,9 @@ class JdkTlsContextTest {
     @Test
     void apply_client_tls_options_to_ssl_engine() throws Exception {
         Path keyStorePath = createKeyStore();
-        TlsOptions options = new TlsOptions(
-                TlsSide.CLIENT,
-                new TlsVersion[]{TlsVersion.TLS_1_3, TlsVersion.TLS_1_2},
-                TlsClientAuth.NONE,
-                keyStorePath,
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                true
-        );
+        TlsOptions options = keyStoreOptions(TlsSide.CLIENT, keyStorePath)
+                .verifyHostname(true)
+                .build();
 
         JdkTlsContext context = new JdkTlsContext(options);
         SSLEngine engine = context.newHandler("localhost", 61614).sslEngine();
@@ -69,16 +62,9 @@ class JdkTlsContextTest {
 
     @Test
     void apply_server_client_auth_to_ssl_engine() throws Exception {
-        TlsOptions options = new TlsOptions(
-                TlsSide.SERVER,
-                new TlsVersion[]{TlsVersion.TLS_1_3, TlsVersion.TLS_1_2},
-                TlsClientAuth.NEED,
-                createKeyStore(),
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                false
-        );
+        TlsOptions options = keyStoreOptions(TlsSide.SERVER, createKeyStore())
+                .clientAuth(TlsClientAuth.NEED)
+                .build();
 
         SSLEngine engine = new JdkTlsContext(options)
                 .newHandler("localhost", 61614)
@@ -91,18 +77,29 @@ class JdkTlsContextTest {
     }
 
     @Test
+    void create_client_context_from_external_managers() {
+        TlsOptions options = TlsOptions.builder()
+                .side(TlsSide.CLIENT)
+                .managers(new javax.net.ssl.KeyManager[0], new javax.net.ssl.TrustManager[0])
+                .verifyHostname(true)
+                .build();
+        JdkTlsContext context = new JdkTlsContext(options);
+
+        SSLEngine engine = context.newHandler("localhost", 61614).sslEngine();
+
+        assertThat(context.side()).isEqualTo(TlsSide.CLIENT);
+        assertThat(engine.getUseClientMode()).isTrue();
+        assertThat(engine.getEnabledProtocols()).containsExactly("TLSv1.2", "TLSv1.3");
+        assertThat(engine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+    }
+
+    @Test
     void protect_tls_version_array_from_external_changes() throws Exception {
         TlsVersion[] versions = {TlsVersion.TLS_1_3, TlsVersion.TLS_1_2};
-        TlsOptions options = new TlsOptions(
-                TlsSide.CLIENT,
-                versions,
-                TlsClientAuth.NONE,
-                createKeyStore(),
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                true
-        );
+        TlsOptions options = keyStoreOptions(TlsSide.CLIENT, createKeyStore())
+                .versions(versions)
+                .verifyHostname(true)
+                .build();
 
         versions[0] = TlsVersion.TLS_1_2;
         TlsVersion[] returned = options.versions();
@@ -113,16 +110,10 @@ class JdkTlsContextTest {
 
     @Test
     void reject_client_with_server_client_auth_policy() {
-        TlsOptions options = new TlsOptions(
-                TlsSide.CLIENT,
-                new TlsVersion[]{TlsVersion.TLS_1_3, TlsVersion.TLS_1_2},
-                TlsClientAuth.NEED,
-                directory.resolve("unused.p12"),
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                true
-        );
+        TlsOptions options = keyStoreOptions(TlsSide.CLIENT, directory.resolve("unused.p12"))
+                .clientAuth(TlsClientAuth.NEED)
+                .verifyHostname(true)
+                .build();
 
         assertThatThrownBy(() -> new JdkTlsContext(options))
                 .isInstanceOf(NetSecureException.class)
@@ -131,16 +122,9 @@ class JdkTlsContextTest {
 
     @Test
     void reject_empty_tls_versions() throws Exception {
-        TlsOptions options = new TlsOptions(
-                TlsSide.SERVER,
-                new TlsVersion[0],
-                TlsClientAuth.NONE,
-                createKeyStore(),
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                false
-        );
+        TlsOptions options = keyStoreOptions(TlsSide.SERVER, createKeyStore())
+                .versions()
+                .build();
 
         assertThatThrownBy(() -> new JdkTlsContext(options))
                 .isInstanceOf(NetSecureException.class)
@@ -149,16 +133,11 @@ class JdkTlsContextTest {
 
     @Test
     void reject_invalid_key_store_password() throws Exception {
-        TlsOptions options = new TlsOptions(
-                TlsSide.SERVER,
-                new TlsVersion[]{TlsVersion.TLS_1_3},
-                TlsClientAuth.NONE,
-                createKeyStore(),
-                "PKCS12",
-                "wrong-password",
-                PASSWORD,
-                false
-        );
+        TlsOptions options = TlsOptions.builder()
+                .side(TlsSide.SERVER)
+                .versions(TlsVersion.TLS_1_3)
+                .keyStore(createKeyStore(), "PKCS12", "wrong-password", PASSWORD)
+                .build();
 
         assertThatThrownBy(() -> new JdkTlsContext(options))
                 .isInstanceOf(NetSecureException.class)
@@ -174,5 +153,12 @@ class JdkTlsContextTest {
             keyStore.store(output, PASSWORD.toCharArray());
         }
         return path;
+    }
+
+    private static TlsOptions.Builder keyStoreOptions(TlsSide side, Path path) {
+        return TlsOptions.builder()
+                .side(side)
+                .versions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+                .keyStore(path, "PKCS12", PASSWORD, PASSWORD);
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerIntegrationTest.java
@@ -218,16 +218,12 @@ class JdkTlsHandlerIntegrationTest {
     }
 
     private static JdkTlsContext context(TlsSide side, Path keyStore, TlsVersion... versions) {
-        return new JdkTlsContext(new TlsOptions(
-                side,
-                versions,
-                TlsClientAuth.NONE,
-                keyStore,
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                side == TlsSide.CLIENT
-        ));
+        return new JdkTlsContext(TlsOptions.builder()
+                .side(side)
+                .versions(versions)
+                .keyStore(keyStore, "PKCS12", PASSWORD, PASSWORD)
+                .verifyHostname(side == TlsSide.CLIENT)
+                .build());
     }
 
     private static Endpoint endpoint(String name, JdkTlsContext context, String peerHost, int peerPort) {

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
@@ -181,16 +181,13 @@ class TlsTransportIntegrationTest {
     }
 
     private static JdkTlsContext context(TlsSide side, TlsClientAuth clientAuth, Path keyStore) {
-        return new JdkTlsContext(new TlsOptions(
-                side,
-                new TlsVersion[]{TlsVersion.TLS_1_3, TlsVersion.TLS_1_2},
-                clientAuth,
-                keyStore,
-                "PKCS12",
-                PASSWORD,
-                PASSWORD,
-                side == TlsSide.CLIENT
-        ));
+        return new JdkTlsContext(TlsOptions.builder()
+                .side(side)
+                .versions(TlsVersion.TLS_1_3, TlsVersion.TLS_1_2)
+                .clientAuth(clientAuth)
+                .keyStore(keyStore, "PKCS12", PASSWORD, PASSWORD)
+                .verifyHostname(side == TlsSide.CLIENT)
+                .build());
     }
 
     private static ChannelInBoundHandler echo(LinkedBlockingQueue<String> messages) {

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -144,6 +144,34 @@ available.
 `spring.titan.host` and `spring.titan.port`.
 
 `spring.titan.endpoint` is the preferred connection setting and accepts
-`tcp://host:port` or `ws://host:port/path`. When present, it takes precedence
+`tcp://host:port`, `ws://host:port/path`, or `wss://host:port/path`. When present, it takes precedence
 over the separate host, port, transport, and WebSocket path properties. The
 legacy properties remain available for compatibility.
+
+## TLS With PKCS12
+
+Secure WebSocket connections use a named Spring SSL bundle. Titan receives the
+key and trust managers prepared by Spring, so certificate locations and passwords
+remain in Spring Boot's standard SSL configuration.
+
+```yaml
+spring:
+  titan:
+    client: titan
+    endpoint: wss://localhost:8443/stomp
+    ssl:
+      bundle: titan-client
+      verify-hostname: true
+  ssl:
+    bundle:
+      jks:
+        titan-client:
+          truststore:
+            location: classpath:titan-client.p12
+            password: secret
+            type: PKCS12
+```
+
+Providing the bundle for a TCP endpoint enables TLS directly over that TCP
+connection. Spring SSL bundles are currently supported by the native Titan
+client; the Vert.x client adapter remains available for non-TLS connections.

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -27,6 +27,8 @@ public final class TitanProperties {
 
     private String websocketPath = "/stomp";
 
+    private final Ssl ssl = new Ssl();
+
     private int primaryThreads = 1;
 
     private int secondaryThreads = Runtime.getRuntime().availableProcessors();
@@ -225,6 +227,36 @@ public final class TitanProperties {
 
     public void setWebsocketPath(String websocketPath) {
         this.websocketPath = websocketPath;
+    }
+
+    public Ssl getSsl() {
+        return ssl;
+    }
+
+    /**
+     * References TLS material managed by Spring Boot's SSL bundle infrastructure.
+     */
+    public static final class Ssl {
+
+        private @Nullable String bundle;
+
+        private boolean verifyHostname = true;
+
+        public @Nullable String getBundle() {
+            return bundle;
+        }
+
+        public void setBundle(@Nullable String bundle) {
+            this.bundle = bundle;
+        }
+
+        public boolean isVerifyHostname() {
+            return verifyHostname;
+        }
+
+        public void setVerifyHostname(boolean verifyHostname) {
+            this.verifyHostname = verifyHostname;
+        }
     }
 
     public enum Client {

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -6,12 +6,20 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundles;
+import org.springframework.boot.ssl.SslManagerBundle;
 import org.springframework.context.annotation.Bean;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.net.JdkTlsContext;
+import org.traffichunter.titan.core.net.TlsOptions;
+import org.traffichunter.titan.core.net.TlsSide;
+import org.traffichunter.titan.core.net.TlsVersion;
 import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.StompEndpoint;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
@@ -31,7 +39,7 @@ import org.traffichunter.titan.springframework.stomp.core.TitanTemplate;
  *
  * @author yun
  */
-@AutoConfiguration
+@AutoConfiguration(after = SslAutoConfiguration.class)
 @ConditionalOnClass({StompClient.class, EventLoopGroups.class})
 @EnableConfigurationProperties(TitanProperties.class)
 @ConditionalOnProperty(prefix = "spring.titan", name = "enabled", havingValue = "true", matchIfMissing = true)
@@ -82,7 +90,8 @@ public class TitanStompClientAutoConfiguration {
     public StompClient titanStompClient(
             List<StompClientProvider> stompClientProviders,
             StompClientOption titanStompClientOption,
-            TitanProperties properties
+            TitanProperties properties,
+            ObjectProvider<SslBundles> sslBundles
     ) {
         StompClient client = stompClientProviders.stream()
                 .filter(provider -> provider.supports(properties.getClient().getName(), titanStompClientOption.stompVersion().getVersion()))
@@ -94,13 +103,12 @@ public class TitanStompClientAutoConfiguration {
                 .create(titanStompClientOption);
 
         StompEndpoint endpoint = endpoint(properties);
+        configureSsl(client, properties, endpoint, sslBundles);
+
         boolean webSocket = endpoint == null
                 ? properties.getTransport() == TitanProperties.Transport.WEBSOCKET
                 : endpoint.isWebSocket();
         if (webSocket) {
-            if (endpoint != null && endpoint.isSecure()) {
-                throw new IllegalStateException("Secure WebSocket transport is not supported yet");
-            }
             String path = endpoint == null ? properties.getWebsocketPath() : endpoint.path();
             if (client instanceof TitanStompClient titanClient) {
                 titanClient.upgradeWebsocket(path);
@@ -111,6 +119,66 @@ public class TitanStompClientAutoConfiguration {
             }
         }
         return client;
+    }
+
+    private static void configureSsl(
+            StompClient client,
+            TitanProperties properties,
+            @Nullable StompEndpoint endpoint,
+            ObjectProvider<SslBundles> sslBundles
+    ) {
+        String bundleName = properties.getSsl().getBundle();
+        boolean hasBundle = bundleName != null && !bundleName.isBlank();
+        boolean secureEndpoint = endpoint != null && endpoint.isSecure();
+
+        if (secureEndpoint && !hasBundle) {
+            throw new IllegalStateException("Secure STOMP endpoint requires spring.titan.ssl.bundle");
+        }
+        if (!hasBundle) {
+            return;
+        }
+        if (endpoint != null && endpoint.isWebSocket() && !secureEndpoint) {
+            throw new IllegalStateException("WebSocket SSL bundle requires a wss endpoint");
+        }
+        if (!(client instanceof TitanStompClient titanClient)) {
+            throw new IllegalStateException("Spring SSL bundles are supported only by the Titan STOMP client");
+        }
+
+        SslBundles bundles = sslBundles.getIfAvailable();
+        if (bundles == null) {
+            throw new IllegalStateException("Spring SSL bundle infrastructure is not available");
+        }
+
+        SslBundle bundle = bundles.getBundle(bundleName);
+        SslManagerBundle managers = bundle.getManagers();
+        String[] protocols = bundle.getOptions().getEnabledProtocols();
+        String[] ciphers = bundle.getOptions().getCiphers();
+        TlsOptions.Builder options = TlsOptions.builder()
+                .side(TlsSide.CLIENT)
+                .managers(managers.getKeyManagers(), managers.getTrustManagers())
+                .verifyHostname(properties.getSsl().isVerifyHostname());
+        if (protocols != null && protocols.length > 0) {
+            options.versions(tlsVersions(protocols));
+        }
+        if (ciphers != null) {
+            options.ciphers(ciphers);
+        }
+        titanClient.tls(new JdkTlsContext(options.build()));
+    }
+
+    private static TlsVersion[] tlsVersions(String[] protocols) {
+        TlsVersion[] versions = new TlsVersion[protocols.length];
+        for (int i = 0; i < protocols.length; i++) {
+            String protocol = protocols[i];
+            if (TlsVersion.TLS_1_2.getValue().equals(protocol)) {
+                versions[i] = TlsVersion.TLS_1_2;
+            } else if (TlsVersion.TLS_1_3.getValue().equals(protocol)) {
+                versions[i] = TlsVersion.TLS_1_3;
+            } else {
+                throw new IllegalStateException("Unsupported TLS protocol in Spring SSL bundle: " + protocol);
+            }
+        }
+        return versions;
     }
 
     private static @Nullable StompEndpoint endpoint(TitanProperties properties) {

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/listener/TitanListenerConfiguration.java
@@ -64,9 +64,7 @@ public class TitanListenerConfiguration {
         converters.add(new StompFrameMessageConverter());
         converters.add(new ByteArrayMessageConverter());
         converters.add(new StringMessageConverter());
-        if (ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", getClass().getClassLoader())) {
-            converters.add(new MappingJackson2MessageConverter());
-        }
+        addJacksonConverter(converters);
 
         return new CompositeMessageConverter(converters);
     }
@@ -87,5 +85,28 @@ public class TitanListenerConfiguration {
                 new TitanPayloadHandlerMethodArgumentResolver(converter)
         );
         return factory;
+    }
+
+    private void addJacksonConverter(List<MessageConverter> converters) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String converterClass;
+        if (ClassUtils.isPresent("tools.jackson.databind.ObjectMapper", classLoader)
+                && ClassUtils.isPresent(
+                "org.springframework.messaging.converter.JacksonJsonMessageConverter",
+                classLoader
+        )) {
+            converterClass = "org.springframework.messaging.converter.JacksonJsonMessageConverter";
+        } else if (ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader)) {
+            converterClass = "org.springframework.messaging.converter.MappingJackson2MessageConverter";
+        } else {
+            return;
+        }
+
+        try {
+            Class<?> type = ClassUtils.forName(converterClass, classLoader);
+            converters.add((MessageConverter) type.getDeclaredConstructor().newInstance());
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to create Jackson message converter", e);
+        }
     }
 }

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
@@ -20,6 +20,8 @@ class TitanPropertiesTest {
         assertNull(properties.getEndpoint());
         assertEquals(TitanProperties.Transport.TCP, properties.getTransport());
         assertEquals("/stomp", properties.getWebsocketPath());
+        assertNull(properties.getSsl().getBundle());
+        assertTrue(properties.getSsl().isVerifyHostname());
         assertEquals("127.0.0.1", properties.getHost());
         assertEquals(61613, properties.getPort());
         assertEquals(5000L, properties.getConnectTimeoutMillis());
@@ -46,5 +48,16 @@ class TitanPropertiesTest {
         properties.setSecondaryThreads(4);
 
         assertEquals(4, properties.getSecondaryThreads());
+    }
+
+    @Test
+    void configure_spring_ssl_bundle() {
+        TitanProperties properties = new TitanProperties();
+
+        properties.getSsl().setBundle("titan-client");
+        properties.getSsl().setVerifyHostname(false);
+
+        assertEquals("titan-client", properties.getSsl().getBundle());
+        assertFalse(properties.getSsl().isVerifyHostname());
     }
 }

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfigurationTest.java
@@ -1,10 +1,17 @@
 package org.traffichunter.titan.springframework.stomp.autoconfigure;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.ssl.SslBundle;
+import org.springframework.boot.ssl.SslBundles;
+import org.springframework.boot.ssl.SslManagerBundle;
+import org.springframework.boot.ssl.SslOptions;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.net.JdkTlsContext;
 import org.traffichunter.titan.core.transport.stomp.TitanStompClient;
 import org.traffichunter.titan.core.transport.stomp.VertxStompClient;
 import org.traffichunter.titan.core.transport.stomp.client.StompClient;
@@ -16,9 +23,15 @@ import org.traffichunter.titan.springframework.stomp.TitanProperties;
 import org.traffichunter.titan.springframework.stomp.core.TitanTemplate;
 
 import java.time.Duration;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.TrustManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,7 +44,13 @@ import static org.mockito.Mockito.when;
 class TitanStompClientAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(TitanStompClientAutoConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(
+                    SslAutoConfiguration.class,
+                    TitanStompClientAutoConfiguration.class
+            ));
+
+    @TempDir
+    Path directory;
 
     @Test
     void creates_titan_client_from_titan_client() {
@@ -45,7 +64,8 @@ class TitanStompClientAutoConfigurationTest {
         StompClient client = configuration.titanStompClient(
                 List.of(provider),
                 StompClientOption.builder().build(),
-                properties
+                properties,
+                noSslBundles()
         );
 
         assertThat(client).isInstanceOf(TitanStompClient.class);
@@ -61,7 +81,8 @@ class TitanStompClientAutoConfigurationTest {
         StompClient client = configuration.titanStompClient(
                 List.of(provider),
                 StompClientOption.builder().build(),
-                properties
+                properties,
+                noSslBundles()
         );
 
         assertThat(client).isInstanceOf(VertxStompClient.class);
@@ -80,7 +101,8 @@ class TitanStompClientAutoConfigurationTest {
         StompClient client = configuration.titanStompClient(
                 List.of(provider),
                 StompClientOption.builder().build(),
-                properties
+                properties,
+                noSslBundles()
         );
 
         assertThat(client)
@@ -101,7 +123,8 @@ class TitanStompClientAutoConfigurationTest {
         StompClient client = configuration.titanStompClient(
                 List.of(configuration.titanStompClientProvider(eventLoopGroups)),
                 option,
-                properties
+                properties,
+                noSslBundles()
         );
 
         assertThat(option.host()).isEqualTo("localhost");
@@ -113,7 +136,43 @@ class TitanStompClientAutoConfigurationTest {
     }
 
     @Test
-    void rejects_secure_websocket_endpoint_until_tls_is_supported() {
+    void configures_secure_websocket_from_spring_ssl_bundle() throws Exception {
+        TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
+        ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
+        when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
+        TitanProperties properties = new TitanProperties();
+        properties.setEndpoint("wss://localhost/stomp");
+        properties.getSsl().setBundle("titan-client");
+
+        SslOptions sslOptions = mock(SslOptions.class);
+        when(sslOptions.getEnabledProtocols()).thenReturn(new String[0]);
+        when(sslOptions.getCiphers()).thenReturn(new String[0]);
+        SslBundle sslBundle = mock(SslBundle.class);
+        when(sslBundle.getOptions()).thenReturn(sslOptions);
+        SslManagerBundle managerBundle = mock(SslManagerBundle.class);
+        when(managerBundle.getKeyManagers()).thenReturn(new KeyManager[0]);
+        when(managerBundle.getTrustManagers()).thenReturn(new TrustManager[0]);
+        when(sslBundle.getManagers()).thenReturn(managerBundle);
+
+        StompClient client = configuration.titanStompClient(
+                List.of(configuration.titanStompClientProvider(eventLoopGroups)),
+                configuration.titanStompClientOption(properties),
+                properties,
+                sslBundles(sslBundle)
+        );
+
+        assertThat(client)
+                .isInstanceOf(TitanStompClient.class)
+                .extracting("webSocketPath")
+                .isEqualTo("/stomp");
+        assertThat(client)
+                .extracting("inetClient")
+                .extracting("tlsContext")
+                .isInstanceOf(JdkTlsContext.class);
+    }
+
+    @Test
+    void rejects_secure_websocket_without_ssl_bundle() {
         TitanStompClientAutoConfiguration configuration = new TitanStompClientAutoConfiguration();
         ObjectProvider<EventLoopGroups> eventLoopGroups = mock();
         when(eventLoopGroups.getObject()).thenReturn(mock(EventLoopGroups.class));
@@ -123,10 +182,11 @@ class TitanStompClientAutoConfigurationTest {
         assertThatThrownBy(() -> configuration.titanStompClient(
                 List.of(configuration.titanStompClientProvider(eventLoopGroups)),
                 configuration.titanStompClientOption(properties),
-                properties
+                properties,
+                noSslBundles()
         ))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Secure WebSocket transport is not supported yet");
+                .hasMessage("Secure STOMP endpoint requires spring.titan.ssl.bundle");
     }
 
     @Test
@@ -140,7 +200,8 @@ class TitanStompClientAutoConfigurationTest {
         StompClient client = configuration.titanStompClient(
                 List.of(configuration.vertxStompClientProvider()),
                 StompClientOption.builder().build(),
-                properties
+                properties,
+                noSslBundles()
         );
 
         assertThat(client)
@@ -262,6 +323,51 @@ class TitanStompClientAutoConfigurationTest {
     }
 
     @Test
+    void binds_spring_ssl_bundle_properties() {
+        StompClient client = lifecycleClient(mock(StompConnection.class));
+
+        contextRunner
+                .withBean(StompClient.class, () -> client)
+                .withPropertyValues(
+                        "spring.titan.auto-start=false",
+                        "spring.titan.ssl.bundle=titan-client",
+                        "spring.titan.ssl.verify-hostname=false"
+                )
+                .run(context -> {
+                    TitanProperties properties = context.getBean(TitanProperties.class);
+                    assertThat(properties.getSsl().getBundle()).isEqualTo("titan-client");
+                    assertThat(properties.getSsl().isVerifyHostname()).isFalse();
+                });
+    }
+
+    @Test
+    void creates_titan_client_from_pkcs12_ssl_bundle() throws Exception {
+        Path trustStore = directory.resolve("titan-client.p12");
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, "changeit".toCharArray());
+        try (OutputStream output = Files.newOutputStream(trustStore)) {
+            keyStore.store(output, "changeit".toCharArray());
+        }
+
+        contextRunner
+                .withPropertyValues(
+                        "spring.titan.auto-start=false",
+                        "spring.titan.endpoint=wss://localhost:8443/stomp",
+                        "spring.titan.ssl.bundle=titan-client",
+                        "spring.ssl.bundle.jks.titan-client.truststore.location=" + trustStore.toUri(),
+                        "spring.ssl.bundle.jks.titan-client.truststore.password=changeit",
+                        "spring.ssl.bundle.jks.titan-client.truststore.type=PKCS12"
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(StompClient.class))
+                            .isInstanceOf(TitanStompClient.class)
+                            .extracting("webSocketPath")
+                            .isEqualTo("/stomp");
+                });
+    }
+
+    @Test
     void applies_connect_timeout_to_stomp_client_option() {
         TitanProperties properties = new TitanProperties();
         properties.setConnectTimeoutMillis(2000L);
@@ -283,5 +389,17 @@ class TitanStompClientAutoConfigurationTest {
         when(client.connect()).thenReturn(CompletableFuture.completedFuture(connection));
         when(client.connection()).thenReturn(connection);
         return client;
+    }
+
+    private static ObjectProvider<SslBundles> noSslBundles() {
+        return mock();
+    }
+
+    private static ObjectProvider<SslBundles> sslBundles(SslBundle sslBundle) {
+        SslBundles bundles = mock(SslBundles.class);
+        when(bundles.getBundle("titan-client")).thenReturn(sslBundle);
+        ObjectProvider<SslBundles> provider = mock();
+        when(provider.getIfAvailable()).thenReturn(bundles);
+        return provider;
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/TitanStompClient.java
@@ -45,6 +45,7 @@ import org.traffichunter.titan.core.channel.stomp.StompNetChannelException;
 import org.traffichunter.titan.core.codec.stomp.*;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
+import org.traffichunter.titan.core.net.TlsContext;
 import org.traffichunter.titan.core.resilience.retry.RetryExecutor;
 import org.traffichunter.titan.core.resilience.retry.RetryExecutors;
 import org.traffichunter.titan.core.resilience.retry.RetryResult;
@@ -137,6 +138,18 @@ public final class TitanStompClient implements StompClient {
             throw new IllegalArgumentException("WebSocket path must start with '/'");
         }
         this.webSocketPath = path;
+        return this;
+    }
+
+    /**
+     * Configures transport TLS before the client event loops are started.
+     */
+    @CanIgnoreReturnValue
+    public TitanStompClient tls(TlsContext tlsContext) {
+        if (status.get() != Status.INITIALIZED) {
+            throw new IllegalStateException("Cannot configure TLS after STOMP client start");
+        }
+        inetClient.tls(tlsContext);
         return this;
     }
 


### PR DESCRIPTION
## Motivation:

The Spring STOMP client could configure WebSocket transport but could not use secure TCP or WSS endpoints through Spring Boot's SSL infrastructure. TLS context construction also accepted only file-based key stores, which prevented integration with externally prepared key and trust managers.

## Modification:

- Reworked `TlsOptions` as an immutable builder-based configuration supporting key stores or externally managed key and trust managers.
- Added TLS configuration to the native Titan STOMP client and integrated named Spring SSL Bundles through `spring.titan.ssl`.
- Added secure endpoint validation, hostname verification, TLS protocol and cipher handling, PKCS12 configuration documentation, and compatibility with Spring 6 and 7 JSON message converters.
- Expanded TLS context, transport integration, property binding, and Spring autoconfiguration tests.

## Result:

Titan Spring clients can connect over TLS and WSS using Spring Boot SSL Bundles while retaining Spring Boot 3 and 4 compatibility.

Validated with:

```bash
./gradlew :core:test :titan-spring-client:test :smoke-test:smoke-spring:test
```
