### PR TITLE
Define buffer allocation and ownership boundaries

### DIFF
--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/DispatcherBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/DispatcherBenchmark.java
@@ -20,7 +20,6 @@ import org.traffichunter.titan.core.message.dispatcher.MapDispatcher;
 import org.traffichunter.titan.core.message.dispatcher.TrieDispatcher;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
@@ -60,7 +59,7 @@ public class DispatcherBenchmark {
                 .destination(exactKey)
                 .createdAt(Instant.now())
                 .producerId("benchmark-producer")
-                .body(Buffer.alloc("payload"))
+                .body("payload".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
     }
 

--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
@@ -25,7 +25,6 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.fanout.AggregationResult;
 import org.traffichunter.titan.fanout.DispatchGateway;
 import org.traffichunter.titan.fanout.DispatchMode;
@@ -58,7 +57,7 @@ public class FanoutGatewayBenchmark {
                 .destination(destination)
                 .createdAt(Instant.now())
                 .producerId("benchmark-producer")
-                .body(Buffer.alloc("payload"))
+                .body("payload".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
         batchMessages = createBatchMessages(destination, batchSize);
 
@@ -103,7 +102,7 @@ public class FanoutGatewayBenchmark {
                     .destination(destination)
                     .createdAt(Instant.now())
                     .producerId("benchmark-producer-" + i)
-                    .body(Buffer.alloc("payload-" + i))
+                    .body(("payload-" + i).getBytes(java.nio.charset.StandardCharsets.UTF_8))
                     .build());
         }
         return messages;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
@@ -108,7 +108,7 @@ public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
     }
 
     private void processRead(NetChannel channel, ChannelHandlerChain chain) {
-        Buffer buffer = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, Buffers.DEFAULT_MAX_CAPACITY);
+        Buffer buffer = Buffer.direct().alloc(Buffers.DEFAULT_INITIAL_CAPACITY, Buffers.DEFAULT_MAX_CAPACITY);
         final int read;
         try {
             read = channel.internal().read(buffer);

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandlerImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketControlFrameHandlerImpl.java
@@ -50,7 +50,7 @@ public final class WebSocketControlFrameHandlerImpl implements WebSocketControlF
         WebSocketFrame frame = context.frame();
         try {
             WebSocketFrame pong = WebSocketFrames.pong(
-                    Buffer.alloc(frame.payload().getBytes()),
+                    Buffer.heap().alloc(frame.payload().getBytes()),
                     context.side(),
                     frame.subProtocol()
             );
@@ -62,7 +62,7 @@ public final class WebSocketControlFrameHandlerImpl implements WebSocketControlF
 
     private void handleClose(WebSocketContext context) {
         WebSocketFrame frame = context.frame();
-        Buffer closePayload = Buffer.alloc(frame.payload().getBytes());
+        Buffer closePayload = Buffer.heap().alloc(frame.payload().getBytes());
         try {
             WebSocketFrame close = WebSocketFrames.close(
                     closePayload,

--- a/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
@@ -45,7 +45,7 @@ public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoClose
      * Combines a previously retained buffer with newly received bytes.
      */
     public static final MergeBuffer MERGE_BUFFER = ((mergeBuffer, in) -> {
-        final Buffer newBuffer = Buffer.alloc(mergeBuffer.length() + in.length());
+        final Buffer newBuffer = Buffer.heap().alloc(mergeBuffer.length() + in.length());
         boolean isExpanding = false;
         try {
             newBuffer.accumulateBuffer(mergeBuffer);

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrame.java
@@ -57,7 +57,7 @@ public record WebSocketFrame(
             throw new WebSocketFrameException("Frame payload length mismatch: header=" + payloadLength + ", actual=" + payload.length());
         }
 
-        Buffer frame = Buffer.alloc(Math.addExact(header.size(), payload.length()));
+        Buffer frame = Buffer.heap().alloc(Math.addExact(header.size(), payload.length()));
         try {
             int firstByte = (header.isFin() ? 0x80 : 0) | header.getOpCode().code();
             int maskBit = header.isMasked() ? 0x80 : 0;

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameHeader.java
@@ -90,7 +90,7 @@ public class WebSocketFrameHeader {
 
     static Buffer unmask(Buffer payload, int maskingKey) {
         try {
-            return Buffer.alloc(unmask(payload.getBytes(), maskingKey));
+            return Buffer.heap().alloc(unmask(payload.getBytes(), maskingKey));
         } finally {
             payload.release();
         }
@@ -106,7 +106,7 @@ public class WebSocketFrameHeader {
 
     Buffer mask(Buffer payload) {
         try {
-            return Buffer.alloc(mask(payload.getBytes()));
+            return Buffer.heap().alloc(mask(payload.getBytes()));
         } finally {
             payload.release();
         }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrames.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrames.java
@@ -87,7 +87,7 @@ public final class WebSocketFrames {
 
         Assert.check(reasonBytes.length <= 123, () -> new WebSocketFrameException("Close reason must be at most 123 bytes"));
 
-        Buffer payload = Buffer.alloc(Short.BYTES + reasonBytes.length)
+        Buffer payload = Buffer.heap().alloc(Short.BYTES + reasonBytes.length)
                 .accumulateUnsignedShort(statusCode)
                 .accumulateBytes(reasonBytes);
 

--- a/core/src/main/java/org/traffichunter/titan/core/message/Message.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/Message.java
@@ -30,9 +30,14 @@ import lombok.Builder;
 import lombok.Getter;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
+ * Message stored and routed by Titan's dispatcher queues.
+ *
+ * <p>The payload is kept as a heap byte array rather than a reference-counted transport buffer.
+ * The constructor copies the supplied array, so queued messages do not retain codec or network
+ * resources and do not require explicit release.</p>
+ *
  * @author yungwang-o
  */
 @Getter
@@ -56,12 +61,12 @@ public final class Message {
     public Message(final Destination destination,
                    final Instant createdAt,
                    final String producerId,
-                   final Buffer body
+                   final byte[] body
     ) {
         this.destination = Objects.requireNonNull(destination, "routingKey");
         this.createdAt = Objects.requireNonNull(createdAt, "createdAt");
         this.producerId = Objects.requireNonNull(producerId, "producerId");
-        this.body = Objects.requireNonNull(body, "body").getBytes();
+        this.body = Objects.requireNonNull(body, "body").clone();
         this.size = this.body.length;
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/net/JdkTlsHandler.java
@@ -235,7 +235,7 @@ class JdkTlsHandler extends TlsHandler {
 
     private Buffer wrap(Buffer plainBuffer) throws SSLException {
         int packetSize = sslEngine.getSession().getPacketBufferSize();
-        Buffer encrypted = Buffer.alloc(packetSize);
+        Buffer encrypted = Buffer.direct().alloc(packetSize);
         boolean success = false;
 
         try {
@@ -276,7 +276,7 @@ class JdkTlsHandler extends TlsHandler {
 
     private @Nullable Buffer unwrap(NetChannel channel, Buffer encrypted) throws SSLException {
         int appBufferSize = sslEngine.getSession().getApplicationBufferSize();
-        Buffer plainText = Buffer.alloc(appBufferSize);
+        Buffer plainText = Buffer.direct().alloc(appBufferSize);
         boolean success = false;
 
         try {
@@ -317,7 +317,7 @@ class JdkTlsHandler extends TlsHandler {
     }
 
     private void writeHandshake(NetChannel channel) throws SSLException {
-        Buffer empty = Buffer.empty();
+        Buffer empty = Buffer.heap().empty();
         Buffer encrypted = null;
         try {
             encrypted = wrap(empty);
@@ -338,7 +338,7 @@ class JdkTlsHandler extends TlsHandler {
     }
 
     private void unwrapAgain(NetChannel channel) throws SSLException {
-        Buffer empty = Buffer.empty();
+        Buffer empty = Buffer.heap().empty();
         Buffer plainText = null;
         try {
             plainText = unwrap(channel, empty);
@@ -367,8 +367,8 @@ class JdkTlsHandler extends TlsHandler {
     }
 
     private Buffer wrapCloseNotify() throws SSLException {
-        Buffer source = Buffer.empty();
-        Buffer encrypted = Buffer.alloc(sslEngine.getSession().getPacketBufferSize());
+        Buffer source = Buffer.heap().empty();
+        Buffer encrypted = Buffer.direct().alloc(sslEngine.getSession().getPacketBufferSize());
         boolean success = false;
 
         try {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -93,7 +93,7 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
         Promise<NetChannel> upgradeResult = Promise.newPromise(channel.eventLoop());
         channel.chain().add(new WebSocketUpgradeHandler(this, key, upgradeResult));
 
-        channel.writeAndFlush(Buffer.alloc(request.toString())).addListener(result -> {
+        channel.writeAndFlush(Buffer.heap().alloc(request.toString())).addListener(result -> {
             if (result.isFailed() && !upgradeResult.isDone()) {
                 Throwable error = result.error();
                 upgradeResult.fail(error == null

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -177,7 +177,7 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
         @Override
         protected void handleHead(NetChannel channel, String head) {
             HttpRequest parsed = handshaker.parseRequest(head);
-            channel.writeAndFlush(Buffer.alloc(handshaker.createResponse(parsed)));
+            channel.writeAndFlush(Buffer.heap().alloc(handshaker.createResponse(parsed)));
             installWebSocketCodec(channel, WebSocketSide.SERVER, handshaker.subProtocol());
             request = parsed;
         }

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffer.java
@@ -27,89 +27,88 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.netty.buffer.ByteBuf;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.Objects;
-import org.traffichunter.titan.core.codec.base64.Base64Codec;
 import org.traffichunter.titan.core.util.Clearable;
 
 /**
- * Byte buffer abstraction used by Titan codecs and transports.
+ * Reference-counted byte buffer used inside Titan codecs and transports.
  *
  * <p>{@code Buffer} wraps Netty's {@link ByteBuf} while keeping the rest of the codebase
  * independent from direct Netty APIs. It preserves the familiar reader/writer index model:
  * read operations consume or inspect readable bytes, and {@code accumulate*} operations append
  * bytes at the writer index.</p>
  *
- * <p>Buffers are reference-counted through the underlying {@link ByteBuf}. Callers that keep
- * slices or pass buffers across asynchronous boundaries should use {@link #retain()} or retained
- * slice operations where ownership must outlive the current handler call.</p>
+ * <p>Every buffer returned by an allocator owns one reference to its underlying {@link ByteBuf}.
+ * The owner must either call {@link #release()} exactly once or transfer that reference to an API
+ * whose contract takes ownership. Passing a buffer to a borrowing API does not transfer that
+ * responsibility.</p>
+ *
+ * <p>Use {@link #heap()} for short-lived codec and protocol processing. Use {@link #direct()} only
+ * where native I/O benefits from direct memory, such as socket reads and TLS packet processing.
+ * Messages stored by queues and fanout use byte arrays rather than {@code Buffer}, so their
+ * lifetime is managed by the JVM.</p>
+ *
+ * <p>Non-retained slices share both storage and reference count with their parent. Use retained
+ * slice operations only when a view must outlive the current call, and release that retained
+ * reference when it is no longer needed.</p>
  *
  * @author yungwang-o
  */
 public interface Buffer extends Clearable {
 
     /**
-     * Allocates a direct buffer with bounded capacity.
+     * Returns the shared pooled allocator for short-lived heap buffers.
+     *
+     * <p>Heap buffers remain reference-counted and must be released even though their storage is
+     * located in JVM heap memory.</p>
      */
-    static Buffer alloc(final int initialCapacity, final int maxCapacity) {
-        return new InternalBuffer(initialCapacity, maxCapacity);
+    static BufferAllocator heap() {
+        return BufferAllocators.HEAP;
     }
 
     /**
-     * Allocates a direct buffer using the default maximum capacity of the allocator.
+     * Returns the shared pooled allocator for native transport buffers.
+     *
+     * <p>Prefer this allocator at socket and TLS boundaries. Application state and queued message
+     * payloads should not retain direct buffers.</p>
      */
-    static Buffer alloc(final int initialCapacity) {
-        return new InternalBuffer(initialCapacity);
-    }
-
-    static Buffer alloc(final String data) {
-        Objects.requireNonNull(data);
-        return new InternalBuffer(data);
-    }
-
-    static Buffer alloc(final String data, final Charset charset) {
-        Objects.requireNonNull(data); Objects.requireNonNull(charset);
-        return new InternalBuffer(data, charset);
-    }
-
-    static Buffer alloc(final byte[] data) {
-        Objects.requireNonNull(data);
-        return new InternalBuffer(data);
-    }
-
-    static Buffer allocAfterBase64Decode(final String data) {
-        Objects.requireNonNull(data);
-        byte[] decode = Base64Codec.decode(data);
-        return new InternalBuffer(decode);
-    }
-
-    static Buffer empty() {
-        return new InternalBuffer();
+    static BufferAllocator direct() {
+        return BufferAllocators.DIRECT;
     }
 
     /**
-     * Wraps an existing {@link ByteBuf}. Ownership follows the wrapped buffer's reference count.
+     * Wraps an existing {@link ByteBuf} without retaining it.
+     *
+     * <p>The returned wrapper represents the reference already owned by the supplied buffer. The
+     * caller must not release both objects as if they owned independent references.</p>
      */
     static Buffer buffer(final ByteBuf buffer) {
         return new InternalBuffer(buffer);
     }
 
     /**
-     * Returns a NIO view over the readable/writable region of the underlying buffer.
+     * Returns a shared NIO view over the readable bytes of this buffer.
+     *
+     * <p>The view has no independent lifetime and must not be used after this buffer is released.</p>
      */
     ByteBuffer byteBuffer();
 
     /**
-     * Exposes the underlying Netty buffer for channel I/O and codec internals.
+     * Exposes a borrowed reference to the underlying Netty buffer for channel I/O and codec
+     * internals.
+     *
+     * <p>Calling this method does not retain the returned buffer.</p>
      */
     ByteBuf byteBuf();
 
     /**
-     * Releases one reference to the underlying buffer.
+     * Releases the reference represented by this buffer.
      */
     void release();
 
     /**
-     * Retains the underlying buffer and returns a buffer view for the retained reference.
+     * Adds one reference to the underlying storage.
+     *
+     * <p>The returned buffer must eventually be released independently from the original owner.</p>
      */
     Buffer retain();
 
@@ -266,19 +265,21 @@ public interface Buffer extends Clearable {
     }
 
     /**
-     * Creates a copy with independent storage.
+     * Creates an owned copy with independent storage and reference count.
      */
     @CanIgnoreReturnValue
     Buffer copy();
 
     /**
-     * Creates a non-retained slice sharing the underlying storage.
+     * Creates a non-retained slice sharing storage and reference count with this buffer.
+     *
+     * <p>The slice must not outlive this buffer.</p>
      */
     @CanIgnoreReturnValue
     Buffer slice();
 
     /**
-     * Creates a retained slice sharing the underlying storage.
+     * Creates a retained slice with an independently releasable reference to shared storage.
      */
     @CanIgnoreReturnValue
     Buffer retainSlice();

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAccumulator.java
@@ -49,7 +49,7 @@ public final class BufferAccumulator implements Clearable {
 
     public BufferAccumulator(int maxAccumulatedSize) {
         this.maxAccumulatedSize = maxAccumulatedSize;
-        this.accumulator = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
+        this.accumulator = Buffer.heap().alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
     }
 
     /**
@@ -162,7 +162,7 @@ public final class BufferAccumulator implements Clearable {
         if (accumulator != null) {
             accumulator.release();
         }
-        accumulator = Buffer.alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
+        accumulator = Buffer.heap().alloc(Buffers.DEFAULT_INITIAL_CAPACITY, maxAccumulatedSize);
     }
 
     /**

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocator.java
@@ -1,0 +1,72 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+import java.nio.charset.Charset;
+
+/**
+ * Allocates owned Titan buffers using a fixed heap or direct-memory policy.
+ *
+ * <p>Every allocation returns a reference-counted buffer owned by the caller. Both heap and
+ * direct implementations use pooled Netty storage, so every returned buffer must be released or
+ * transferred to another owner.</p>
+ *
+ * <p>Heap buffers are intended for short-lived codec and protocol work. Direct buffers are
+ * intended for native transport boundaries such as socket reads and TLS processing. Long-lived
+ * message and queue data should use byte arrays instead of this API.</p>
+ *
+ * @author yun
+ */
+public interface BufferAllocator {
+
+    Buffer alloc();
+
+    Buffer alloc(int initialCapacity);
+
+    Buffer alloc(int initialCapacity, int maxCapacity);
+
+    /**
+     * Allocates a buffer and copies the supplied bytes into its storage.
+     */
+    Buffer alloc(byte[] data);
+
+    /**
+     * Allocates a buffer containing the UTF-8 representation of the supplied string.
+     */
+    Buffer alloc(String data);
+
+    Buffer alloc(String data, Charset charset);
+
+    /**
+     * Decodes Base64 text and copies the decoded bytes into a new buffer.
+     */
+    Buffer allocAfterBase64Decode(String data);
+
+    /**
+     * Allocates an empty buffer using this allocator's memory policy.
+     */
+    default Buffer empty() {
+        return alloc(0);
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocators.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocators.java
@@ -1,0 +1,37 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+/**
+ * Holds the shared allocators exposed through {@link Buffer}.
+ *
+ * @author yun
+ */
+final class BufferAllocators {
+
+    static final BufferAllocator HEAP = new HeapBufferAllocator();
+    static final BufferAllocator DIRECT = new DirectBufferAllocator();
+
+    private BufferAllocators() {}
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/DirectBufferAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/DirectBufferAllocator.java
@@ -1,0 +1,76 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+import io.netty.buffer.ByteBufAllocator;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import org.traffichunter.titan.core.codec.base64.Base64Codec;
+
+/**
+ * Allocates reference-counted buffers from Netty's pooled native memory.
+ *
+ * @author yun
+ */
+final class DirectBufferAllocator implements BufferAllocator {
+
+    private static final ByteBufAllocator ALLOCATOR = PooledByteBufAllocator.DEFAULT;
+
+    @Override
+    public Buffer alloc() {
+        return alloc(0);
+    }
+
+    @Override
+    public Buffer alloc(int initialCapacity) {
+        return new InternalBuffer(ALLOCATOR.directBuffer(initialCapacity));
+    }
+
+    @Override
+    public Buffer alloc(int initialCapacity, int maxCapacity) {
+        return new InternalBuffer(ALLOCATOR.directBuffer(initialCapacity, maxCapacity));
+    }
+
+    @Override
+    public Buffer alloc(byte[] data) {
+        return new InternalBuffer(ALLOCATOR.directBuffer(data.length).writeBytes(data));
+    }
+
+    @Override
+    public Buffer alloc(String data) {
+        return alloc(data, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Buffer alloc(String data, Charset charset) {
+        return alloc(data.getBytes(charset));
+    }
+
+    @Override
+    public Buffer allocAfterBase64Decode(String data) {
+        return alloc(Base64Codec.decode(data));
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/HeapBufferAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/HeapBufferAllocator.java
@@ -1,0 +1,76 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.util.buffer;
+
+import io.netty.buffer.ByteBufAllocator;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import io.netty.buffer.PooledByteBufAllocator;
+import org.traffichunter.titan.core.codec.base64.Base64Codec;
+
+/**
+ * Allocates reference-counted buffers from Netty's pooled JVM heap storage.
+ *
+ * @author yun
+ */
+final class HeapBufferAllocator implements BufferAllocator {
+
+    private static final ByteBufAllocator ALLOCATOR = PooledByteBufAllocator.DEFAULT;
+
+    @Override
+    public Buffer alloc() {
+        return alloc(0);
+    }
+
+    @Override
+    public Buffer alloc(int initialCapacity) {
+        return new InternalBuffer(ALLOCATOR.heapBuffer(initialCapacity));
+    }
+
+    @Override
+    public Buffer alloc(int initialCapacity, int maxCapacity) {
+        return new InternalBuffer(ALLOCATOR.heapBuffer(initialCapacity, maxCapacity));
+    }
+
+    @Override
+    public Buffer alloc(byte[] data) {
+        return new InternalBuffer(ALLOCATOR.heapBuffer(data.length).writeBytes(data));
+    }
+
+    @Override
+    public Buffer alloc(String data) {
+        return alloc(data, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public Buffer alloc(String data, Charset charset) {
+        return alloc(data.getBytes(charset));
+    }
+
+    @Override
+    public Buffer allocAfterBase64Decode(String data) {
+        return alloc(Base64Codec.decode(data));
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
@@ -29,52 +29,26 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-import io.netty.buffer.ByteBufAllocator;
-import lombok.extern.slf4j.Slf4j;
 import org.traffichunter.titan.core.util.Assert;
 
 /**
- * Default {@link Buffer} implementation backed by a Netty {@link ByteBuf}.
+ * Internal {@link Buffer} wrapper backed by a Netty {@link ByteBuf}.
  *
- * <p>The implementation delegates most primitive accessors directly to {@code ByteBuf}.
- * Append-style methods use Netty's writer index, while slice methods preserve Netty's
- * shared-storage semantics. When appending strings, the buffer expands beyond its current
- * max capacity by allocating a larger direct buffer and copying existing contents.</p>
+ * <p>This class does not choose an initial allocation policy. {@link BufferAllocator}
+ * implementations create the underlying storage and this wrapper delegates primitive access,
+ * reader/writer indexes, slicing, copying and reference counting to it. Internal growth preserves
+ * the current buffer's heap or direct memory type.</p>
  *
- * <p>Reference: Vert.x buffer API shape.</p>
+ * <p>The class is package-private so callers cannot bypass {@link Buffer#heap()} and
+ * {@link Buffer#direct()} when creating buffers.</p>
  *
  * @author yungwang-o
  */
-@Slf4j
-public class InternalBuffer implements Buffer {
+final class InternalBuffer implements Buffer {
 
     private ByteBuf buf;
 
-    public InternalBuffer() {
-        this(0);
-    }
-
-    public InternalBuffer(final String src) {
-        this(src.getBytes(StandardCharsets.UTF_8));
-    }
-
-    public InternalBuffer(final String src, final Charset charset) {
-        this(src.getBytes(charset));
-    }
-
-    public InternalBuffer(final int initialCapacity, final int maxCapacity) {
-        this.buf = ByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
-    }
-
-    public InternalBuffer(final int initialCapacity) {
-        this.buf = ByteBufAllocator.DEFAULT.directBuffer(initialCapacity);
-    }
-
-    public InternalBuffer(final byte[] bytes) {
-        this.buf = ByteBufAllocator.DEFAULT.directBuffer(bytes.length).writeBytes(bytes);
-    }
-
-    public InternalBuffer(final ByteBuf buf) {
+    InternalBuffer(final ByteBuf buf) {
         this.buf = buf;
     }
 
@@ -207,8 +181,9 @@ public class InternalBuffer implements Buffer {
 
     @Override
     public Buffer getBuffer(final int start, final int length) {
-        final byte[] bytes = getBytes(start, length);
-        return new InternalBuffer(bytes);
+        ByteBuf copy = allocateLike(length);
+        copy.writeBytes(buf, start, length);
+        return new InternalBuffer(copy);
     }
 
     @Override
@@ -568,7 +543,7 @@ public class InternalBuffer implements Buffer {
 
     private void reAlloc(final int capacity) {
         ByteBuf previous = buf;
-        ByteBuf replacement = previous.alloc().directBuffer(capacity);
+        ByteBuf replacement = allocateLike(capacity);
         boolean replaced = false;
         try {
             replacement.writeBytes(previous, previous.readerIndex(), previous.readableBytes());
@@ -581,5 +556,11 @@ public class InternalBuffer implements Buffer {
                 replacement.release();
             }
         }
+    }
+
+    private ByteBuf allocateLike(int capacity) {
+        return buf.isDirect()
+                ? buf.alloc().directBuffer(capacity)
+                : buf.alloc().heapBuffer(capacity);
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/util/file/LocalFileHandle.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/file/LocalFileHandle.java
@@ -74,7 +74,7 @@ final class LocalFileHandle implements FileHandle {
         Assert.checkArgument(position >= 0, "position must be greater than or equal to zero");
         Assert.checkArgument(length >= 0, "length must be greater than or equal to zero");
 
-        Buffer destination = Buffer.alloc(length);
+        Buffer destination = Buffer.heap().alloc(length);
         try {
             ByteBuffer buffer = Buffers.writableByteBuffer(destination);
             long nextPosition = position;

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImplTest.java
@@ -21,7 +21,7 @@ class ChannelInBoundHandlerChainImplTest {
 
     @Test
     void when_terminal_chain_then_buffer_refCnt_is_zero() {
-        Buffer buf = Buffer.alloc("data");
+        Buffer buf = Buffer.heap().alloc("data");
         ChannelHandlerChain chain = new ChannelHandlerChain();
 
         chain.processChannelRead(new InMemoryNetChannel(), buf);
@@ -33,7 +33,7 @@ class ChannelInBoundHandlerChainImplTest {
 
     @Test
     void when_pass_through_handler_then_buffer_released_at_chain_end() {
-        Buffer buf = Buffer.alloc("data");
+        Buffer buf = Buffer.heap().alloc("data");
         ChannelHandlerChain chain = new ChannelHandlerChain();
         chain.add(new PassThroughHandler());
 
@@ -46,7 +46,7 @@ class ChannelInBoundHandlerChainImplTest {
 
     @Test
     void when_handler_retains_buffer_then_refCnt_reflects_retain() {
-        Buffer buf = Buffer.alloc("data");
+        Buffer buf = Buffer.heap().alloc("data");
         ChannelHandlerChain chain = new ChannelHandlerChain();
         chain.add(new RetainingHandler());
 
@@ -62,7 +62,7 @@ class ChannelInBoundHandlerChainImplTest {
 
     @Test
     void addFirst_places_inbound_handler_before_existing_handlers() {
-        Buffer buf = Buffer.alloc("data");
+        Buffer buf = Buffer.heap().alloc("data");
         List<String> order = new ArrayList<>();
         ChannelHandlerChain chain = new ChannelHandlerChain();
         chain.add(new RecordingInboundHandler("second", order));
@@ -75,7 +75,7 @@ class ChannelInBoundHandlerChainImplTest {
 
     @Test
     void remove_detaches_inbound_handler_and_preserves_tail() {
-        Buffer buf = Buffer.alloc("data");
+        Buffer buf = Buffer.heap().alloc("data");
         List<String> order = new ArrayList<>();
         ChannelHandlerChain chain = new ChannelHandlerChain();
         RecordingInboundHandler first = new RecordingInboundHandler("first", order);

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImplTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImplTest.java
@@ -41,7 +41,7 @@ class ChannelOutBoundHandlerChainImplTest {
 
     @Test
     void terminal_chain_writes_to_internal_channel() {
-        Buffer buffer = Buffer.alloc("data");
+        Buffer buffer = Buffer.heap().alloc("data");
         InMemoryNetChannel channel = new InMemoryNetChannel();
         ChannelOutBoundHandlerChainImpl chain = new ChannelOutBoundHandlerChainImpl();
 
@@ -58,7 +58,7 @@ class ChannelOutBoundHandlerChainImplTest {
 
     @Test
     void addFirst_places_handler_before_existing_handlers() {
-        Buffer buffer = Buffer.alloc("data");
+        Buffer buffer = Buffer.heap().alloc("data");
         List<String> order = new ArrayList<>();
         InMemoryNetChannel channel = new InMemoryNetChannel();
         ChannelOutBoundHandlerChainImpl chain = new ChannelOutBoundHandlerChainImpl()
@@ -75,7 +75,7 @@ class ChannelOutBoundHandlerChainImplTest {
 
     @Test
     void remove_detaches_handler_and_preserves_tail() {
-        Buffer buffer = Buffer.alloc("data");
+        Buffer buffer = Buffer.heap().alloc("data");
         List<String> order = new ArrayList<>();
         InMemoryNetChannel channel = new InMemoryNetChannel();
         RecordingHandler first = new RecordingHandler("first", order);

--- a/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/NetChannelInternalTest.java
@@ -89,7 +89,7 @@ class NetChannelInternalTest {
         channel.register(eventLoop);
 
         try {
-            Buffer pipelineBuffer = Buffer.alloc("pipeline");
+            Buffer pipelineBuffer = Buffer.heap().alloc("pipeline");
             ChannelPromise publicWrite = channel.writeAndFlush(pipelineBuffer);
             publicWrite.await(2, TimeUnit.SECONDS);
             pipelineBuffer.release();
@@ -99,7 +99,7 @@ class NetChannelInternalTest {
             assertThat(pipelineWrites).hasValue(1);
             release(channel.pollWritten());
 
-            Buffer internalBuffer = Buffer.alloc("internal");
+            Buffer internalBuffer = Buffer.heap().alloc("internal");
             channel.internal().writeAndFlush(internalBuffer);
             internalBuffer.release();
 

--- a/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/WebSocketChannelTest.java
@@ -54,7 +54,7 @@ class WebSocketChannelTest {
         eventLoop.start();
         delegate.register(eventLoop);
         WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
-        Buffer payload = Buffer.alloc("data");
+        Buffer payload = Buffer.heap().alloc("data");
 
         try {
             ChannelPromise write = channel.writeAndFlush(payload);
@@ -86,7 +86,7 @@ class WebSocketChannelTest {
         when(delegate.eventLoop()).thenReturn(eventLoop);
         when(eventLoop.inEventLoop()).thenReturn(true);
         WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrame frame = new WebSocketFrame(
                 WebSocketFrameHeader.builder()
                         .op(WebSocketFrameHeader.OpCode.TEXT, true)
@@ -113,7 +113,7 @@ class WebSocketChannelTest {
     void reject_frame_with_different_subprotocol() {
         NetChannel delegate = mock(NetChannel.class);
         WebSocketChannel channel = new WebSocketChannel(delegate, Protocol.STOMP);
-        Buffer payload = Buffer.alloc("data");
+        Buffer payload = Buffer.heap().alloc("data");
         WebSocketFrame frame = new WebSocketFrame(
                 WebSocketFrameHeader.builder()
                         .op(WebSocketFrameHeader.OpCode.BINARY, true)

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameDecoderTest.java
@@ -24,7 +24,7 @@ class WebSocketFrameDecoderTest {
         InMemoryNetChannel channel = new InMemoryNetChannel();
 
         byte[] bytes = {(byte) 0x81, (byte) 0x02, 'O', 'K'};
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -42,7 +42,7 @@ class WebSocketFrameDecoderTest {
         InMemoryNetChannel channel = new InMemoryNetChannel();
 
         byte[] bytes = {(byte) 0x81, (byte) 0x04, 'O', 'K', 'O', 'K'};
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -61,7 +61,7 @@ class WebSocketFrameDecoderTest {
 
         // ASCII payloads = 'A', 'B', 'A', 'B'
         byte[] bytes = {(byte) 0x82, (byte) 0x04, (byte) 0x41, (byte) 0x42, (byte) 0x41, (byte) 0x42};
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -89,7 +89,7 @@ class WebSocketFrameDecoderTest {
                 body[0],
                 body[1]
         };
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -115,7 +115,7 @@ class WebSocketFrameDecoderTest {
                 'O',
                 'K'
         };
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -138,7 +138,7 @@ class WebSocketFrameDecoderTest {
         bytes[2] = 0x00;
         bytes[3] = 0x7E;
         System.arraycopy(body, 0, bytes, 4, body.length);
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -168,7 +168,7 @@ class WebSocketFrameDecoderTest {
         bytes[8] = 0x00;
         bytes[9] = 0x00;
         System.arraycopy(body, 0, bytes, 10, body.length);
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -185,7 +185,7 @@ class WebSocketFrameDecoderTest {
     @Test
     void return_null_when_frame_header_is_incomplete() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81});
+        Buffer buffer = Buffer.heap().alloc(new byte[]{(byte) 0x81});
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -200,7 +200,7 @@ class WebSocketFrameDecoderTest {
     @Test
     void preserve_buffer_when_extended_length_is_incomplete() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81, 0x7E, 0x00});
+        Buffer buffer = Buffer.heap().alloc(new byte[]{(byte) 0x81, 0x7E, 0x00});
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -216,7 +216,7 @@ class WebSocketFrameDecoderTest {
     @Test
     void preserve_buffer_when_payload_is_incomplete() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x81, 0x04, 'O', 'K'});
+        Buffer buffer = Buffer.heap().alloc(new byte[]{(byte) 0x81, 0x04, 'O', 'K'});
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -285,7 +285,7 @@ class WebSocketFrameDecoderTest {
     @Test
     void consume_close_frame_without_forwarding_payload() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x88, 0x00});
+        Buffer buffer = Buffer.heap().alloc(new byte[]{(byte) 0x88, 0x00});
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);
@@ -300,7 +300,7 @@ class WebSocketFrameDecoderTest {
     @Test
     void consume_ping_frame_without_forwarding_payload() {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(new byte[]{(byte) 0x89, 0x02, 'O', 'K'});
+        Buffer buffer = Buffer.heap().alloc(new byte[]{(byte) 0x89, 0x02, 'O', 'K'});
         AtomicReference<WebSocketContext> received = new AtomicReference<>();
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder(
@@ -340,7 +340,7 @@ class WebSocketFrameDecoderTest {
 
     private static void assertInvalidFrameClosesChannel(byte[] bytes) {
         InMemoryNetChannel channel = new InMemoryNetChannel();
-        Buffer buffer = Buffer.alloc(bytes);
+        Buffer buffer = Buffer.heap().alloc(bytes);
 
         WebSocketFrameDecoder decoder = new WebSocketFrameDecoder();
         Buffer payload = decoder.decode(channel, buffer);

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameEncoderTest.java
@@ -36,7 +36,7 @@ class WebSocketFrameEncoderTest {
 
     @Test
     void release_input_after_encoding_server_frame() {
-        Buffer input = Buffer.alloc("OK");
+        Buffer input = Buffer.heap().alloc("OK");
 
         Buffer encoded = new WebSocketFrameEncoder(WebSocketSide.SERVER)
                 .encode(new InMemoryNetChannel(), input);
@@ -50,7 +50,7 @@ class WebSocketFrameEncoderTest {
 
     @Test
     void release_input_after_encoding_client_frame() {
-        Buffer input = Buffer.alloc("OK");
+        Buffer input = Buffer.heap().alloc("OK");
 
         Buffer encoded = new WebSocketFrameEncoder(WebSocketSide.CLIENT)
                 .encode(new InMemoryNetChannel(), input);

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFrameTest.java
@@ -37,7 +37,7 @@ class WebSocketFrameTest {
 
     @Test
     void convert_unmasked_frame_to_buffer() {
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrameHeader header = WebSocketFrameHeader.builder()
                 .op(TEXT, true)
                 .payloadLength(payload.length())
@@ -55,7 +55,7 @@ class WebSocketFrameTest {
 
     @Test
     void convert_masked_frame_to_buffer() {
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrameHeader header = WebSocketFrameHeader.builder()
                 .op(TEXT, true)
                 .masked(0x01020304)
@@ -83,7 +83,7 @@ class WebSocketFrameTest {
 
     @Test
     void reject_payload_length_mismatch() {
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrameHeader header = WebSocketFrameHeader.builder()
                 .op(TEXT, true)
                 .payloadLength(1)

--- a/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFramesTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/codec/websocket/WebSocketFramesTest.java
@@ -37,7 +37,7 @@ class WebSocketFramesTest {
 
     @Test
     void create_unmasked_server_ping_frame() {
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrame frame = WebSocketFrames.ping(payload, WebSocketSide.SERVER, Protocol.STOMP);
 
         assertThat(frame.header().getOpCode()).isEqualTo(WebSocketFrameHeader.OpCode.PING);
@@ -49,7 +49,7 @@ class WebSocketFramesTest {
 
     @Test
     void create_masked_client_pong_frame() {
-        Buffer payload = Buffer.alloc("OK");
+        Buffer payload = Buffer.heap().alloc("OK");
         WebSocketFrame frame = WebSocketFrames.pong(payload, WebSocketSide.CLIENT, Protocol.STOMP);
 
         assertThat(frame.header().getOpCode()).isEqualTo(WebSocketFrameHeader.OpCode.PONG);
@@ -70,7 +70,7 @@ class WebSocketFramesTest {
 
     @Test
     void reject_oversized_control_frame_payload() {
-        Buffer payload = Buffer.alloc(new byte[126]);
+        Buffer payload = Buffer.heap().alloc(new byte[126]);
 
         assertThatThrownBy(() -> WebSocketFrames.ping(payload, WebSocketSide.SERVER, Protocol.STOMP))
                 .isInstanceOf(WebSocketFrameException.class)
@@ -81,7 +81,7 @@ class WebSocketFramesTest {
 
     @Test
     void reject_one_byte_close_payload() {
-        Buffer payload = Buffer.alloc(new byte[1]);
+        Buffer payload = Buffer.heap().alloc(new byte[1]);
 
         assertThatThrownBy(() -> WebSocketFrames.close(payload, WebSocketSide.SERVER, Protocol.STOMP))
                 .isInstanceOf(WebSocketFrameException.class)

--- a/core/src/test/java/org/traffichunter/titan/core/message/MessageTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/message/MessageTest.java
@@ -1,0 +1,52 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.Destination;
+
+/**
+ * @author yun
+ */
+class MessageTest {
+
+    @Test
+    void copy_payload_before_storing_message() {
+        byte[] payload = {1, 2, 3};
+
+        Message message = Message.builder()
+                .destination(Destination.create("/queue/test"))
+                .createdAt(Instant.now())
+                .producerId("producer")
+                .body(payload)
+                .build();
+
+        payload[0] = 9;
+
+        assertThat(message.getBody()).containsExactly((byte) 1, (byte) 2, (byte) 3);
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueueTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/message/dispatcher/MessageDispatcherQueueTest.java
@@ -64,7 +64,7 @@ class MessageDispatcherQueueTest {
                 .destination(Destination.create(destination))
                 .createdAt(Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("test".getBytes()))
+                .body("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerIntegrationTest.java
@@ -170,10 +170,10 @@ class JdkTlsHandlerIntegrationTest {
             }
 
             int splitIndex = 3;
-            server.receive(Buffer.alloc(Arrays.copyOfRange(record, 0, splitIndex)));
+            server.receive(Buffer.heap().alloc(Arrays.copyOfRange(record, 0, splitIndex)));
             assertThat(server.plainTexts).isEmpty();
 
-            server.receive(Buffer.alloc(Arrays.copyOfRange(record, splitIndex, record.length)));
+            server.receive(Buffer.heap().alloc(Arrays.copyOfRange(record, splitIndex, record.length)));
 
             assertPlainText(server, "fragmented-record");
         } finally {
@@ -361,7 +361,7 @@ class JdkTlsHandlerIntegrationTest {
         private void write(byte[] value) throws Exception {
             Promise<Void> result = eventLoop.submit(() -> {
                 ChannelOutBoundHandlerChainImpl chain = new ChannelOutBoundHandlerChainImpl();
-                handler.sparkChannelWrite(channel, Buffer.alloc(value), chain);
+                handler.sparkChannelWrite(channel, Buffer.heap().alloc(value), chain);
                 channel.internal().flush();
             });
             result.get(2, TimeUnit.SECONDS);

--- a/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/net/JdkTlsHandlerTest.java
@@ -198,7 +198,7 @@ class JdkTlsHandlerTest {
 
         JdkTlsHandler handler = handler(sslEngine);
         handler.handshakeResult = ChannelPromise.newPromise(eventLoop, channel).success();
-        Buffer plainText = Buffer.alloc("message");
+        Buffer plainText = Buffer.heap().alloc("message");
 
         handler.sparkChannelWrite(channel, plainText, chain);
 
@@ -232,7 +232,7 @@ class JdkTlsHandlerTest {
         when(channel.internal()).thenReturn(internal);
 
         eventLoop.start();
-        Buffer encrypted = Buffer.alloc(new byte[]{0x01});
+        Buffer encrypted = Buffer.heap().alloc(new byte[]{0x01});
         Buffer closeNotify = null;
         try {
             JdkTlsHandler handler = handler(sslEngine);

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileHandlerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/FileHandlerTest.java
@@ -44,7 +44,7 @@ class FileHandlerTest {
     @Test
     void create_directories_and_open_create_file() {
         Path file = tempDir.resolve("data/queue.log");
-        Buffer content = Buffer.alloc("hello", UTF_8);
+        Buffer content = Buffer.heap().alloc("hello", UTF_8);
 
         try (FileHandle resource = FileHandle.open(file, CREATE, WRITE)) {
             resource.write(content);
@@ -59,8 +59,8 @@ class FileHandlerTest {
     @Test
     void append_returns_start_offset_and_read_reads_positioned_bytes() {
         Path file = tempDir.resolve("queue.log");
-        Buffer first = Buffer.alloc("hello", UTF_8);
-        Buffer second = Buffer.alloc(" titan", UTF_8);
+        Buffer first = Buffer.heap().alloc("hello", UTF_8);
+        Buffer second = Buffer.heap().alloc(" titan", UTF_8);
         Buffer buffer = null;
 
         try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE)) {
@@ -85,8 +85,8 @@ class FileHandlerTest {
     @Test
     void positioned_write_replaces_content_at_offset() throws Exception {
         Path file = tempDir.resolve("queue.log");
-        Buffer content = Buffer.alloc("hello", UTF_8);
-        Buffer replacement = Buffer.alloc("y", UTF_8);
+        Buffer content = Buffer.heap().alloc("hello", UTF_8);
+        Buffer replacement = Buffer.heap().alloc("y", UTF_8);
 
         try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE, TRUNCATE_EXISTING)) {
             resource.write(content);
@@ -102,7 +102,7 @@ class FileHandlerTest {
     @Test
     void truncate_reduces_file_size() {
         Path file = tempDir.resolve("queue.log");
-        Buffer content = Buffer.alloc("hello", UTF_8);
+        Buffer content = Buffer.heap().alloc("hello", UTF_8);
 
         try (FileHandle resource = FileHandle.open(file, CREATE, READ, WRITE, TRUNCATE_EXISTING)) {
             resource.write(content);
@@ -145,7 +145,7 @@ class FileHandlerTest {
     void atomic_write_replaces_file_content() throws Exception {
         Path file = tempDir.resolve("manifest.json");
         Files.writeString(file, "old");
-        Buffer content = Buffer.alloc("new", UTF_8);
+        Buffer content = Buffer.heap().alloc("new", UTF_8);
 
         try {
             FileHandler.atomicWrite(file, content);
@@ -162,8 +162,8 @@ class FileHandlerTest {
     @Test
     void utility_read_write_and_append_handle_whole_file_buffers() {
         Path file = tempDir.resolve("data.log");
-        Buffer first = Buffer.alloc("hello", UTF_8);
-        Buffer second = Buffer.alloc(" titan", UTF_8);
+        Buffer first = Buffer.heap().alloc("hello", UTF_8);
+        Buffer second = Buffer.heap().alloc(" titan", UTF_8);
         Buffer read = null;
 
         try {

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
@@ -30,8 +30,8 @@ class ChannelDecoderTest {
 
     @Test
     void when_keeping_buffer() {
-        Buffer keeping = Buffer.alloc("alloc");
-        Buffer in = Buffer.alloc("in");
+        Buffer keeping = Buffer.heap().alloc("alloc");
+        Buffer in = Buffer.heap().alloc("in");
 
         Buffer expandBuffer = ChannelDecoder.MERGE_BUFFER.merge(keeping, in);
 
@@ -44,7 +44,7 @@ class ChannelDecoderTest {
 
     @Test
     void when_decode_returns_null_after_consuming_then_no_frames() {
-        Buffer in = Buffer.alloc("drop");
+        Buffer in = Buffer.heap().alloc("drop");
         CollectingChain chain = new CollectingChain();
         ChannelDecoder decoder = new ChannelDecoder() {
             @Override
@@ -62,7 +62,7 @@ class ChannelDecoderTest {
 
     @Test
     void release_pending_buffer_when_channel_closes() {
-        Buffer input = Buffer.alloc("partial");
+        Buffer input = Buffer.heap().alloc("partial");
         ChannelDecoder decoder = new ChannelDecoder() {
             @Override
             protected Buffer decode(@NonNull NetChannel channel, @NonNull Buffer buffer) {
@@ -101,7 +101,7 @@ class ChannelDecoderTest {
         };
         channel.chain().add(decoder);
 
-        Buffer input = Buffer.alloc("partial");
+        Buffer input = Buffer.heap().alloc("partial");
         decoder.sparkChannelRead(channel, input, new CollectingChain());
 
         channel.close();

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/LineFrameChannelDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/LineFrameChannelDecoderTest.java
@@ -25,7 +25,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnFrame_whenDelimiterIsCRLF() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hello\r\nhello\r\n");
+        Buffer buffer = Buffer.heap().alloc("hello\r\nhello\r\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -41,7 +41,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnFrame_whenDelimiterIsLF() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hello\nhello\n");
+        Buffer buffer = Buffer.heap().alloc("hello\nhello\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -57,7 +57,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnIsEmpty_whenDelimiterNotFound() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hello");
+        Buffer buffer = Buffer.heap().alloc("hello");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -72,7 +72,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnIsEmpty_whenFrameExceedsMaxLength_withDelimiter() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hellohellohello\r\n");
+        Buffer buffer = Buffer.heap().alloc("hellohellohello\r\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -87,7 +87,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnIsEmpty_whenFrameExceedsMaxLength_withoutDelimiter() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hellohellohello");
+        Buffer buffer = Buffer.heap().alloc("hellohellohello");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -102,7 +102,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnFrame_whenFrameExceedsMaxLength_withDelimiterAndCRLF() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("hellohellohello\r\nhello\r\n");
+        Buffer buffer = Buffer.heap().alloc("hellohellohello\r\nhello\r\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -117,7 +117,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnFrame_whenStripDelimiter() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10, false);
 
-        Buffer buffer = Buffer.alloc("hello\r\n");
+        Buffer buffer = Buffer.heap().alloc("hello\r\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {
@@ -133,7 +133,7 @@ class LineFrameChannelDecoderTest {
     void shouldReturnEmptyFrame_whenFrameIsEmpty() {
         TestLineFrameChannelDecoder decoder = new TestLineFrameChannelDecoder(10);
 
-        Buffer buffer = Buffer.alloc("\nabc\n");
+        Buffer buffer = Buffer.heap().alloc("\nabc\n");
         List<Buffer> frames = decoder.decodes(buffer);
 
         try {

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/ClientToServerTest.java
@@ -94,7 +94,7 @@ public class ClientToServerTest {
         assertThat(channel.isConnected()).isTrue();
         assertThat(channel.isActive()).isTrue();
 
-        client.send(Buffer.alloc("hello\n".getBytes(StandardCharsets.UTF_8))).addListener(future -> {
+        client.send(Buffer.heap().alloc("hello\n".getBytes(StandardCharsets.UTF_8))).addListener(future -> {
             if(future.isSuccess()) {
                 log.info("Send successfully");
             }
@@ -122,7 +122,7 @@ public class ClientToServerTest {
         for (int i = 0; i < count; i++) {
             es.execute(() -> {
                 try {
-                    client.send(Buffer.alloc("hello\n".getBytes(StandardCharsets.UTF_8))).addListener(future -> {
+                    client.send(Buffer.heap().alloc("hello\n".getBytes(StandardCharsets.UTF_8))).addListener(future -> {
                         if(future.isSuccess()) {
                             log.info("Send successfully");
                         }
@@ -147,7 +147,7 @@ public class ClientToServerTest {
         public void sparkChannelRead(@NonNull NetChannel channel, @NonNull Buffer buffer, @NonNull ChannelInBoundHandlerChain chain) {
             final Message msg = Message.builder()
                     .destination(Destination.create("/route/test"))
-                    .body(buffer)
+                    .body(buffer.getBytes())
                     .producerId(IdGenerator.uuid())
                     .createdAt(Instant.now())
                     .build();

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
@@ -115,7 +115,7 @@ class TlsTransportIntegrationTest {
         assertThat(channel.isConnected()).isTrue();
         assertThat(channel.isActive()).isTrue();
 
-        client.send(Buffer.alloc("hello tls")).get(5, TimeUnit.SECONDS);
+        client.send(Buffer.heap().alloc("hello tls")).get(5, TimeUnit.SECONDS);
 
         assertThat(serverMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("hello tls");
         assertThat(clientMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("echo:hello tls");
@@ -140,7 +140,7 @@ class TlsTransportIntegrationTest {
 
         NetChannel channel = client.connect("localhost", port, 5, TimeUnit.SECONDS)
                 .get(5, TimeUnit.SECONDS);
-        client.send(Buffer.alloc("mutual tls")).get(5, TimeUnit.SECONDS);
+        client.send(Buffer.heap().alloc("mutual tls")).get(5, TimeUnit.SECONDS);
 
         assertThat(channel.isConnected()).isTrue();
         assertThat(serverMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("mutual tls");
@@ -170,7 +170,7 @@ class TlsTransportIntegrationTest {
                 .get(5, TimeUnit.SECONDS);
         channel.chain().add(capture(clientMessages));
 
-        webSocketClient.send(Buffer.alloc("secure websocket")).get(5, TimeUnit.SECONDS);
+        webSocketClient.send(Buffer.heap().alloc("secure websocket")).get(5, TimeUnit.SECONDS);
 
         assertThat(serverMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("secure websocket");
         assertThat(clientMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("echo:secure websocket");
@@ -201,7 +201,7 @@ class TlsTransportIntegrationTest {
                 try {
                     String message = buffer.toString();
                     messages.add(message);
-                    channel.writeAndFlush(Buffer.alloc("echo:" + message));
+                    channel.writeAndFlush(Buffer.heap().alloc("echo:" + message));
                 } finally {
                     buffer.release();
                 }

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/WebSocketTransportIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/WebSocketTransportIntegrationTest.java
@@ -82,7 +82,7 @@ class WebSocketTransportIntegrationTest {
                 .get(5, TimeUnit.SECONDS);
         channel.chain().add(capture(clientMessages));
 
-        client.send(Buffer.alloc("hello websocket")).get(5, TimeUnit.SECONDS);
+        client.send(Buffer.heap().alloc("hello websocket")).get(5, TimeUnit.SECONDS);
 
         assertThat(serverMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("hello websocket");
         assertThat(clientMessages.poll(5, TimeUnit.SECONDS)).isEqualTo("echo:hello websocket");
@@ -99,7 +99,7 @@ class WebSocketTransportIntegrationTest {
                 try {
                     String message = buffer.toString();
                     messages.add(message);
-                    channel.writeAndFlush(Buffer.alloc("echo:" + message));
+                    channel.writeAndFlush(Buffer.heap().alloc("echo:" + message));
                 } finally {
                     buffer.release();
                 }

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
@@ -175,7 +175,7 @@ class WebSocketClientHandshakerTest {
         }
 
         private void read(byte[] data) {
-            handler.sparkChannelRead(channel, Buffer.alloc(data), chain);
+            handler.sparkChannelRead(channel, Buffer.heap().alloc(data), chain);
         }
     }
 

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
@@ -199,7 +199,7 @@ class WebSocketServerHandshakerTest {
                 EVENT_LOOP.submit(() ->
                         handler.sparkChannelRead(
                                 channel,
-                                Buffer.alloc(data.getBytes(ISO_8859_1)),
+                                Buffer.heap().alloc(data.getBytes(ISO_8859_1)),
                                 chain
                         )
                 ).get(2, TimeUnit.SECONDS);

--- a/core/src/test/java/org/traffichunter/titan/core/util/buffer/BufferOwnershipTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/util/buffer/BufferOwnershipTest.java
@@ -35,8 +35,41 @@ import org.junit.jupiter.api.Test;
 class BufferOwnershipTest {
 
     @Test
+    void allocate_application_buffer_on_heap() {
+        Buffer buffer = Buffer.heap().alloc("data");
+
+        assertThat(buffer.byteBuf().isDirect()).isFalse();
+
+        buffer.release();
+    }
+
+    @Test
+    void allocate_transport_buffer_in_direct_memory() {
+        Buffer buffer = Buffer.direct().alloc("data");
+
+        assertThat(buffer.byteBuf().isDirect()).isTrue();
+
+        buffer.release();
+    }
+
+    @Test
+    void preserve_memory_type_after_reallocation() {
+        Buffer heap = Buffer.heap().alloc(1, 1);
+        Buffer direct = Buffer.direct().alloc(1, 1);
+
+        heap.accumulateString("12");
+        direct.accumulateString("12");
+
+        assertThat(heap.byteBuf().isDirect()).isFalse();
+        assertThat(direct.byteBuf().isDirect()).isTrue();
+
+        heap.release();
+        direct.release();
+    }
+
+    @Test
     void release_previous_buffer_after_reallocation() {
-        Buffer buffer = Buffer.alloc(1, 1);
+        Buffer buffer = Buffer.heap().alloc(1, 1);
         ByteBuf previous = buffer.byteBuf();
 
         buffer.accumulateString("12");
@@ -64,7 +97,7 @@ class BufferOwnershipTest {
     @Test
     void keep_read_all_result_alive_after_accumulator_is_cleared() {
         BufferAccumulator accumulator = new BufferAccumulator();
-        Buffer input = Buffer.alloc("data");
+        Buffer input = Buffer.heap().alloc("data");
         accumulator.accumulate(input);
         input.release();
 

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/StompSendToFanoutHandler.java
@@ -38,7 +38,6 @@ import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 
@@ -73,18 +72,12 @@ public final class StompSendToFanoutHandler implements StompServerCommandHandler
             return;
         }
 
-        Buffer body = Buffer.alloc(sf.body());
-        Message message;
-        try {
-            message = Message.builder()
-                    .destination(Destination.create(destination))
-                    .createdAt(Instant.now())
-                    .producerId(connection.session())
-                    .body(body)
-                    .build();
-        } finally {
-            body.release();
-        }
+        Message message = Message.builder()
+                .destination(Destination.create(destination))
+                .createdAt(Instant.now())
+                .producerId(connection.session())
+                .body(sf.body())
+                .build();
 
         try {
             CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/VertxStompSendToFanoutHandler.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
@@ -75,18 +74,12 @@ public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame>
         }
 
         io.vertx.core.buffer.Buffer body = frame.getBody();
-        Buffer payload = Buffer.alloc(body == null ? new byte[]{} : body.getBytes());
-        Message message;
-        try {
-            message = Message.builder()
-                    .destination(Destination.create(destination))
-                    .createdAt(Instant.now())
-                    .producerId(serverFrame.connection().session())
-                    .body(payload)
-                    .build();
-        } finally {
-            payload.release();
-        }
+        Message message = Message.builder()
+                .destination(Destination.create(destination))
+                .createdAt(Instant.now())
+                .producerId(serverFrame.connection().session())
+                .body(body == null ? new byte[]{} : body.getBytes())
+                .build();
 
         try {
             CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);

--- a/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/DispatchExporter.java
+++ b/fanout/src/main/java/org/traffichunter/titan/fanout/exporter/DispatchExporter.java
@@ -54,7 +54,7 @@ public interface DispatchExporter {
 
     @CanIgnoreReturnValue
     default AggregationResult export(Destination destination, Message payload) {
-        Buffer buffer = Buffer.alloc(payload.getBody());
+        Buffer buffer = Buffer.heap().alloc(payload.getBody());
         try {
             return export(destination, buffer);
         } finally {

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchChainHandlerChainTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchChainHandlerChainTest.java
@@ -107,7 +107,7 @@ class DispatchChainHandlerChainTest {
                 .destination(Destination.create(destination))
                 .createdAt(Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("test".getBytes()))
+                .body("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchGatewayQueueManagementTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchGatewayQueueManagementTest.java
@@ -98,7 +98,7 @@ class DispatchGatewayQueueManagementTest {
                 .destination(destination)
                 .createdAt(Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("test".getBytes()))
+                .body("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchHandlerChainTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/DispatchHandlerChainTest.java
@@ -155,7 +155,7 @@ class DispatchHandlerChainTest {
                 .destination(Destination.create(destination))
                 .createdAt(Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("test".getBytes()))
+                .body("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build();
     }
 }

--- a/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/DispatchExporterTest.java
+++ b/fanout/src/test/java/org/traffichunter/titan/fanout/exporter/DispatchExporterTest.java
@@ -102,18 +102,12 @@ class DispatchExporterTest {
 
     @Test
     void default_message_export_releases_temporary_buffer() {
-        Buffer source = Buffer.alloc("payload");
-        Message message;
-        try {
-            message = Message.builder()
-                    .destination(Destination.create("/topic/test"))
-                    .createdAt(Instant.now())
-                    .producerId("producer")
-                    .body(source)
-                    .build();
-        } finally {
-            source.release();
-        }
+        Message message = Message.builder()
+                .destination(Destination.create("/topic/test"))
+                .createdAt(Instant.now())
+                .producerId("producer")
+                .body("payload".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                .build();
 
         AtomicReference<Buffer> exported = new AtomicReference<>();
         DispatchExporter exporter = new DispatchExporter() {
@@ -170,7 +164,7 @@ class DispatchExporterTest {
                 .build());
 
         StompDispatchExporter exporter = new StompDispatchExporter(serverConnection);
-        AggregationResult result = exporter.export(destination, Buffer.alloc("hello".getBytes()));
+        AggregationResult result = exporter.export(destination, Buffer.heap().alloc("hello".getBytes()));
 
         assertThat(result.totalAttempted()).isEqualTo(2);
         assertThat(result.done()).isEqualTo(2);
@@ -181,7 +175,7 @@ class DispatchExporterTest {
     @Test
     void vertxStompDispatchExporter_dispatches_message_frame_to_subscribers() {
         Destination destination = Destination.create("/topic/orders");
-        Buffer payload = Buffer.alloc("hello".getBytes());
+        Buffer payload = Buffer.heap().alloc("hello".getBytes());
 
         when(vertxServer.isListening()).thenReturn(true);
         when(vertxServer.stompHandler()).thenReturn(vertxServerHandler);
@@ -215,7 +209,7 @@ class DispatchExporterTest {
         when(vertxServerHandler.getDestination(destination.path())).thenReturn(null);
 
         VertxStompDispatchExporter exporter = new VertxStompDispatchExporter(vertxServer);
-        AggregationResult result = exporter.export(destination, Buffer.alloc("hello".getBytes()));
+        AggregationResult result = exporter.export(destination, Buffer.heap().alloc("hello".getBytes()));
 
         assertThat(result.totalAttempted()).isZero();
         assertThat(result.succeeded()).isZero();
@@ -243,7 +237,7 @@ class DispatchExporterTest {
         when(inetServer.childChannel()).thenReturn(registry.getChannels());
 
         TcpDispatchExporter exporter = new TcpDispatchExporter(inetServer);
-        AggregationResult result = exporter.export(Destination.create("/topic/a"), Buffer.alloc("p".getBytes()));
+        AggregationResult result = exporter.export(Destination.create("/topic/a"), Buffer.heap().alloc("p".getBytes()));
 
         assertThat(result.isDone()).isTrue();
         assertThat(result.totalAttempted()).isEqualTo(2);

--- a/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/MetadataCodec.java
+++ b/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/MetadataCodec.java
@@ -107,7 +107,7 @@ public final class MetadataCodec {
         buffer.putInt(crc32);
         buffer.put(destination);
         buffer.put(payload);
-        return Buffer.alloc(buffer.array());
+        return Buffer.heap().alloc(buffer.array());
     }
 
     /**

--- a/incubator/src/test/java/org/traffichunter/titan/incubator/resilience/backup/DestinationBackupSystemTest.java
+++ b/incubator/src/test/java/org/traffichunter/titan/incubator/resilience/backup/DestinationBackupSystemTest.java
@@ -68,7 +68,7 @@ class DestinationBackupSystemTest {
     }
 
     private Metadata metadata(String destination, String payload) {
-        Buffer buffer = Buffer.alloc(payload, UTF_8);
+        Buffer buffer = Buffer.heap().alloc(payload, UTF_8);
         try {
             return Metadata.create(Type.MESSAGE_APPEND, 100, destination, buffer);
         } finally {

--- a/incubator/src/test/java/org/traffichunter/titan/incubator/resilience/backup/FileAppendOnlyFileTest.java
+++ b/incubator/src/test/java/org/traffichunter/titan/incubator/resilience/backup/FileAppendOnlyFileTest.java
@@ -174,7 +174,7 @@ class FileAppendOnlyFileTest {
     }
 
     private Metadata metadata(Type type, String destination, String payload) {
-        Buffer buffer = Buffer.alloc(payload, UTF_8);
+        Buffer buffer = Buffer.heap().alloc(payload, UTF_8);
         try {
             return Metadata.create(type, 100, destination, buffer);
         } finally {
@@ -208,13 +208,13 @@ class FileAppendOnlyFileTest {
 
         @Override
         public Buffer readAll() {
-            return Buffer.alloc(bytes);
+            return Buffer.heap().alloc(bytes);
         }
 
         @Override
         public Buffer read(long position, int length) {
             byte[] slice = Arrays.copyOfRange(bytes, (int) position, (int) position + length);
-            return Buffer.alloc(slice);
+            return Buffer.heap().alloc(slice);
         }
 
         @Override

--- a/incubator/src/test/java/org/traffichunter/titan/incubator/test/implementation/backup/MetadataCodecTest.java
+++ b/incubator/src/test/java/org/traffichunter/titan/incubator/test/implementation/backup/MetadataCodecTest.java
@@ -25,7 +25,7 @@ class MetadataCodecTest {
     @Test
     void encode_and_decode_round_trip_binary_payload() {
         byte[] payloadBytes = new byte[] { 'a', '\n', 0, (byte) 0xff };
-        Buffer payload = Buffer.alloc(payloadBytes);
+        Buffer payload = Buffer.heap().alloc(payloadBytes);
         Buffer encoded = null;
 
         try {
@@ -51,7 +51,7 @@ class MetadataCodecTest {
 
     @Test
     void encode_does_not_release_input_payload() {
-        Buffer payload = Buffer.alloc("payload", UTF_8);
+        Buffer payload = Buffer.heap().alloc("payload", UTF_8);
         Buffer encoded = null;
 
         try {
@@ -132,7 +132,7 @@ class MetadataCodecTest {
     }
 
     private Buffer encodeSample() {
-        Buffer payload = Buffer.alloc("payload", UTF_8);
+        Buffer payload = Buffer.heap().alloc("payload", UTF_8);
         try {
             return MetadataCodec.encode(Metadata.create(Type.MESSAGE_APPEND, 100, "/queue/orders", payload));
         } finally {

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/http/MonitoringHttpServerTest.java
@@ -206,7 +206,7 @@ class MonitoringHttpServerTest {
                 .destination(Destination.create("/queue/non-empty"))
                 .createdAt(java.time.Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("test".getBytes()))
+                .body("test".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build());
         DispatcherQueueManagers.register("test", manager);
 

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollectorTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/queue/JmxDispatcherQueueCollectorTest.java
@@ -24,7 +24,7 @@ class JmxDispatcherQueueCollectorTest {
                 .destination(Destination.create("/queue/orders"))
                 .createdAt(Instant.now())
                 .producerId("test")
-                .body(Buffer.alloc("hello".getBytes()))
+                .body("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8))
                 .build());
         queue.pause();
         DispatcherQueueMbeans.register(server, queue);

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
@@ -96,7 +96,7 @@ class TitanFanoutSmokeTest {
                 received.countDown();
             }).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
-            producerConnection.send(FANOUT_DESTINATION, Buffer.alloc(payload))
+            producerConnection.send(FANOUT_DESTINATION, Buffer.heap().alloc(payload))
                     .get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
             assertThat(received.await(10, TimeUnit.SECONDS)).isTrue();

--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
@@ -88,7 +88,7 @@ public interface TitanClient {
      * @return the asynchronous transport result
      */
     default CompletableFuture<StompFrames> send(String destination, String payload) {
-        return send(destination, Buffer.alloc(payload));
+        return send(destination, Buffer.heap().alloc(payload));
     }
 
     /**

--- a/titan-client/src/test/java/org/traffichunter/titan/client/BufferOwnershipTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/BufferOwnershipTest.java
@@ -51,7 +51,7 @@ class BufferOwnershipTest {
     @Test
     void disconnected_client_consumes_payload() {
         TitanClient client = TitanClient.builder().build();
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         try {
             assertThatThrownBy(() -> client.send("/queue/test", payload).join())
@@ -65,7 +65,7 @@ class BufferOwnershipTest {
     @Test
     void disconnected_client_consumes_payload_with_headers() {
         TitanClient client = TitanClient.builder().build();
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         try {
             assertThatThrownBy(() -> client.send(
@@ -84,7 +84,7 @@ class BufferOwnershipTest {
         StompClientChannel channel = mock(StompClientChannel.class);
         when(channel.handler()).thenReturn(mock(StompClientHandler.class));
         TitanStompConnection connection = new TitanStompConnection(channel);
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         assertThatThrownBy(() -> connection.send("/queue/invalid destination", payload))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -98,7 +98,7 @@ class BufferOwnershipTest {
         when(nativeConnection.send(eq("/queue/test"), any(io.vertx.core.buffer.Buffer.class)))
                 .thenReturn(io.vertx.core.Future.succeededFuture(response));
         VertxStompConnection connection = new VertxStompConnection(nativeConnection);
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         connection.send("/queue/test", payload).join();
 
@@ -116,7 +116,7 @@ class BufferOwnershipTest {
                 any(io.vertx.core.buffer.Buffer.class)
         )).thenReturn(io.vertx.core.Future.succeededFuture(response));
         VertxStompConnection connection = new VertxStompConnection(nativeConnection);
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         connection.send(
                 "/queue/test",
@@ -136,7 +136,7 @@ class BufferOwnershipTest {
     void vertx_connection_consumes_payload_when_destination_is_invalid() {
         StompClientConnection nativeConnection = mock(StompClientConnection.class);
         VertxStompConnection connection = new VertxStompConnection(nativeConnection);
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
 
         assertThatThrownBy(() -> connection.send("/queue/invalid destination", payload))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/titan-client/src/test/java/org/traffichunter/titan/client/StompIntegrationTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/StompIntegrationTest.java
@@ -132,7 +132,7 @@ class StompIntegrationTest {
             client.start();
             client.connect(testServer.host(), testServer.port()).get(3, TimeUnit.SECONDS);
 
-            Buffer body = Buffer.alloc("Hello STOMP!");
+            Buffer body = Buffer.heap().alloc("Hello STOMP!");
             StompFrame result = client.channel().send("/queue/test", body).get(3, TimeUnit.SECONDS);
 
             assertThat(result).isNotNull();
@@ -174,7 +174,7 @@ class StompIntegrationTest {
             assertThat(client.channel().subscriptions()).hasSize(1);
 
             // Publish message
-            client.channel().send("/topic/test", Buffer.alloc("Test message")).get(3, TimeUnit.SECONDS);
+            client.channel().send("/topic/test", Buffer.heap().alloc("Test message")).get(3, TimeUnit.SECONDS);
 
             // Wait for message
             boolean received = latch.await(5, TimeUnit.SECONDS);
@@ -406,7 +406,7 @@ class StompIntegrationTest {
             // Send within transaction
             StompHeaders headers = StompHeaders.create();
             headers.put(Elements.TRANSACTION, txId);
-            client.channel().send("/queue/tx-test", Buffer.alloc("TX message"), headers).get(3, TimeUnit.SECONDS);
+            client.channel().send("/queue/tx-test", Buffer.heap().alloc("TX message"), headers).get(3, TimeUnit.SECONDS);
 
             client.channel().commit(txId).get(3, TimeUnit.SECONDS);
 
@@ -519,7 +519,7 @@ class StompIntegrationTest {
                     .destination(queue.route())
                     .createdAt(Instant.now())
                     .producerId(UUID.randomUUID().toString())
-                    .body(buffer)
+                    .body(buffer.getBytes())
                     .build();
 
             queue.enqueue(message);

--- a/titan-client/src/test/java/org/traffichunter/titan/client/StompReconnectIntegrationTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/StompReconnectIntegrationTest.java
@@ -96,7 +96,7 @@ class StompReconnectIntegrationTest {
                     received::add
             ).get(3, SECONDS);
 
-            client.send(destination, Buffer.alloc("before-restart")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("before-restart")).get(3, SECONDS);
             StompFrames beforeRestart = received.poll(3, SECONDS);
             assertThat(beforeRestart).isNotNull();
             assertThat(beforeRestart.body()).asString(StandardCharsets.UTF_8).isEqualTo("before-restart");
@@ -113,7 +113,7 @@ class StompReconnectIntegrationTest {
                         assertThat(client.isConnected()).isTrue();
                     });
 
-            client.send(destination, Buffer.alloc("after-restart")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("after-restart")).get(3, SECONDS);
             StompFrames afterRestart = received.poll(3, SECONDS);
             assertThat(afterRestart).isNotNull();
             assertThat(afterRestart.body()).asString(StandardCharsets.UTF_8).isEqualTo("after-restart");
@@ -153,7 +153,7 @@ class StompReconnectIntegrationTest {
                         assertThat(client.isConnected()).isTrue();
                     });
 
-            client.send(destination, Buffer.alloc("must-not-be-delivered")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("must-not-be-delivered")).get(3, SECONDS);
             assertThat(received.poll(500, TimeUnit.MILLISECONDS)).isNull();
         } finally {
             client.shutdown(SHUTDOWN_TIMEOUT_SECONDS, SECONDS);
@@ -189,8 +189,8 @@ class StompReconnectIntegrationTest {
             await().atMost(10, SECONDS)
                     .untilAsserted(() -> assertThat(client.isConnected()).isTrue());
 
-            client.send("/queue/reconnect-first", Buffer.alloc("first")).get(3, SECONDS);
-            client.send("/queue/reconnect-second", Buffer.alloc("second")).get(3, SECONDS);
+            client.send("/queue/reconnect-first", Buffer.heap().alloc("first")).get(3, SECONDS);
+            client.send("/queue/reconnect-second", Buffer.heap().alloc("second")).get(3, SECONDS);
 
             assertThat(firstMessages.poll(3, SECONDS)).isNotNull()
                     .extracting(frame -> new String(frame.body(), StandardCharsets.UTF_8))
@@ -229,7 +229,7 @@ class StompReconnectIntegrationTest {
             await().atMost(10, SECONDS)
                     .untilAsserted(() -> assertThat(client.isConnected()).isTrue());
 
-            client.send(destination, Buffer.alloc("vertx-restored")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("vertx-restored")).get(3, SECONDS);
             StompFrames restored = received.poll(3, SECONDS);
             assertThat(restored).isNotNull();
             assertThat(restored.body()).asString(StandardCharsets.UTF_8).isEqualTo("vertx-restored");
@@ -285,8 +285,8 @@ class StompReconnectIntegrationTest {
                         assertThat(client.isConnected()).isTrue();
                     });
 
-            client.send("/queue/partial-first", Buffer.alloc("first-restored")).get(3, SECONDS);
-            client.send("/queue/partial-second", Buffer.alloc("second-restored")).get(3, SECONDS);
+            client.send("/queue/partial-first", Buffer.heap().alloc("first-restored")).get(3, SECONDS);
+            client.send("/queue/partial-second", Buffer.heap().alloc("second-restored")).get(3, SECONDS);
             assertThat(firstMessages.poll(3, SECONDS)).isNotNull();
             assertThat(secondMessages.poll(3, SECONDS)).isNotNull();
         } finally {
@@ -332,7 +332,7 @@ class StompReconnectIntegrationTest {
                         assertThat(client.isConnected()).isTrue();
                     });
 
-            client.send(destination, Buffer.alloc("restored-after-timeout")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("restored-after-timeout")).get(3, SECONDS);
             assertThat(received.poll(3, SECONDS)).isNotNull();
         } finally {
             client.shutdown(SHUTDOWN_TIMEOUT_SECONDS, SECONDS);
@@ -381,7 +381,7 @@ class StompReconnectIntegrationTest {
 
             releaseSubscriptionResult.complete(null);
             subscription.get(3, SECONDS);
-            client.send(destination, Buffer.alloc("late-subscription-restored")).get(3, SECONDS);
+            client.send(destination, Buffer.heap().alloc("late-subscription-restored")).get(3, SECONDS);
             assertThat(received.poll(3, SECONDS)).isNotNull();
         } finally {
             releaseSubscriptionResult.complete(null);

--- a/titan-client/src/test/java/org/traffichunter/titan/client/VertxStompClientTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/VertxStompClientTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.after;
 import static org.mockito.ArgumentMatchers.any;
@@ -153,6 +154,8 @@ class VertxStompClientTest {
         connectionDroppedHandler(firstConnection).handle(firstConnection);
 
         verify(nativeClient, timeout(1000).times(3)).connect(option.port(), option.host());
+        await().atMost(2, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(client.isConnected()).isTrue());
         assertThat(driver.channel()).isSameAs(restoredConnection);
         assertThat(client.connection()).isNotSameAs(initialConnection);
 

--- a/titan-client/src/test/java/org/traffichunter/titan/client/VertxStompClientTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/VertxStompClientTest.java
@@ -156,7 +156,7 @@ class VertxStompClientTest {
         assertThat(driver.channel()).isSameAs(restoredConnection);
         assertThat(client.connection()).isNotSameAs(initialConnection);
 
-        Buffer payload = Buffer.alloc("message");
+        Buffer payload = Buffer.heap().alloc("message");
         client.send("/queue/reconnected", payload).get();
         assertThat(payload.byteBuf().refCnt()).isZero();
         verify(restoredConnection).send(eq("/queue/reconnected"), any(io.vertx.core.buffer.Buffer.class));

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
@@ -103,7 +103,7 @@ public final class TitanTemplate implements StompOperations {
     }
 
     public StompFrames send(String destination, byte[] payload) throws Exception {
-        return await(send(destination, Buffer.alloc(payload)));
+        return await(send(destination, Buffer.heap().alloc(payload)));
     }
 
     public String subscribe(String destination) throws Exception {

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplateTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplateTest.java
@@ -82,7 +82,7 @@ class TitanTemplateTest {
     @Test
     void async_send_buffer_returns_connection_future() {
         CompletableFuture<StompFrames> expected = CompletableFuture.completedFuture(frame);
-        Buffer payload = Buffer.alloc("hello".getBytes(StandardCharsets.UTF_8));
+        Buffer payload = Buffer.heap().alloc("hello".getBytes(StandardCharsets.UTF_8));
         when(client.send("/topic/test", payload)).thenReturn(expected);
 
         CompletableFuture<StompFrames> result = template.send("/topic/test", payload);
@@ -94,7 +94,7 @@ class TitanTemplateTest {
     void send_consumes_payload_when_connection_resolution_fails() {
         when(client.isConnected()).thenReturn(false);
         when(client.connect()).thenReturn(CompletableFuture.failedFuture(new IllegalStateException("unavailable")));
-        Buffer payload = Buffer.alloc("hello");
+        Buffer payload = Buffer.heap().alloc("hello");
 
         assertThatThrownBy(() -> template.send("/topic/test", payload))
                 .isInstanceOf(IllegalStateException.class)

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -116,7 +116,7 @@ public class StompChannelDecoder extends ChannelDecoder {
             // Skip stomp last delimiter (null)
             buffer.skipBytes(1);
 
-            Buffer stompFrame = Buffer.alloc(sliceBuffer.length() + 1);
+            Buffer stompFrame = Buffer.heap().alloc(sliceBuffer.length() + 1);
             List<Buffer> frames = List.of();
             try {
                 stompFrame.accumulateBuffer(sliceBuffer)

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
@@ -126,7 +126,7 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
      * {@link #body()} when a byte array is sufficient.</p>
      */
     public Buffer getBody() {
-        return Buffer.alloc(body);
+        return Buffer.heap().alloc(body);
     }
 
     @Override
@@ -142,10 +142,10 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
     @Override
     public Buffer toBuffer() {
         if(command == StompCommand.PING) {
-            return Buffer.alloc(StompDelimiter.LF.getString());
+            return Buffer.heap().alloc(StompDelimiter.LF.getString());
         }
 
-        Buffer buffer = Buffer.alloc(command.name());
+        Buffer buffer = Buffer.heap().alloc(command.name());
         buffer.accumulateString(StompDelimiter.CR.getString()).accumulateString(StompDelimiter.LF.getString());
 
         Set<Entry<Elements, String>> entries = headers.entrySet();
@@ -258,7 +258,7 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
     }
 
     public static StompFrame errorFrame(final StompHeaders headers, final String message, final String body) {
-        StompFrame errorFrame = new StompFrame(headers, StompCommand.ERROR, Buffer.alloc(body));
+        StompFrame errorFrame = new StompFrame(headers, StompCommand.ERROR, Buffer.heap().alloc(body));
         errorFrame.addHeader(Elements.MESSAGE, message);
         errorFrame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length()));
         errorFrame.addHeader(Elements.CONTENT_TYPE, MediaType.TEXT_PLAIN);
@@ -267,7 +267,7 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
     }
 
     public static Buffer errorFrame(final String message) {
-        return Buffer.alloc(message);
+        return Buffer.heap().alloc(message);
     }
 
     public static String formatString(final String message, final Object... obj) {

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -34,7 +34,7 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, IdGenerator.uuid());
 
-        StompFrame stompFrame = StompFrame.create(headers, command, Buffer.alloc("hello"));
+        StompFrame stompFrame = StompFrame.create(headers, command, Buffer.heap().alloc("hello"));
         Buffer frames = stompFrame.toBuffer();
 
         try {
@@ -53,7 +53,7 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, IdGenerator.uuid());
 
-        StompFrame stompFrame = StompFrame.create(headers, command, Buffer.alloc("hello"));
+        StompFrame stompFrame = StompFrame.create(headers, command, Buffer.heap().alloc("hello"));
         Buffer frame = stompFrame.toBuffer();
 
         Buffer notEofFrame = frame.readSlice(frame.length() - 1);
@@ -74,7 +74,7 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.CONTENT_LENGTH, "10");
 
-        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
 
         try {
@@ -92,7 +92,7 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.CONTENT_LENGTH, "5");
 
-        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
 
         Buffer buf = frame.toBuffer();
 
@@ -111,7 +111,7 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, "1");
 
-        StompFrame frame = StompFrame.create(headers, StompCommand.CONNECT, Buffer.empty());
+        StompFrame frame = StompFrame.create(headers, StompCommand.CONNECT, Buffer.heap().empty());
         Buffer buf = frame.toBuffer();
 
         try {
@@ -129,9 +129,9 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, "1");
 
-        StompFrame stompFrame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        StompFrame stompFrame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
 
-        Buffer stompFrames = Buffer.alloc(stompFrame + "CONNECT\r\nid:1\r");
+        Buffer stompFrames = Buffer.heap().alloc(stompFrame + "CONNECT\r\nid:1\r");
 
         try {
             TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, ((sf, sc) -> {}));
@@ -148,13 +148,13 @@ class StompChannelDecoderTest {
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, "1");
 
-        StompFrame stompFrame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        StompFrame stompFrame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer total = stompFrame.toBuffer();
         byte[] bytes = total.getBytes();
 
         int split = bytes.length / 2;
-        Buffer part1 = Buffer.alloc(Arrays.copyOfRange(bytes, 0, split));
-        Buffer part2 = Buffer.alloc(Arrays.copyOfRange(bytes, split, bytes.length));
+        Buffer part1 = Buffer.heap().alloc(Arrays.copyOfRange(bytes, 0, split));
+        Buffer part2 = Buffer.heap().alloc(Arrays.copyOfRange(bytes, split, bytes.length));
 
         CollectingChain chain = new CollectingChain();
         TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, ((sf, sc) -> {}));
@@ -182,7 +182,7 @@ class StompChannelDecoderTest {
         // returned by decode() when it reaches the end of the chain (next == null).
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.ID, IdGenerator.uuid());
-        StompFrame frame = StompFrame.create(headers, StompCommand.CONNECT, Buffer.alloc("hello"));
+        StompFrame frame = StompFrame.create(headers, StompCommand.CONNECT, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
 
         TerminalChain terminal = new TerminalChain();
@@ -208,7 +208,7 @@ class StompChannelDecoderTest {
         // must be released even when ERR_STOMP_FRAME is returned early.
         StompHeaders headers = StompHeaders.create();
         headers.put(StompHeaders.Elements.CONTENT_LENGTH, "999");
-        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.alloc("hello"));
+        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
 
         TerminalChain terminal = new TerminalChain();

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompFrameTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompFrameTest.java
@@ -45,7 +45,7 @@ class StompFrameTest {
 
     @Test
     void consume_buffer_and_keep_copied_body() {
-        Buffer body = Buffer.alloc("body");
+        Buffer body = Buffer.heap().alloc("body");
 
         StompFrame frame = StompFrame.create(
                 StompHeaders.create(),


### PR DESCRIPTION
## Motivation:

Titan previously allocated direct, reference-counted buffers across codec, message, queue, and fanout boundaries. This made buffer lifetime difficult to reason about and increased the risk of retaining native memory beyond the transport pipeline.

## Modification:

- Add explicit pooled heap and direct `BufferAllocator` APIs through `Buffer.heap()` and `Buffer.direct()`.
- Reserve direct buffers for socket and TLS boundaries while using heap buffers for short-lived codec work.
- Restrict `InternalBuffer` to wrapping allocated `ByteBuf` instances and preserve memory type during copies and growth.
- Store queued message payloads as defensively copied byte arrays so dispatcher and fanout state does not require reference-count management.
- Migrate buffer allocation call sites and document ownership, transfer, slice, and release contracts.
- Add coverage for allocator memory types, reallocation behavior, and message payload isolation.

## Result:

Buffer allocation and ownership now follow explicit transport and application boundaries. Queue and fanout messages are GC-managed, while pooled direct memory is limited to native I/O paths.

Validation:

- `./gradlew test`
- `./gradlew :core:test`
