### PR TITLE
Remove Lombok from the project

### DIFF
--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/StopWatch.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/StopWatch.java
@@ -23,8 +23,6 @@
  */
 package org.traffichunter.titan.bootstrap;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
@@ -57,7 +55,6 @@ import java.time.Instant;
  *
  * @author yungwang-o
 */
-@Getter
 public abstract class StopWatch {
 
     private final Instant startTime;
@@ -66,6 +63,14 @@ public abstract class StopWatch {
 
     protected StopWatch() {
         this.startTime = Instant.now();
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public @Nullable Instant getEndTime() {
+        return endTime;
     }
 
     public void setEndTime() {

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
@@ -26,7 +26,8 @@ package org.traffichunter.titan.bootstrap;
 import java.lang.reflect.Constructor;
 import java.time.Duration;
 import java.time.Instant;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.bootstrap.Configurations.Property;
 import org.traffichunter.titan.bootstrap.environment.ConfigurationInitializer;
 
@@ -43,8 +44,9 @@ import org.traffichunter.titan.bootstrap.environment.ConfigurationInitializer;
  * protocol packages. The only contract shared across that boundary is
  * {@link ApplicationStarter#start(Settings)}.</p>
  */
-@Slf4j
 public final class TitanBootstrap {
+
+    private static final Logger log = LoggerFactory.getLogger(TitanBootstrap.class);
 
     private static final String CALL_CORE_APPLICATION =
             "org.traffichunter.titan.core.TitanApplication";

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
@@ -27,7 +27,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.bootstrap.Settings;
@@ -64,8 +65,9 @@ import org.yaml.snakeyaml.constructor.Constructor;
  * Settings
  * }</pre>
  */
-@Slf4j
 final class YamlConfigurationInitializer implements ConfigurationInitializer {
+
+    private static final Logger log = LoggerFactory.getLogger(YamlConfigurationInitializer.class);
 
     private static final String DEFAULT_ENV_FILE = "titan-env.yml";
 

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/RootYamlProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/RootYamlProperty.java
@@ -23,10 +23,7 @@
  */
 package org.traffichunter.titan.bootstrap.environment.proprerty;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * Root object used only for YAML binding.
@@ -35,10 +32,37 @@ import lombok.NoArgsConstructor;
  * should not depend on this DTO directly; it is mapped to {@code Settings}
  * after parsing.</p>
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class RootYamlProperty {
 
     private TitanSubProperty titan;
+
+    public RootYamlProperty() {
+    }
+
+    public RootYamlProperty(TitanSubProperty titan) {
+        this.titan = titan;
+    }
+
+    public TitanSubProperty getTitan() {
+        return titan;
+    }
+
+    public void setTitan(TitanSubProperty titan) {
+        this.titan = titan;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof RootYamlProperty other && Objects.equals(titan, other.titan);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(titan);
+    }
+
+    @Override
+    public String toString() {
+        return "RootYamlProperty{titan=" + titan + '}';
+    }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/TitanSubProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/TitanSubProperty.java
@@ -24,10 +24,7 @@
 package org.traffichunter.titan.bootstrap.environment.proprerty;
 
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.BackupProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.FlowControlProperty;
 import org.traffichunter.titan.bootstrap.environment.proprerty.sub.HttpServerProperty;
@@ -42,9 +39,6 @@ import org.traffichunter.titan.bootstrap.environment.proprerty.sub.ServiceDiscov
  * {@link #servers} is the active path used to construct managed server
  * settings.</p>
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class TitanSubProperty {
 
     private HttpServerProperty httpServer;
@@ -58,4 +52,99 @@ public class TitanSubProperty {
     private ServiceDiscoveryProperty serviceDiscovery;
 
     private List<ServerProperty> servers;
+
+    public TitanSubProperty() {
+    }
+
+    public TitanSubProperty(
+            HttpServerProperty httpServer,
+            MonitorProperty monitor,
+            BackupProperty backup,
+            FlowControlProperty flowControl,
+            ServiceDiscoveryProperty serviceDiscovery,
+            List<ServerProperty> servers
+    ) {
+        this.httpServer = httpServer;
+        this.monitor = monitor;
+        this.backup = backup;
+        this.flowControl = flowControl;
+        this.serviceDiscovery = serviceDiscovery;
+        this.servers = servers;
+    }
+
+    public HttpServerProperty getHttpServer() {
+        return httpServer;
+    }
+
+    public void setHttpServer(HttpServerProperty httpServer) {
+        this.httpServer = httpServer;
+    }
+
+    public MonitorProperty getMonitor() {
+        return monitor;
+    }
+
+    public void setMonitor(MonitorProperty monitor) {
+        this.monitor = monitor;
+    }
+
+    public BackupProperty getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupProperty backup) {
+        this.backup = backup;
+    }
+
+    public FlowControlProperty getFlowControl() {
+        return flowControl;
+    }
+
+    public void setFlowControl(FlowControlProperty flowControl) {
+        this.flowControl = flowControl;
+    }
+
+    public ServiceDiscoveryProperty getServiceDiscovery() {
+        return serviceDiscovery;
+    }
+
+    public void setServiceDiscovery(ServiceDiscoveryProperty serviceDiscovery) {
+        this.serviceDiscovery = serviceDiscovery;
+    }
+
+    public List<ServerProperty> getServers() {
+        return servers;
+    }
+
+    public void setServers(List<ServerProperty> servers) {
+        this.servers = servers;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof TitanSubProperty other
+                && Objects.equals(httpServer, other.httpServer)
+                && Objects.equals(monitor, other.monitor)
+                && Objects.equals(backup, other.backup)
+                && Objects.equals(flowControl, other.flowControl)
+                && Objects.equals(serviceDiscovery, other.serviceDiscovery)
+                && Objects.equals(servers, other.servers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(httpServer, monitor, backup, flowControl, serviceDiscovery, servers);
+    }
+
+    @Override
+    public String toString() {
+        return "TitanSubProperty{" +
+                "httpServer=" + httpServer +
+                ", monitor=" + monitor +
+                ", backup=" + backup +
+                ", flowControl=" + flowControl +
+                ", serviceDiscovery=" + serviceDiscovery +
+                ", servers=" + servers +
+                '}';
+    }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/HttpServerProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/HttpServerProperty.java
@@ -23,20 +23,55 @@
  */
 package org.traffichunter.titan.bootstrap.environment.proprerty.sub;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * YAML DTO for the optional HTTP server section.
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class HttpServerProperty {
 
     private int port;
 
     private String pool;
+
+    public HttpServerProperty() {
+    }
+
+    public HttpServerProperty(int port, String pool) {
+        this.port = port;
+        this.pool = pool;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getPool() {
+        return pool;
+    }
+
+    public void setPool(String pool) {
+        this.pool = pool;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof HttpServerProperty other
+                && port == other.port
+                && Objects.equals(pool, other.pool);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(port, pool);
+    }
+
+    @Override
+    public String toString() {
+        return "HttpServerProperty{port=" + port + ", pool='" + pool + "'}";
+    }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/MonitorProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/MonitorProperty.java
@@ -23,17 +23,11 @@
  */
 package org.traffichunter.titan.bootstrap.environment.proprerty.sub;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * YAML DTO for monitor scheduling options.
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class MonitorProperty {
 
     private boolean enabled;
@@ -51,4 +45,132 @@ public class MonitorProperty {
     private long delay;
 
     private int scheduledThreadPool;
+
+    public MonitorProperty() {
+    }
+
+    public MonitorProperty(
+            boolean enabled,
+            String host,
+            int port,
+            String token,
+            int threadPoolSize,
+            long initialDelay,
+            long delay,
+            int scheduledThreadPool
+    ) {
+        this.enabled = enabled;
+        this.host = host;
+        this.port = port;
+        this.token = token;
+        this.threadPoolSize = threadPoolSize;
+        this.initialDelay = initialDelay;
+        this.delay = delay;
+        this.scheduledThreadPool = scheduledThreadPool;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public int getThreadPoolSize() {
+        return threadPoolSize;
+    }
+
+    public void setThreadPoolSize(int threadPoolSize) {
+        this.threadPoolSize = threadPoolSize;
+    }
+
+    public long getInitialDelay() {
+        return initialDelay;
+    }
+
+    public void setInitialDelay(long initialDelay) {
+        this.initialDelay = initialDelay;
+    }
+
+    public long getDelay() {
+        return delay;
+    }
+
+    public void setDelay(long delay) {
+        this.delay = delay;
+    }
+
+    public int getScheduledThreadPool() {
+        return scheduledThreadPool;
+    }
+
+    public void setScheduledThreadPool(int scheduledThreadPool) {
+        this.scheduledThreadPool = scheduledThreadPool;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof MonitorProperty other
+                && enabled == other.enabled
+                && port == other.port
+                && threadPoolSize == other.threadPoolSize
+                && initialDelay == other.initialDelay
+                && delay == other.delay
+                && scheduledThreadPool == other.scheduledThreadPool
+                && Objects.equals(host, other.host)
+                && Objects.equals(token, other.token);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                enabled,
+                host,
+                port,
+                token,
+                threadPoolSize,
+                initialDelay,
+                delay,
+                scheduledThreadPool
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "MonitorProperty{" +
+                "enabled=" + enabled +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                ", token='" + token + '\'' +
+                ", threadPoolSize=" + threadPoolSize +
+                ", initialDelay=" + initialDelay +
+                ", delay=" + delay +
+                ", scheduledThreadPool=" + scheduledThreadPool +
+                '}';
+    }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/ServerProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/ServerProperty.java
@@ -24,10 +24,7 @@
 package org.traffichunter.titan.bootstrap.environment.proprerty.sub;
 
 import java.util.Map;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * Mutable YAML DTO for one configured server.
@@ -36,9 +33,6 @@ import lombok.NoArgsConstructor;
  * input with minimal ceremony. Validation and defaulting are intentionally
  * deferred to {@code ServerSettings}, which is the immutable runtime model.</p>
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class ServerProperty {
 
     private String name;
@@ -52,4 +46,171 @@ public class ServerProperty {
     private Map<String, String> transportOptions;
     private Map<String, String> protocolOptions;
     private TlsProperty tls;
+
+    public ServerProperty() {
+    }
+
+    public ServerProperty(
+            String name,
+            String transport,
+            String protocol,
+            String host,
+            int port,
+            int primaryThreads,
+            int secondaryThreads,
+            Map<String, String> options,
+            Map<String, String> transportOptions,
+            Map<String, String> protocolOptions,
+            TlsProperty tls
+    ) {
+        this.name = name;
+        this.transport = transport;
+        this.protocol = protocol;
+        this.host = host;
+        this.port = port;
+        this.primaryThreads = primaryThreads;
+        this.secondaryThreads = secondaryThreads;
+        this.options = options;
+        this.transportOptions = transportOptions;
+        this.protocolOptions = protocolOptions;
+        this.tls = tls;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getTransport() {
+        return transport;
+    }
+
+    public void setTransport(String transport) {
+        this.transport = transport;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public int getPrimaryThreads() {
+        return primaryThreads;
+    }
+
+    public void setPrimaryThreads(int primaryThreads) {
+        this.primaryThreads = primaryThreads;
+    }
+
+    public int getSecondaryThreads() {
+        return secondaryThreads;
+    }
+
+    public void setSecondaryThreads(int secondaryThreads) {
+        this.secondaryThreads = secondaryThreads;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public void setOptions(Map<String, String> options) {
+        this.options = options;
+    }
+
+    public Map<String, String> getTransportOptions() {
+        return transportOptions;
+    }
+
+    public void setTransportOptions(Map<String, String> transportOptions) {
+        this.transportOptions = transportOptions;
+    }
+
+    public Map<String, String> getProtocolOptions() {
+        return protocolOptions;
+    }
+
+    public void setProtocolOptions(Map<String, String> protocolOptions) {
+        this.protocolOptions = protocolOptions;
+    }
+
+    public TlsProperty getTls() {
+        return tls;
+    }
+
+    public void setTls(TlsProperty tls) {
+        this.tls = tls;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof ServerProperty other
+                && port == other.port
+                && primaryThreads == other.primaryThreads
+                && secondaryThreads == other.secondaryThreads
+                && Objects.equals(name, other.name)
+                && Objects.equals(transport, other.transport)
+                && Objects.equals(protocol, other.protocol)
+                && Objects.equals(host, other.host)
+                && Objects.equals(options, other.options)
+                && Objects.equals(transportOptions, other.transportOptions)
+                && Objects.equals(protocolOptions, other.protocolOptions)
+                && Objects.equals(tls, other.tls);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                name,
+                transport,
+                protocol,
+                host,
+                port,
+                primaryThreads,
+                secondaryThreads,
+                options,
+                transportOptions,
+                protocolOptions,
+                tls
+        );
+    }
+
+    @Override
+    public String toString() {
+        return "ServerProperty{" +
+                "name='" + name + '\'' +
+                ", transport='" + transport + '\'' +
+                ", protocol='" + protocol + '\'' +
+                ", host='" + host + '\'' +
+                ", port=" + port +
+                ", primaryThreads=" + primaryThreads +
+                ", secondaryThreads=" + secondaryThreads +
+                ", options=" + options +
+                ", transportOptions=" + transportOptions +
+                ", protocolOptions=" + protocolOptions +
+                ", tls=" + tls +
+                '}';
+    }
 }

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/ServiceDiscoveryProperty.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/proprerty/sub/ServiceDiscoveryProperty.java
@@ -23,18 +23,43 @@
  */
 package org.traffichunter.titan.bootstrap.environment.proprerty.sub;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import java.util.Objects;
 
 /**
  * YAML DTO for service discovery configuration.
  */
-@Data
-@NoArgsConstructor(access = AccessLevel.PUBLIC)
-@AllArgsConstructor
 public class ServiceDiscoveryProperty {
 
     private String struct;
+
+    public ServiceDiscoveryProperty() {
+    }
+
+    public ServiceDiscoveryProperty(String struct) {
+        this.struct = struct;
+    }
+
+    public String getStruct() {
+        return struct;
+    }
+
+    public void setStruct(String struct) {
+        this.struct = struct;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj || obj instanceof ServiceDiscoveryProperty other
+                && Objects.equals(struct, other.struct);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(struct);
+    }
+
+    @Override
+    public String toString() {
+        return "ServiceDiscoveryProperty{struct='" + struct + "'}";
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,9 +92,6 @@ subprojects {
         testImplementation(rootProject.libs.mokito)
         testImplementation("org.mockito:mockito-junit-jupiter:5.21.0")
 
-        compileOnly(rootProject.libs.lombok)
-        annotationProcessor(rootProject.libs.lombok)
-
         implementation(rootProject.libs.slf4j)
         implementation(rootProject.libs.google.guava)
 

--- a/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
+++ b/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
@@ -27,7 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.NullMarked;
 import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.bootstrap.TitanBootstrap.ApplicationStarter;
@@ -51,10 +52,11 @@ import org.traffichunter.titan.core.spi.RuntimeLauncher;
  * the resulting managed server is started and registered for process shutdown
  * cleanup.</p>
  */
-@Slf4j
 @NullMarked
 @SuppressWarnings("unused")
 public class TitanApplication implements ApplicationStarter {
+
+    private static final Logger log = LoggerFactory.getLogger(TitanApplication.class);
 
     private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractChannel.java
@@ -23,8 +23,8 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.channel;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
@@ -51,9 +51,10 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  *
  * @author yun
  */
-@Slf4j
 @NullUnmarked
 public abstract class AbstractChannel implements Channel {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractChannel.class);
 
     private final SelectableChannel sc;
     private final ChannelHandShakeEventListener initializer;
@@ -82,7 +83,6 @@ public abstract class AbstractChannel implements Channel {
         }
     }
 
-    @Getter
     protected enum ChannelState {
         INIT(1),
         ACTIVE(2),
@@ -93,6 +93,10 @@ public abstract class AbstractChannel implements Channel {
 
         ChannelState(int value) {
             this.value = value;
+        }
+
+        public int getValue() {
+            return value;
         }
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractEventLoop.java
@@ -27,7 +27,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.Configurations;
 import org.traffichunter.titan.core.concurrent.AdvancedThreadPoolExecutor;
@@ -42,8 +43,9 @@ import org.traffichunter.titan.core.concurrent.Promise;
  *
  * @author yungwang-o
  */
-@Slf4j
 public abstract class AbstractEventLoop extends ThreadPoolExecutor implements EventLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractEventLoop.class);
 
     private static final Runnable WAKEUP_TASK = () -> {};
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelHandlerChain.java
@@ -27,7 +27,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
@@ -85,8 +86,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  *
  * @author yun
  */
-@Slf4j
 public class ChannelHandlerChain {
+
+    private static final Logger log = LoggerFactory.getLogger(ChannelHandlerChain.class);
 
     private final ChannelOutBoundHandlerChainImpl outboundChain;
     private final ChannelInBoundHandlerChainImpl inboundChain;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoop.java
@@ -27,7 +27,8 @@ import java.nio.channels.SelectionKey;
 import java.util.Iterator;
 import java.util.Set;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.event.EventLoopConstants;
 
 /**
@@ -37,8 +38,9 @@ import org.traffichunter.titan.core.util.event.EventLoopConstants;
  * read/write registration for those child channels is delegated by the server acceptor to a
  * secondary event loop.</p>
  */
-@Slf4j
 public class ChannelPrimaryIOEventLoop extends SingleThreadIOEventLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(ChannelPrimaryIOEventLoop.class);
 
     public ChannelPrimaryIOEventLoop() {
         this(EventLoopConstants.PRIMARY_EVENT_LOOP_THREAD_NAME);

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoopGroup.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelPrimaryIOEventLoopGroup.java
@@ -23,7 +23,8 @@
  */
 package org.traffichunter.titan.core.channel;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.concurrent.Promise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
 import org.traffichunter.titan.core.util.selector.RoundRobinSelector;
@@ -41,8 +42,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @author yun
  */
-@Slf4j
 public final class ChannelPrimaryIOEventLoopGroup implements ChannelEventLoopGroup<ChannelPrimaryIOEventLoop> {
+
+    private static final Logger log = LoggerFactory.getLogger(ChannelPrimaryIOEventLoopGroup.class);
 
     private final RoundRobinSelector<ChannelPrimaryIOEventLoop> selector;
     private final List<ChannelPrimaryIOEventLoop> group;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoop.java
@@ -27,7 +27,8 @@ import java.nio.channels.SelectionKey;
 import java.util.Iterator;
 import java.util.Set;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.util.buffer.Buffers;
 import org.traffichunter.titan.core.util.event.EventLoopConstants;
@@ -40,8 +41,9 @@ import org.traffichunter.titan.core.util.event.EventLoopConstants;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class ChannelSecondaryIOEventLoop extends SingleThreadIOEventLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(ChannelSecondaryIOEventLoop.class);
 
     public ChannelSecondaryIOEventLoop() {
         this(EventLoopConstants.SECONDARY_EVENT_LOOP_THREAD_NAME);

--- a/core/src/main/java/org/traffichunter/titan/core/channel/EventLoopFactory.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/EventLoopFactory.java
@@ -23,7 +23,8 @@
  */
 package org.traffichunter.titan.core.channel;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.event.EventLoopConstants;
 
 /**
@@ -33,8 +34,9 @@ import org.traffichunter.titan.core.util.event.EventLoopConstants;
  *
  * @author yungwang-o
  */
-@Slf4j
 public final class EventLoopFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(EventLoopFactory.class);
 
     public static ChannelPrimaryIOEventLoop createPrimaryIOEventLoop() {
         return new ChannelPrimaryIOEventLoop();

--- a/core/src/main/java/org/traffichunter/titan/core/channel/EventLoopStatus.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/EventLoopStatus.java
@@ -1,14 +1,11 @@
 package org.traffichunter.titan.core.channel;
 
-import lombok.Getter;
-
 /**
  * Ordered lifecycle states for event-loop shutdown checks.
  *
  * <p>The enum order is significant; code compares states to determine whether a loop has
  * reached or passed a shutdown phase.</p>
  */
-@Getter
 enum EventLoopStatus {
 
     NOT_STARTED(1),
@@ -22,5 +19,9 @@ enum EventLoopStatus {
 
     EventLoopStatus(int value) {
         this.value = value;
+    }
+
+    int getValue() {
+        return value;
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/IOSelector.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/IOSelector.java
@@ -24,7 +24,8 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.concurrent.NewIOException;
 
 import java.io.IOException;
@@ -43,8 +44,9 @@ import java.util.Set;
  *
  * @author yun
  */
-@Slf4j
 public final class IOSelector {
+
+    private static final Logger log = LoggerFactory.getLogger(IOSelector.class);
 
     private final Selector selector;
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -24,7 +24,8 @@ THE SOFTWARE.
 package org.traffichunter.titan.core.channel;
 
 import io.netty.buffer.ByteBuf;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.concurrent.ScheduledPromise;
@@ -49,8 +50,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @author yun, gkdbssla97
  */
-@Slf4j
 public class NewIONetChannel extends AbstractChannel implements NetChannel {
+
+    private static final Logger log = LoggerFactory.getLogger(NewIONetChannel.class);
 
     private final ChannelWriteBuffer channelWriteBuffer;
     private final Internal internal = new NewIOInternal();

--- a/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadEventLoop.java
@@ -30,7 +30,8 @@ import java.util.Comparator;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.Configurations;
@@ -48,8 +49,9 @@ import org.traffichunter.titan.core.util.Time;
  *
  * @author yungwang-o
  */
-@Slf4j
 public abstract class SingleThreadEventLoop extends AbstractEventLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(SingleThreadEventLoop.class);
 
     private static final int INITIAL_TASK_QUEUE_CAPACITY = 16;
     private static final Comparator<ScheduledPromise<?>> SCHEDULE_PROMISE_COMPARATOR = ScheduledPromise::compareTo;

--- a/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadIOEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadIOEventLoop.java
@@ -29,7 +29,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.Assert;
 
 /**
@@ -41,8 +42,9 @@ import org.traffichunter.titan.core.util.Assert;
  *
  * @author yungwang-o
  */
-@Slf4j
 public abstract class SingleThreadIOEventLoop extends SingleThreadEventLoop implements IOEventLoop {
+
+    private static final Logger log = LoggerFactory.getLogger(SingleThreadIOEventLoop.class);
 
     private final IOSelector ioSelector;
 

--- a/core/src/main/java/org/traffichunter/titan/core/channel/Subscription.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/Subscription.java
@@ -23,13 +23,11 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.channel;
 
-import lombok.Getter;
 import org.traffichunter.titan.core.util.Destination;
 
 /**
  * @author yun
  */
-@Getter
 public class Subscription {
 
     private final Destination destination;
@@ -38,5 +36,13 @@ public class Subscription {
     public Subscription(Destination destination, String id) {
         this.destination = destination;
         this.id = id;
+    }
+
+    public Destination getDestination() {
+        return destination;
+    }
+
+    public String getId() {
+        return id;
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
@@ -23,7 +23,8 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
@@ -38,8 +39,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  *
  * @author yun
  */
-@Slf4j
 public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(ChannelDecoder.class);
 
     /**
      * Combines a previously retained buffer with newly received bytes.

--- a/core/src/main/java/org/traffichunter/titan/core/codec/json/Json.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/json/Json.java
@@ -24,7 +24,8 @@
 package org.traffichunter.titan.core.codec.json;
 
 import java.io.InputStream;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
@@ -36,8 +37,9 @@ import tools.jackson.databind.json.JsonMapper;
  *
  * @author yungwang-o
  */
-@Slf4j
 public final class Json {
+
+    private static final Logger log = LoggerFactory.getLogger(Json.class);
 
     private static final JsonMapper mapper = new JsonMapper();
 

--- a/core/src/main/java/org/traffichunter/titan/core/concurrent/PromiseImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/concurrent/PromiseImpl.java
@@ -30,7 +30,8 @@ import java.util.concurrent.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.EventLoop;
 import org.traffichunter.titan.core.util.Assert;
@@ -45,8 +46,9 @@ import org.traffichunter.titan.core.util.Assert;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class PromiseImpl<C> implements Promise<C> {
+
+    private static final Logger log = LoggerFactory.getLogger(PromiseImpl.class);
 
     protected final EventLoop eventLoop;
 

--- a/core/src/main/java/org/traffichunter/titan/core/httpserver/jetty/EmbeddedJettyHttpServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/httpserver/jetty/EmbeddedJettyHttpServer.java
@@ -28,7 +28,8 @@ import jakarta.servlet.Servlet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
@@ -42,8 +43,9 @@ import org.traffichunter.titan.core.util.Pooling;
  * Embedded jetty web-server
  * @author yungwang-o
  */
-@Slf4j
 public class EmbeddedJettyHttpServer implements HttpServer {
+
+    private static final Logger log = LoggerFactory.getLogger(EmbeddedJettyHttpServer.class);
 
     private static final String ROOT_PATH = "/titan";
 

--- a/core/src/main/java/org/traffichunter/titan/core/httpserver/threadpool/JettyThreadPool.java
+++ b/core/src/main/java/org/traffichunter/titan/core/httpserver/threadpool/JettyThreadPool.java
@@ -23,7 +23,6 @@
  */
 package org.traffichunter.titan.core.httpserver.threadpool;
 
-import lombok.Getter;
 import org.eclipse.jetty.util.thread.MonitoredQueuedThreadPool;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;
@@ -33,7 +32,6 @@ import org.traffichunter.titan.core.util.Pooling;
 /**
  * @author yungwang-o
  */
-@Getter
 public enum JettyThreadPool {
 
     _VIRTUAL(Pooling._VIRTUAL) {
@@ -75,6 +73,10 @@ public enum JettyThreadPool {
 
     JettyThreadPool(final Pooling pooling) {
         this.pooling = pooling;
+    }
+
+    public Pooling getPooling() {
+        return pooling;
     }
 
     public JettyThreadPool match(final Pooling pooling) {

--- a/core/src/main/java/org/traffichunter/titan/core/message/Message.java
+++ b/core/src/main/java/org/traffichunter/titan/core/message/Message.java
@@ -26,8 +26,6 @@ package org.traffichunter.titan.core.message;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Objects;
-import lombok.Builder;
-import lombok.Getter;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.Destination;
 
@@ -40,7 +38,6 @@ import org.traffichunter.titan.core.util.Destination;
  *
  * @author yungwang-o
  */
-@Getter
 public final class Message {
 
     private final String uniqueId = IdGenerator.uuid();
@@ -57,7 +54,6 @@ public final class Message {
 
     private final byte[] body;
 
-    @Builder
     public Message(final Destination destination,
                    final Instant createdAt,
                    final String producerId,
@@ -68,6 +64,38 @@ public final class Message {
         this.producerId = Objects.requireNonNull(producerId, "producerId");
         this.body = Objects.requireNonNull(body, "body").clone();
         this.size = this.body.length;
+    }
+
+    public static MessageBuilder builder() {
+        return new MessageBuilder();
+    }
+
+    public String getUniqueId() {
+        return uniqueId;
+    }
+
+    public Destination getDestination() {
+        return destination;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getDispatchedAt() {
+        return dispatchedAt;
+    }
+
+    public String getProducerId() {
+        return producerId;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public byte[] getBody() {
+        return body;
     }
 
     public void setDispatchAt(final Instant dispatchedAt) {
@@ -112,5 +140,40 @@ public final class Message {
                 ", size:" + size +
                 ", body:" + Arrays.toString(body) +
                 '}';
+    }
+
+    public static final class MessageBuilder {
+
+        private Destination destination;
+        private Instant createdAt;
+        private String producerId;
+        private byte[] body;
+
+        private MessageBuilder() {
+        }
+
+        public MessageBuilder destination(Destination destination) {
+            this.destination = destination;
+            return this;
+        }
+
+        public MessageBuilder createdAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public MessageBuilder producerId(String producerId) {
+            this.producerId = producerId;
+            return this;
+        }
+
+        public MessageBuilder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public Message build() {
+            return new Message(destination, createdAt, producerId, body);
+        }
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -29,7 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.ChannelHandShakeEventListener;
@@ -57,8 +58,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class InetClient extends AbstractTransport<NetChannel> {
+
+    private static final Logger log = LoggerFactory.getLogger(InetClient.class);
 
     private final AtomicReference<State> state = new AtomicReference<>(State.INIT);
     private final InetClientOption option;

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -31,7 +31,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.*;
 import org.traffichunter.titan.core.concurrent.ChannelPromise;
@@ -54,8 +55,9 @@ import org.traffichunter.titan.core.util.channel.ChannelRegistry;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class InetServer extends AbstractTransport<NetServerChannel> {
+
+    private static final Logger log = LoggerFactory.getLogger(InetServer.class);
 
     private final NetServerChannel channel;
     private final ChannelRegistry<NetChannel> childChannels;

--- a/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/Protocol.java
@@ -23,12 +23,9 @@
  */
 package org.traffichunter.titan.core.util;
 
-import lombok.Getter;
-
 /**
  * @author yungwang-o
  */
-@Getter
 public enum Protocol {
     STOMP("stomp", "1.2", "v12.stomp"),
     MQTT("mqtt", "5.0", "v50.mqtt"),
@@ -42,6 +39,18 @@ public enum Protocol {
         this.name = name;
         this.version = version;
         this.subProtocol = subProtocol;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getSubProtocol() {
+        return subProtocol;
     }
 
     public static Protocol subProtocol(String subProtocol) {

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/AutoManagedByteBufAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/AutoManagedByteBufAllocator.java
@@ -31,7 +31,8 @@ import io.netty.buffer.WrappedByteBuf;
 import io.netty.util.IllegalReferenceCountException;
 import java.lang.ref.Cleaner;
 import java.util.concurrent.atomic.AtomicBoolean;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.util.Assert;
 
 /**
@@ -75,8 +76,9 @@ public class AutoManagedByteBufAllocator extends AbstractByteBufAllocator {
     /**
      * Wrapped buffer that marks the cleaner state when Netty reference count reaches zero.
      */
-    @Slf4j
     static class AutoReleaseByteBuf extends WrappedByteBuf {
+
+        private static final Logger log = LoggerFactory.getLogger(AutoReleaseByteBuf.class);
 
         private static final Cleaner CLEANER = Cleaner.create();
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/secure/auth/authentication/UsernamePasswordCredentials.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/secure/auth/authentication/UsernamePasswordCredentials.java
@@ -23,22 +23,29 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.util.secure.auth.authentication;
 
-import lombok.Builder;
-import lombok.Getter;
-
 /**
  * @author yun
  */
-@Getter
 public class UsernamePasswordCredentials implements Credentials {
 
     private final String username;
     private final String password;
 
-    @Builder
     public UsernamePasswordCredentials(String username, String password) {
         this.username = username;
         this.password = password;
+    }
+
+    public static UsernamePasswordCredentialsBuilder builder() {
+        return new UsernamePasswordCredentialsBuilder();
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     @Override
@@ -49,6 +56,29 @@ public class UsernamePasswordCredentials implements Credentials {
 
         if(password.isBlank()) {
             throw new CredentialsException("Password cannot be blank");
+        }
+    }
+
+    public static final class UsernamePasswordCredentialsBuilder {
+
+        private String username;
+        private String password;
+
+        private UsernamePasswordCredentialsBuilder() {
+        }
+
+        public UsernamePasswordCredentialsBuilder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public UsernamePasswordCredentialsBuilder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public UsernamePasswordCredentials build() {
+            return new UsernamePasswordCredentials(username, password);
         }
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchMode.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchMode.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import lombok.Getter;
 import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
 /**
@@ -34,7 +33,6 @@ import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
  * so protocol launchers can switch execution strategy without changing the
  * fanout contract.</p>
  */
-@Getter
 public enum DispatchMode {
 
     PLATFORM_EXECUTOR("platform") {
@@ -65,6 +63,10 @@ public enum DispatchMode {
 
     DispatchMode(String name) {
         this.name = name;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public abstract DispatchGateway dispatchGateway(DispatchExporter dispatchExporter);

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/MapDispatcher.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/MapDispatcher.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.Destination;
 
@@ -39,8 +40,9 @@ import org.traffichunter.titan.core.util.Destination;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class MapDispatcher implements Dispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(MapDispatcher.class);
 
     private final Map<Destination, DispatcherQueue> map;
     private final long defaultMaxPendingBytes;

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompServerFanoutLauncher.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompServerFanoutLauncher.java
@@ -3,7 +3,8 @@ package org.traffichunter.titan.dispatch;
 import java.util.Locale;
 import java.util.Map;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.bootstrap.Settings;
 import org.traffichunter.titan.core.resilience.flowcontrol.FlowControlConfiguration;
@@ -32,9 +33,10 @@ import org.traffichunter.titan.core.spi.*;
  * SEND handler -> DispatchGateway -> StompDispatchExporter
  * }</pre>
  */
-@Slf4j
 @SuppressWarnings("unused")
 public final class StompServerFanoutLauncher implements FanoutLauncher {
+
+    private static final Logger log = LoggerFactory.getLogger(StompServerFanoutLauncher.class);
 
     private static final String OPTION_FANOUT_MODE = "fanout-mode";
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/TitanStompManagedServerFanoutAdapter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/TitanStompManagedServerFanoutAdapter.java
@@ -23,7 +23,8 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.StompManagedServer;
@@ -38,8 +39,9 @@ import java.util.function.Function;
  *
  * @author yun
  */
-@Slf4j
 public final class TitanStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(TitanStompManagedServerFanoutAdapter.class);
 
     private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/TrieDispatcher.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/TrieDispatcher.java
@@ -24,7 +24,8 @@
 package org.traffichunter.titan.dispatch;
 
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Trie;
@@ -38,8 +39,9 @@ import org.traffichunter.titan.core.util.TrieImpl;
  *
  * @author yungwang-o
  */
-@Slf4j
 public class TrieDispatcher implements Dispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(TrieDispatcher.class);
 
     private final Trie<DispatcherQueue> trie = new TrieImpl<>();
     private final long defaultMaxPendingBytes;

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/VertxStompManagedServerFanoutAdapter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/VertxStompManagedServerFanoutAdapter.java
@@ -23,7 +23,8 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.bootstrap.GlobalShutdownHook;
 import org.traffichunter.titan.core.spi.ManagedServer;
 import org.traffichunter.titan.core.spi.vertx.VertxStompManagedServer;
@@ -38,8 +39,9 @@ import java.util.function.Function;
  *
  * @author yun
  */
-@Slf4j
 public final class VertxStompManagedServerFanoutAdapter implements ManagedServerFanoutAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(VertxStompManagedServerFanoutAdapter.class);
 
     private static final GlobalShutdownHook SHUTDOWN_HOOK = GlobalShutdownHook.INSTANCE;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-lombok = "1.18.46"
 slf4j = "2.0.17"
 google-guava = "33.6.0-jre"
 netty = "4.2.15.Final"
@@ -17,7 +16,6 @@ spring = "6.1.14"
 spring-boot = "3.3.5"
 
 [libraries]
-lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 mokito = { module = "org.mockito:mockito-core", version.ref = "mokito" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 google-guava = { module = "com.google.guava:guava", version.ref = "google-guava" }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/cpu/CpuData.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/cpu/CpuData.java
@@ -23,13 +23,11 @@
  */
 package org.traffichunter.titan.monitor.jmx.cpu;
 
-import lombok.Builder;
 import org.traffichunter.titan.monitor.jmx.ThreshHold;
 
 /**
  * @author yungwang-o
  */
-@Builder
 public record CpuData(
 
         double systemCpuLoad,
@@ -40,8 +38,41 @@ public record CpuData(
 
 ) implements ThreshHold {
 
+    public static CpuDataBuilder builder() {
+        return new CpuDataBuilder();
+    }
+
     @Override
     public boolean isCheckThreshold(final double factor) {
         return this.systemCpuLoad() > factor;
+    }
+
+    public static final class CpuDataBuilder {
+
+        private double systemCpuLoad;
+        private double processCpuLoad;
+        private long availableProcessors;
+
+        private CpuDataBuilder() {
+        }
+
+        public CpuDataBuilder systemCpuLoad(double value) {
+            this.systemCpuLoad = value;
+            return this;
+        }
+
+        public CpuDataBuilder processCpuLoad(double value) {
+            this.processCpuLoad = value;
+            return this;
+        }
+
+        public CpuDataBuilder availableProcessors(long value) {
+            this.availableProcessors = value;
+            return this;
+        }
+
+        public CpuData build() {
+            return new CpuData(systemCpuLoad, processCpuLoad, availableProcessors);
+        }
     }
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/heap/HeapData.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/heap/HeapData.java
@@ -23,13 +23,11 @@
  */
 package org.traffichunter.titan.monitor.jmx.heap;
 
-import lombok.Builder;
 import org.traffichunter.titan.monitor.jmx.ThreshHold;
 
 /**
  * @author yungwang-o
  */
-@Builder
 public record HeapData(
 
         long init,
@@ -42,6 +40,10 @@ public record HeapData(
 
 ) implements ThreshHold {
 
+    public static HeapDataBuilder builder() {
+        return new HeapDataBuilder();
+    }
+
     @Override
     public boolean isCheckThreshold(final double factor) {
         if (this.max() <= 0) {
@@ -50,5 +52,40 @@ public record HeapData(
 
         double usageRate = (double) this.used() / this.max();
         return usageRate > factor;
+    }
+
+    public static final class HeapDataBuilder {
+
+        private long init;
+        private long used;
+        private long committed;
+        private long max;
+
+        private HeapDataBuilder() {
+        }
+
+        public HeapDataBuilder init(long value) {
+            this.init = value;
+            return this;
+        }
+
+        public HeapDataBuilder used(long value) {
+            this.used = value;
+            return this;
+        }
+
+        public HeapDataBuilder committed(long value) {
+            this.committed = value;
+            return this;
+        }
+
+        public HeapDataBuilder max(long value) {
+            this.max = value;
+            return this;
+        }
+
+        public HeapData build() {
+            return new HeapData(init, used, committed, max);
+        }
     }
 }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/ThreadData.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/thread/ThreadData.java
@@ -23,13 +23,11 @@
  */
 package org.traffichunter.titan.monitor.jmx.thread;
 
-import lombok.Builder;
 import org.traffichunter.titan.monitor.jmx.ThreshHold;
 
 /**
  * @author yungwang-o
  */
-@Builder
 public record ThreadData(
 
         int threadCount,
@@ -40,8 +38,41 @@ public record ThreadData(
 
 ) implements ThreshHold {
 
+    public static ThreadDataBuilder builder() {
+        return new ThreadDataBuilder();
+    }
+
     @Override
     public boolean isCheckThreshold(final double factor) {
         return this.threadCount() > (int) factor;
+    }
+
+    public static final class ThreadDataBuilder {
+
+        private int threadCount;
+        private int peakThreadCount;
+        private long totalStartedThreadCount;
+
+        private ThreadDataBuilder() {
+        }
+
+        public ThreadDataBuilder threadCount(int value) {
+            this.threadCount = value;
+            return this;
+        }
+
+        public ThreadDataBuilder peakThreadCount(int value) {
+            this.peakThreadCount = value;
+            return this;
+        }
+
+        public ThreadDataBuilder totalStartedThreadCount(long value) {
+            this.totalStartedThreadCount = value;
+            return this;
+        }
+
+        public ThreadData build() {
+            return new ThreadData(threadCount, peakThreadCount, totalStartedThreadCount);
+        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
@@ -32,7 +32,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.*;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompClientSubscription;
@@ -54,8 +55,9 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
 /**
  * @author yun
  */
-@Slf4j
 public class StompClientTcpChannel implements StompClientChannel {
+
+    private static final Logger log = LoggerFactory.getLogger(StompClientTcpChannel.class);
 
     private final String sessionId = IdGenerator.randomId16("session");
     private final NetChannel netChannel;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompFrameDispatchHandler.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompFrameDispatchHandler.java
@@ -25,7 +25,8 @@ package org.traffichunter.titan.core.channel.stomp;
 
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.NetChannel;
@@ -39,8 +40,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  *
  * @author yun
  */
-@Slf4j
 public final class StompFrameDispatchHandler implements ChannelInBoundHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(StompFrameDispatchHandler.class);
 
     private final StompClientChannel stompChannel;
     private final StompHandler stompHandler;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerHandlerImpl.java
@@ -23,7 +23,8 @@
  */
 package org.traffichunter.titan.core.channel.stomp;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.codec.stomp.*;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Handler;
@@ -37,9 +38,10 @@ import static org.traffichunter.titan.core.codec.stomp.StompFrame.create;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 import static org.traffichunter.titan.core.codec.stomp.StompFrame.formatString;
 import static org.traffichunter.titan.core.codec.stomp.StompVersion.STOMP_1_0;
-
-@Slf4j
 public final class StompServerHandlerImpl implements StompServerHandler {
+
+
+    private static final Logger log = LoggerFactory.getLogger(StompServerHandlerImpl.class);
 
     private final StompServerHandlerContext context;
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -23,7 +23,8 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec.stomp;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.StompHandler;
@@ -40,8 +41,9 @@ import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
 /**
  * @author yun, gkdbssla97
  */
-@Slf4j
 public class StompChannelDecoder extends ChannelDecoder {
+
+    private static final Logger log = LoggerFactory.getLogger(StompChannelDecoder.class);
 
     private static final int DEFAULT_MAX_LENGTH = 65536;
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompClientSubscription.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompClientSubscription.java
@@ -23,8 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec.stomp;
 
-import lombok.Builder;
-import lombok.Getter;
 import org.traffichunter.titan.core.channel.Subscription;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Handler;
@@ -32,12 +30,10 @@ import org.traffichunter.titan.core.util.Handler;
 /**
  * @author yun
  */
-@Getter
 public class StompClientSubscription extends Subscription implements StompSubscription {
 
     private final Handler<StompFrame> handler;
 
-    @Builder
     public StompClientSubscription(
             String destination,
             String id,
@@ -45,6 +41,14 @@ public class StompClientSubscription extends Subscription implements StompSubscr
     ) {
         super(Destination.create(destination), id);
         this.handler = handler;
+    }
+
+    public static StompClientSubscriptionBuilder builder() {
+        return new StompClientSubscriptionBuilder();
+    }
+
+    public Handler<StompFrame> getHandler() {
+        return handler;
     }
 
     @Override
@@ -55,5 +59,34 @@ public class StompClientSubscription extends Subscription implements StompSubscr
     @Override
     public Destination destination() {
         return getDestination();
+    }
+
+    public static final class StompClientSubscriptionBuilder {
+
+        private String destination;
+        private String id;
+        private Handler<StompFrame> handler;
+
+        private StompClientSubscriptionBuilder() {
+        }
+
+        public StompClientSubscriptionBuilder destination(String destination) {
+            this.destination = destination;
+            return this;
+        }
+
+        public StompClientSubscriptionBuilder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public StompClientSubscriptionBuilder handler(Handler<StompFrame> handler) {
+            this.handler = handler;
+            return this;
+        }
+
+        public StompClientSubscription build() {
+            return new StompClientSubscription(destination, id, handler);
+        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompDelimiter.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompDelimiter.java
@@ -23,12 +23,9 @@
  */
 package org.traffichunter.titan.core.codec.stomp;
 
-import lombok.Getter;
-
 /**
  * @author yungwang-o
  */
-@Getter
 public enum StompDelimiter {
 
     CR((byte) 0x0D, '\r'),         // carriage return
@@ -43,6 +40,14 @@ public enum StompDelimiter {
     StompDelimiter(final byte hex, final char character) {
         this.hex = hex;
         this.character = character;
+    }
+
+    public byte getHex() {
+        return hex;
+    }
+
+    public char getCharacter() {
+        return character;
     }
 
     public String getString() {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompFrame.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.helpers.MessageFormatter;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements;
@@ -43,9 +43,9 @@ import org.traffichunter.titan.core.util.inet.Frame;
 /**
  * @author yungwang-o
  */
-@Getter
-@Slf4j
 public final class StompFrame implements Frame<Elements, String>, StompFrames {
+
+    private static final Logger log = LoggerFactory.getLogger(StompFrame.class);
 
     public static final StompFrame ERR_STOMP_FRAME =
             new StompFrame(new StompHeaders(StompVersion.STOMP_1_2), StompCommand.ERROR);
@@ -95,6 +95,14 @@ public final class StompFrame implements Frame<Elements, String>, StompFrames {
                                     final Buffer body) {
 
         return new StompFrame(headers, command, body);
+    }
+
+    public StompHeaders getHeaders() {
+        return headers;
+    }
+
+    public StompCommand getCommand() {
+        return command;
     }
 
     public static StompFrame create(final StompHeaders headers,

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompHeaders.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompHeaders.java
@@ -26,7 +26,6 @@ package org.traffichunter.titan.core.codec.stomp;
 import java.util.*;
 import java.util.Map.Entry;
 
-import lombok.Getter;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.codec.frame.Headers;
 import org.traffichunter.titan.core.codec.stomp.StompFrame.StompFrameException;
@@ -34,7 +33,6 @@ import org.traffichunter.titan.core.codec.stomp.StompFrame.StompFrameException;
 /**
  * @author yungwang-o
  */
-@Getter
 public final class StompHeaders extends Headers<StompHeaders.Elements, String, StompHeaders> {
 
     private static final char ESCAPE = '\\';
@@ -72,6 +70,14 @@ public final class StompHeaders extends Headers<StompHeaders.Elements, String, S
 
     public static StompHeaders create() {
         return new StompHeaders(StompVersion.STOMP_1_2);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public static String encode(@Nullable final String value, final StompCommand command) {
@@ -181,7 +187,6 @@ public final class StompHeaders extends Headers<StompHeaders.Elements, String, S
         return new StompHeaders(new HashMap<>(), "stomp", "1.2");
     }
 
-    @Getter
     public enum Elements {
         ACCEPT_VERSION("accept-version"),
         HOST("host"),
@@ -208,6 +213,10 @@ public final class StompHeaders extends Headers<StompHeaders.Elements, String, S
 
         Elements(final String name) {
             this.name = name;
+        }
+
+        public String getName() {
+            return name;
         }
 
         public static Elements convertToElements(final String value) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompServerSubscription.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompServerSubscription.java
@@ -23,8 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.codec.stomp;
 
-import lombok.Builder;
-import lombok.Getter;
 import org.traffichunter.titan.core.channel.Subscription;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
 import org.traffichunter.titan.core.util.Destination;
@@ -32,13 +30,11 @@ import org.traffichunter.titan.core.util.Destination;
 /**
  * @author yun
  */
-@Getter
 public class StompServerSubscription extends Subscription implements StompSubscription {
 
     private final String ackMode;
     private final StompClientChannel connection;
 
-    @Builder
     public StompServerSubscription(
             Destination destination,
             String id,
@@ -50,6 +46,18 @@ public class StompServerSubscription extends Subscription implements StompSubscr
         this.connection = connection;
     }
 
+    public static StompServerSubscriptionBuilder builder() {
+        return new StompServerSubscriptionBuilder();
+    }
+
+    public String getAckMode() {
+        return ackMode;
+    }
+
+    public StompClientChannel getConnection() {
+        return connection;
+    }
+
     @Override
     public String id() {
         return getId();
@@ -58,5 +66,40 @@ public class StompServerSubscription extends Subscription implements StompSubscr
     @Override
     public Destination destination() {
         return getDestination();
+    }
+
+    public static final class StompServerSubscriptionBuilder {
+
+        private Destination destination;
+        private String id;
+        private String ackMode;
+        private StompClientChannel connection;
+
+        private StompServerSubscriptionBuilder() {
+        }
+
+        public StompServerSubscriptionBuilder destination(Destination destination) {
+            this.destination = destination;
+            return this;
+        }
+
+        public StompServerSubscriptionBuilder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public StompServerSubscriptionBuilder ackMode(String ackMode) {
+            this.ackMode = ackMode;
+            return this;
+        }
+
+        public StompServerSubscriptionBuilder connection(StompClientChannel connection) {
+            this.connection = connection;
+            return this;
+        }
+
+        public StompServerSubscription build() {
+            return new StompServerSubscription(destination, id, ackMode, connection);
+        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompVersion.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompVersion.java
@@ -23,12 +23,9 @@
  */
 package org.traffichunter.titan.core.codec.stomp;
 
-import lombok.Getter;
-
 /**
  * @author yungwang-o
  */
-@Getter
 public enum StompVersion {
     STOMP_1_2("stomp", "1.2"),
     STOMP_1_1("stomp", "1.1"),
@@ -41,6 +38,14 @@ public enum StompVersion {
     StompVersion(final String name, final String version) {
         this.name = name;
         this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
     }
 
     public void validate(final String version) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transaction.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/Transaction.java
@@ -26,7 +26,6 @@ package org.traffichunter.titan.core.codec.stomp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import lombok.Getter;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
 
 /**
@@ -34,7 +33,6 @@ import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
  *
  * @author yungwang-o
  */
-@Getter
 public final class Transaction {
 
     private final StompClientChannel stompClientChannel;
@@ -51,6 +49,18 @@ public final class Transaction {
 
     public static Transaction create(final StompClientChannel serverConnection, final String txId) {
         return new Transaction(serverConnection, txId);
+    }
+
+    public StompClientChannel getStompClientChannel() {
+        return stompClientChannel;
+    }
+
+    public String getTxId() {
+        return txId;
+    }
+
+    public int getDEFAULT_TX_SIZE() {
+        return DEFAULT_TX_SIZE;
     }
 
     public synchronized void addFrame(final StompFrame frame) {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompManagedServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompManagedServer.java
@@ -25,7 +25,8 @@ package org.traffichunter.titan.core.spi.vertx;
 
 import io.vertx.core.Future;
 import io.vertx.ext.stomp.StompServer;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.core.spi.ManagedServer;
 
@@ -35,8 +36,9 @@ import java.util.concurrent.TimeoutException;
 /**
  * @author yun
  */
-@Slf4j
 public final class VertxStompManagedServer implements ManagedServer {
+
+    private static final Logger log = LoggerFactory.getLogger(VertxStompManagedServer.class);
 
     private final StompServer server;
     private final ServerSettings settings;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -29,7 +29,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.stomp.StompServer;
 import io.vertx.ext.stomp.StompServerHandler;
 import io.vertx.ext.stomp.StompServerOptions;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelOutBoundHandler;
@@ -43,8 +44,9 @@ import java.util.Map;
 /**
  * @author yun
  */
-@Slf4j
 public class VertxStompServerEngineProvider implements NetworkServerEngineProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(VertxStompServerEngineProvider.class);
 
     @Override
     public String transport() {

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -27,7 +27,8 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
@@ -50,8 +51,9 @@ import org.traffichunter.titan.core.util.Protocol;
 /**
  * @author yun
  */
-@Slf4j
 public final class StompServer {
+
+    private static final Logger log = LoggerFactory.getLogger(StompServer.class);
 
     private final InetServer inetServer;
     private final StompServerChannel serverConnection;

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.transport.stomp.option;
 
-import lombok.Builder;
 import org.traffichunter.titan.core.codec.stomp.StompVersion;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 
@@ -72,7 +71,6 @@ public record StompServerOption(
         }
     }
 
-    @Builder(builderMethodName = "builder")
     public static StompServerOption of(
             Integer maxHeaderLength,
             Integer maxHeaders,
@@ -106,5 +104,119 @@ public record StompServerOption(
                 StompVersion.STOMP_1_2,
                 inetServerOption == null ? InetServerOption.DEFAULT_INET_SERVER_OPTION : inetServerOption
         );
+    }
+
+    public static StompServerOptionBuilder builder() {
+        return new StompServerOptionBuilder();
+    }
+
+    public static final class StompServerOptionBuilder {
+
+        private Integer maxHeaderLength;
+        private Integer maxHeaders;
+        private Integer maxBodyLength;
+        private Integer maxFrameInTransaction;
+        private String supportedVersions;
+        private Boolean secured;
+        private Boolean sendErrorOnNoSubscriptions;
+        private Long ackTimeoutMillis;
+        private Integer timeFactor;
+        private Long heartbeatX;
+        private Long heartbeatY;
+        private Integer transactionChunkSize;
+        private Integer maxSubscriptionsByClient;
+        private InetServerOption inetServerOption;
+
+        private StompServerOptionBuilder() {
+        }
+
+        public StompServerOptionBuilder maxHeaderLength(Integer value) {
+            this.maxHeaderLength = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder maxHeaders(Integer value) {
+            this.maxHeaders = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder maxBodyLength(Integer value) {
+            this.maxBodyLength = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder maxFrameInTransaction(Integer value) {
+            this.maxFrameInTransaction = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder supportedVersions(String value) {
+            this.supportedVersions = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder secured(Boolean value) {
+            this.secured = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder sendErrorOnNoSubscriptions(Boolean value) {
+            this.sendErrorOnNoSubscriptions = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder ackTimeoutMillis(Long value) {
+            this.ackTimeoutMillis = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder timeFactor(Integer value) {
+            this.timeFactor = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder heartbeatX(Long value) {
+            this.heartbeatX = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder heartbeatY(Long value) {
+            this.heartbeatY = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder transactionChunkSize(Integer value) {
+            this.transactionChunkSize = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder maxSubscriptionsByClient(Integer value) {
+            this.maxSubscriptionsByClient = value;
+            return this;
+        }
+
+        public StompServerOptionBuilder inetServerOption(InetServerOption value) {
+            this.inetServerOption = value;
+            return this;
+        }
+
+        public StompServerOption build() {
+            return StompServerOption.of(
+                    maxHeaderLength,
+                    maxHeaders,
+                    maxBodyLength,
+                    maxFrameInTransaction,
+                    supportedVersions,
+                    secured,
+                    sendErrorOnNoSubscriptions,
+                    ackTimeoutMillis,
+                    timeFactor,
+                    heartbeatX,
+                    heartbeatY,
+                    transactionChunkSize,
+                    maxSubscriptionsByClient,
+                    inetServerOption
+            );
+        }
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompSessionOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompSessionOption.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.transport.stomp.option;
 
-import lombok.Builder;
 import org.traffichunter.titan.core.codec.stomp.StompVersion;
 
 /**
@@ -78,7 +77,6 @@ public record StompSessionOption(
      * <p>STOMP 1.2 is currently the only accepted version. Numeric validation is completed by
      * the record's canonical constructor after defaults have been applied.</p>
      */
-    @Builder(builderMethodName = "builder")
     public static StompSessionOption of(
             StompVersion version,
             String login,
@@ -108,5 +106,91 @@ public record StompSessionOption(
                 maxFrameLength == null ? DEFAULT_MAX_FRAME_LENGTH : maxFrameLength,
                 resolvedVersion
         );
+    }
+
+    public static StompSessionOptionBuilder builder() {
+        return new StompSessionOptionBuilder();
+    }
+
+    public static final class StompSessionOptionBuilder {
+
+        private StompVersion version;
+        private String login;
+        private String passcode;
+        private Boolean autoComputeContentLength;
+        private Boolean useStompFrame;
+        private Boolean bypassHostHeader;
+        private Long heartbeatX;
+        private Long heartbeatY;
+        private String virtualHost;
+        private Integer maxFrameLength;
+
+        private StompSessionOptionBuilder() {
+        }
+
+        public StompSessionOptionBuilder version(StompVersion value) {
+            this.version = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder login(String value) {
+            this.login = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder passcode(String value) {
+            this.passcode = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder autoComputeContentLength(Boolean value) {
+            this.autoComputeContentLength = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder useStompFrame(Boolean value) {
+            this.useStompFrame = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder bypassHostHeader(Boolean value) {
+            this.bypassHostHeader = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder heartbeatX(Long value) {
+            this.heartbeatX = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder heartbeatY(Long value) {
+            this.heartbeatY = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder virtualHost(String value) {
+            this.virtualHost = value;
+            return this;
+        }
+
+        public StompSessionOptionBuilder maxFrameLength(Integer value) {
+            this.maxFrameLength = value;
+            return this;
+        }
+
+        public StompSessionOption build() {
+            return StompSessionOption.of(
+                    version,
+                    login,
+                    passcode,
+                    autoComputeContentLength,
+                    useStompFrame,
+                    bypassHostHeader,
+                    heartbeatX,
+                    heartbeatY,
+                    virtualHost,
+                    maxFrameLength
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation:

Titan should keep its public Java API explicit and avoid relying on annotation-generated source for logging, accessors, builders, and configuration binding. Removing Lombok also simplifies compilation and reduces annotation processor dependencies.

## Modification:

- Replace Lombok logging annotations with explicit SLF4J logger fields.
- Implement existing getters and builders as regular Java code while preserving their public method names.
- Keep mutable YAML binding properties compatible through explicit constructors, accessors, and object methods.
- Remove Lombok from the shared Gradle dependencies and version catalog.

## Result:

The project builds without Lombok while retaining the existing source-level getter and builder APIs.

Validation:
- `./gradlew compileJava --no-configuration-cache`
- `./gradlew test --no-configuration-cache`