### PR TITLE
Consolidate dispatch handler responsibilities

### DIFF
--- a/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
+++ b/benchmark/src/jmh/java/org/traffichunter/titan/benchmark/FanoutGatewayBenchmark.java
@@ -63,8 +63,7 @@ public class FanoutGatewayBenchmark {
         batchMessages = createBatchMessages(destination, batchSize);
 
         gateway = DispatchMode.resolveMode(mode).dispatchGateway(new CountingNoopExporter(exportCount));
-        gateway.fanout(destination);
-        gateway.publish(message).get(1, TimeUnit.SECONDS);
+        gateway.sparkDispatch(message).get(1, TimeUnit.SECONDS);
     }
 
     @TearDown(Level.Trial)
@@ -74,22 +73,22 @@ public class FanoutGatewayBenchmark {
 
     @Benchmark
     @Threads(1)
-    public void publishSingleThreadOneMessage() throws Exception {
-        gateway.publish(message).get(1, TimeUnit.SECONDS);
+    public void sparkDispatchSingleThreadOneMessage() throws Exception {
+        gateway.sparkDispatch(message).get(1, TimeUnit.SECONDS);
     }
 
     @Benchmark
     @Threads(16)
-    public void publishConcurrentOneMessage() throws Exception {
-        gateway.publish(message).get(1, TimeUnit.SECONDS);
+    public void sparkDispatchConcurrentOneMessage() throws Exception {
+        gateway.sparkDispatch(message).get(1, TimeUnit.SECONDS);
     }
 
     @Benchmark
     @Threads(16)
-    public void publishConcurrentBatch() throws Exception {
+    public void sparkDispatchConcurrentBatch() throws Exception {
         List<Future<Void>> futures = new ArrayList<>(batchMessages.size());
         for (Message batchMessage : batchMessages) {
-            futures.add(gateway.publish(batchMessage));
+            futures.add(gateway.sparkDispatch(batchMessage));
         }
         for (Future<Void> future : futures) {
             future.get(1, TimeUnit.SECONDS);

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/AbstractExecutorDispatchGateway.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/AbstractExecutorDispatchGateway.java
@@ -30,38 +30,26 @@ import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.Destination;
-import org.traffichunter.titan.core.util.management.DispatcherQueueMbeans;
 import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Executor-backed {@link DispatchGateway} implementation shared by platform and
- * virtual-thread variants.
+ * Executor-backed {@link DispatchGateway} facade shared by platform and virtual-thread variants.
  *
- * <p>Each destination has at most one active consumer task in {@link #consumers}.
- * Producer calls are processed through one {@link DispatchHandlerChain}. The
- * gateway installs routing as the first handler and fanout as the last handler,
- * while optional middle handlers can add behavior such as backup without being
- * embedded in the core queue and consumer flow.</p>
+ * <p>The gateway owns the executor and the public lifecycle, while concrete dispatch work belongs
+ * to the handlers. {@link RouteDispatchChainHandler} admits messages to destination queues and
+ * {@link FanoutDispatchChainHandler} owns destination consumers and fanout lifecycle. Optional
+ * handlers run between those two boundaries.</p>
  *
- * <p>Routing enqueues the message into the dispatcher queue. After middle
- * handlers complete, the terminal fanout handler ensures that a destination
- * consumer exists. The consumer drains the queue sequentially into the
- * configured {@link DispatchExporter}. This gives a simple fanout invariant:
- * ordering is preserved per destination queue, while different destinations can
- * progress independently on the executor.</p>
+ * <p>Queue deletion delegates to the terminal fanout handler so consumer state remains within its
+ * owner. Queue creation remains a direct dispatcher registry operation.</p>
  *
  * <pre>{@code
- * publish(message)
+ * sparkDispatch(message)
  *      |
  *      v
  * DispatchHandlerChain
@@ -76,120 +64,62 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * FanoutDispatchChainHandler -> computeIfAbsent(destination, consume)
  * }</pre>
  *
- * <p>{@link #fanout(Destination)} starts a destination consumer directly when a
- * caller wants to pre-warm delivery without publishing a message.</p>
- *
  * @author yun
  */
 abstract class AbstractExecutorDispatchGateway implements DispatchGateway {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractExecutorDispatchGateway.class);
-    private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
+    private static final long SHUTDOWN_TIMEOUT_SECONDS = 60;
 
-    private final Map<Destination, CompletableFuture<@Nullable Void>> consumers = new ConcurrentHashMap<>();
-    private final Set<DispatcherQueue> deletedQueues = ConcurrentHashMap.newKeySet();
-
-    private final ExecutorService dispatchExecutor;
-    private final DispatchExporter exporter;
+    private final ExecutorService executor;
     private final Dispatcher dispatcher;
-    private final AtomicBoolean isClosed = new AtomicBoolean();
-    private DispatchHandlerChain dispatchHandlerChain;
+    private final FanoutDispatchChainHandler fanoutHandler;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private DispatchHandlerChain handlerChain;
 
     protected AbstractExecutorDispatchGateway(
-            ExecutorService dispatchExecutor,
+            ExecutorService executor,
             DispatchExporter exporter,
             Dispatcher dispatcher
     ) {
-        this.dispatchExecutor = dispatchExecutor;
-        this.exporter = exporter;
+        this.executor = executor;
         this.dispatcher = dispatcher;
-        this.dispatchHandlerChain = DispatchHandlerChain.chain(dispatchExecutor)
-                .add(new RouteDispatchChainHandler(this::route))
-                .add(new FanoutDispatchChainHandler(this::fanout));
+        this.fanoutHandler = new FanoutDispatchChainHandler(executor, exporter, dispatcher);
+        this.handlerChain = DispatchHandlerChain.chain(executor)
+                .add(new RouteDispatchChainHandler(dispatcher))
+                .add(fanoutHandler);
     }
 
     @Override
     public DispatchGateway chainHandler(Handler<DispatchHandlerChain> chainHandler) {
-        DispatchHandlerChain chain = DispatchHandlerChain.chain(dispatchExecutor);
-        chain.add(new RouteDispatchChainHandler(this::route));
+        DispatchHandlerChain chain = DispatchHandlerChain.chain(executor);
+        chain.add(new RouteDispatchChainHandler(dispatcher));
         chainHandler.handle(chain);
-        chain.add(new FanoutDispatchChainHandler(this::fanout));
-        this.dispatchHandlerChain = chain;
+        chain.add(fanoutHandler);
+        this.handlerChain = chain;
         return this;
     }
 
     @Override
-    public List<CompletableFuture<@Nullable Void>> fanout(Collection<Destination> destinations) {
-        if (isClosed.get()) {
-            throw new IllegalStateException("DispatchGateway is closed");
-        }
-
-        return destinations.stream()
-                .map(this::fanout)
-                .toList();
-    }
-
-    @Override
-    public CompletableFuture<@Nullable Void> fanout(Destination destination) {
-        if (isClosed.get()) {
-            throw new IllegalStateException("DispatchGateway is closed");
-        }
-
-        return consumers.computeIfAbsent(destination, this::consume);
-    }
-
-    @Override
-    public List<CompletableFuture<@Nullable Void>> publish(Collection<Message> messages) {
-        if (isClosed.get()) {
-            throw new IllegalStateException("DispatchGateway is closed");
-        }
-
-        return messages.stream()
-                .map(this::publish)
-                .toList();
-    }
-
-    @Override
-    public CompletableFuture<@Nullable Void> publish(Message message) {
+    public CompletableFuture<@Nullable Void> sparkDispatch(Message message) {
         Assert.checkNotNull(message, "message");
 
-        if (isClosed.get()) {
+        if (closed.get()) {
             throw new IllegalStateException("DispatchGateway is closed");
         }
 
-        return dispatchHandlerChain.dispatch(new DispatchContext(message))
+        return handlerChain.sparkDispatch(new DispatchContext(message))
                 .thenApply(ignored -> null);
     }
 
     @Override
     public boolean isOpen() {
-        return !isClosed.get();
+        return !closed.get();
     }
 
     @Override
     public boolean isClosed() {
-        return isClosed.get();
-    }
-
-    @Override
-    public void close() {
-        if (isClosed.compareAndSet(false, true)) {
-            consumers.values().forEach(future -> future.cancel(true));
-            consumers.clear();
-            dispatchExecutor.shutdown();
-            try {
-                if (!dispatchExecutor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                    dispatchExecutor.shutdownNow();
-                    if (!dispatchExecutor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                        log.warn("Fanout executor did not terminate cleanly");
-                    }
-                }
-            } catch (InterruptedException e) {
-                dispatchExecutor.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-            dispatchHandlerChain.clear();
-        }
+        return closed.get();
     }
 
     /**
@@ -200,7 +130,7 @@ abstract class AbstractExecutorDispatchGateway implements DispatchGateway {
      */
     @Override
     public DispatcherQueue createQueue(Destination destination, long maxPendingBytes) {
-        if (isClosed.get()) {
+        if (closed.get()) {
             throw new IllegalStateException("DispatchGateway is closed");
         }
 
@@ -217,98 +147,29 @@ abstract class AbstractExecutorDispatchGateway implements DispatchGateway {
      */
     @Override
     public DispatcherQueueDeleteResult deleteQueue(Destination destination, boolean force) {
-        DispatcherQueue queue = dispatcher.get(destination);
-        if (queue == null) {
-            return DispatcherQueueDeleteResult.notFound();
+        if (closed.get()) {
+            throw new IllegalStateException("DispatchGateway is closed");
         }
-        int size = queue.size();
-        if (size > 0 && !force) {
-            return DispatcherQueueDeleteResult.notEmpty(size);
-        }
-        if (force) {
-            queue.clear();
-        }
-
-        deletedQueues.add(queue);
-        CompletableFuture<@Nullable Void> consumer = consumers.remove(destination);
-        if (consumer != null) {
-            consumer.cancel(true);
-        }
-        dispatcher.remove(destination);
-        DispatcherQueueMbeans.unregister(queue.getDestination());
-        return DispatcherQueueDeleteResult.deleted(size);
+        return fanoutHandler.deleteQueue(destination, force);
     }
 
-    /**
-     * Runs one destination consumer.
-     *
-     * <p>The loop polls with a timeout instead of blocking indefinitely so it
-     * can observe queue deletion and shutdown state. The returned future uses
-     * {@code @Nullable Void} because successful completion is represented by a
-     * {@code null} value.</p>
-     */
-    protected CompletableFuture<@Nullable Void> consume(Destination destination) {
-        DispatcherQueue dispatcherQueue = dispatcher.getOrPut(destination);
-        log.info("Starting fanout consumer for destination={}", destination.path());
-
-        CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
-        dispatchExecutor.execute(() -> {
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            fanoutHandler.close();
+            executor.shutdown();
             try {
-                while (!isClosed()
-                        && !Thread.currentThread().isInterrupted()
-                        && !deletedQueues.contains(dispatcherQueue)) {
-                    try {
-                        Message message = dispatcherQueue.dispatch(1, TimeUnit.SECONDS);
-                        if (message == null) {
-                            continue;
-                        }
-
-                        exporter.export(destination, message);
-                    } catch (InterruptedException e) {
-                        log.error("Interrupted while waiting for message to be delivered", e);
-                        Thread.currentThread().interrupt();
-                        break;
-                    } catch (Exception e) {
-                        log.error("Unexpected error while dispatching message", e);
-                        if (isClosed() || dispatchExecutor.isShutdown()) {
-                            break;
-                        }
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    executor.shutdownNow();
+                    if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        log.warn("Fanout executor did not terminate cleanly");
                     }
                 }
-                result.complete(null);
-            } catch (Exception e) {
-                result.completeExceptionally(e);
-            } finally {
-                deletedQueues.remove(dispatcherQueue);
-                consumers.remove(destination, result);
+            } catch (InterruptedException e) {
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
             }
-        });
-        return result;
-    }
-
-    protected Message route(Message message) {
-        Destination destination = message.getDestination();
-        Assert.checkNotNull(destination, "message.destination");
-
-        DispatcherQueue dq = dispatcher.getOrPut(destination);
-
-        try {
-            Message routeMessage = dq.enqueue(message);
-            if (routeMessage == null) {
-                throw new IllegalStateException("routeMessage is null");
-            }
-
-            return routeMessage;
-        } catch (Exception e) {
-            log.warn(
-                    "Failed to route fanout message. destination={}",
-                    destination.path(),
-                    e
-            );
-            if(dq.contains(message)) {
-                dq.remove(message);
-            }
-            throw e;
+            handlerChain.clear();
         }
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChain.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChain.java
@@ -23,8 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * Continuation passed to a dispatch handler.
  *
@@ -40,7 +38,7 @@ public interface DispatchChain {
      * Propagates the context to the next dispatch handler.
      *
      * @param context dispatch state shared by the chain
-     * @return completion of the remaining dispatch handlers
+     * @return continuation reached after propagation
      */
-    CompletableFuture<Void> next(DispatchContext context);
+    DispatchChain next(DispatchContext context);
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChainHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChainHandler.java
@@ -23,8 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * Handles one ordered step in the message dispatch lifecycle.
  *
@@ -33,8 +31,8 @@ import java.util.concurrent.CompletableFuture;
  * {@link DispatchChain#next(DispatchContext)} to propagate the operation. Not
  * invoking the continuation is an intentional short circuit.</p>
  *
- * <p>The returned future must represent all work performed by this stage. Implementations should
- * compose asynchronous work into that future rather than launching untracked tasks.</p>
+ * <p>Handlers run sequentially on the dispatch executor selected by the gateway. A handler may
+ * stop propagation by returning the supplied continuation without invoking it.</p>
  *
  * @author yun
  */
@@ -48,7 +46,7 @@ public interface DispatchChainHandler {
      *
      * @param context state shared by the dispatch lifecycle
      * @param chain remaining dispatch handlers
-     * @return completion of this stage and any propagated handlers
+     * @return continuation reached after this handler runs
      */
-    CompletableFuture<Void> handle(DispatchContext context, DispatchChain chain);
+    DispatchChain handle(DispatchContext context, DispatchChain chain);
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchContext.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchContext.java
@@ -23,22 +23,20 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.message.Message;
 
 /**
  * Mutable state shared while one dispatch operation moves through a handler chain.
  *
- * <p>The context starts with the original producer {@link Message}. The route
- * handler stores the routed message after enqueueing it, and later handlers use
- * that routed value to decide whether the operation should continue.</p>
+ * <p>The context retains the producer {@link Message} while handlers route, observe, and fan out
+ * one dispatch operation. A routing failure terminates traversal by throwing rather than storing
+ * a nullable routing result.</p>
  *
  * @author yun
  */
 public class DispatchContext {
 
     private final Message message;
-    private @Nullable Message routedMessage;
 
     public DispatchContext(Message message) {
         this.message = message;
@@ -46,13 +44,5 @@ public class DispatchContext {
 
     public Message getMessage() {
         return message;
-    }
-
-    public @Nullable Message getRoutedMessage() {
-        return routedMessage;
-    }
-
-    public void setRoutedMessage(@Nullable Message routedMessage) {
-        this.routedMessage = routedMessage;
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchGateway.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchGateway.java
@@ -24,33 +24,21 @@ THE SOFTWARE.
 package org.traffichunter.titan.dispatch;
 
 import java.io.Closeable;
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.message.Message;
-import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
 /**
  * Asynchronous ingress and routing facade for fanout delivery.
  *
- * <p>The gateway has two responsibilities:</p>
- *
- * <ul>
- *     <li>{@link #publish(Message)} enqueues producer messages into the
- *     dispatcher queue keyed by {@link Destination}.</li>
- *     <li>{@link #fanout(Destination)} starts one long-lived consumer task for
- *     a destination, if it has not already been started.</li>
- * </ul>
- *
- * <p>Callers normally publish first and let the implementation ensure that the
- * matching destination consumer exists. The returned futures represent gateway
- * task submission, not necessarily remote protocol acknowledgement for every
- * subscribed client.</p>
+ * <p>The gateway is the public entry point for one message dispatch lifecycle. Dispatching starts
+ * the configured handler chain; routing and fanout remain internal handler responsibilities. The
+ * returned future represents completion of that chain, not remote protocol acknowledgement from
+ * every subscribed client.</p>
  *
  * @author yungwang-o
  */
@@ -73,7 +61,7 @@ public interface DispatchGateway extends Closeable, DispatcherQueueManager {
     }
 
     /**
-     * Configures the dispatch handler chain used by {@link #publish(Message)}.
+     * Configures the dispatch handler chain used by {@link #sparkDispatch(Message)}.
      *
      * <p>The gateway installs routing before the callback and fanout after the
      * callback. Custom handlers therefore run after the message is routed into
@@ -89,36 +77,12 @@ public interface DispatchGateway extends Closeable, DispatcherQueueManager {
     DispatchGateway chainHandler(Handler<DispatchHandlerChain> chainHandler);
 
     /**
-     * Starts consumers for the destinations if they are not already running.
-     *
-     * <p>The returned futures complete with {@code null}; the value is only a
-     * completion signal.</p>
-     */
-    List<CompletableFuture<@Nullable Void>> fanout(Collection<Destination> destinations);
-
-    /**
-     * Starts the consumer for a destination if it is not already running.
+     * Sparks one message through the configured routing and fanout handler chain.
      *
      * <p>The returned future completes with {@code null}; the value is only a
      * completion signal.</p>
      */
-    CompletableFuture<@Nullable Void> fanout(Destination destination);
-
-    /**
-     * Publishes messages into destination queues.
-     *
-     * <p>The returned futures represent dispatch-chain and consumer-start submission,
-     * not delivery acknowledgement from subscribed clients.</p>
-     */
-    List<CompletableFuture<@Nullable Void>> publish(Collection<Message> messages);
-
-    /**
-     * Publishes one message into its destination queue.
-     *
-     * <p>The returned future completes with {@code null}; the value is only a
-     * completion signal.</p>
-     */
-    CompletableFuture<@Nullable Void> publish(Message message);
+    CompletableFuture<@Nullable Void> sparkDispatch(Message message);
 
     boolean isOpen();
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchHandlerChain.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchHandlerChain.java
@@ -40,9 +40,9 @@ import org.traffichunter.titan.core.util.channel.chain.LinkedNode;
  * metrics to participate without coupling them directly to the gateway. Handler order is
  * significant because each stage observes mutations made by all preceding stages.</p>
  *
- * <p>Starting the chain schedules its first step on the configured {@link Executor}. Each handler
- * decides whether to continue by invoking its supplied {@link DispatchChain}. The future returned
- * to the caller represents every stage propagated by the handlers.</p>
+ * <p>Starting the chain schedules the complete traversal on the configured {@link Executor}.
+ * Each handler decides whether to continue by invoking its supplied {@link DispatchChain}. The
+ * future returned to the caller completes when traversal finishes or a handler throws.</p>
  *
  * <p>A no-op sentinel head is excluded from iteration. The chain only manages structure and
  * propagation; lifecycle ownership remains with the component that creates a handler. Structural
@@ -67,7 +67,7 @@ public class DispatchHandlerChain extends AbstractLinkedHandlerChain<DispatchHan
     }
 
     public DispatchHandlerChain(Executor executor) {
-        super(new Node(DispatchChainHandler.NOOP, executor));
+        super(new Node(DispatchChainHandler.NOOP));
         this.executor = executor;
     }
 
@@ -93,14 +93,14 @@ public class DispatchHandlerChain extends AbstractLinkedHandlerChain<DispatchHan
     /** Inserts a handler before every existing user handler. */
     @CanIgnoreReturnValue
     public DispatchHandlerChain addFirst(DispatchChainHandler handler) {
-        addFirst(new Node(handler, executor));
+        addFirst(new Node(handler));
         return this;
     }
 
     /** Appends a handler after every existing user handler. */
     @CanIgnoreReturnValue
     public DispatchHandlerChain addLast(DispatchChainHandler handler) {
-        addLast(new Node(handler, executor));
+        addLast(new Node(handler));
         return this;
     }
 
@@ -114,21 +114,19 @@ public class DispatchHandlerChain extends AbstractLinkedHandlerChain<DispatchHan
     }
 
     /**
-     * Enters the chain on the configured executor.
+     * Sparks dispatch propagation on the configured executor.
      */
-    public CompletableFuture<Void> dispatch(DispatchContext context) {
-        return head().next(context);
+    public CompletableFuture<Void> sparkDispatch(DispatchContext context) {
+        return CompletableFuture.runAsync(() -> head().next(context), executor);
     }
 
     static final class Node implements LinkedNode<Node>, DispatchChain {
 
         private final DispatchChainHandler handler;
-        private final Executor executor;
         private @Nullable Node next;
 
-        Node(DispatchChainHandler handler, Executor executor) {
+        Node(DispatchChainHandler handler) {
             this.handler = handler;
-            this.executor = executor;
         }
 
         @Override
@@ -142,15 +140,13 @@ public class DispatchHandlerChain extends AbstractLinkedHandlerChain<DispatchHan
         }
 
         @Override
-        public CompletableFuture<Void> next(DispatchContext context) {
+        public DispatchChain next(DispatchContext context) {
             Node chain = next;
             if (chain == null) {
-                return CompletableFuture.completedFuture(null);
+                return this;
             }
 
-            return CompletableFuture
-                    .supplyAsync(() -> chain.handler.handle(context, chain), executor)
-                    .thenCompose(future -> future);
+            return chain.handler.handle(context, chain);
         }
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/FanoutDispatchChainHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/FanoutDispatchChainHandler.java
@@ -23,34 +23,135 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.management.DispatcherQueueMbeans;
+import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
 /**
- * Starts the destination consumer after a message has been routed.
+ * Owns destination consumer registration, execution, and removal after messages are routed.
  *
- * <p>The consumer task is started but not awaited, because publish
- * acknowledgements should not wait for the long-lived consumer loop to finish.</p>
+ * <p>At most one long-lived consumer is registered per destination. The handler starts that task
+ * without awaiting its completion because dispatch completion only represents successful
+ * queue admission and consumer activation. Queue deletion and handler shutdown cancel registered
+ * consumers and let their polling loops observe the corresponding lifecycle state.</p>
  *
  * @author yun
  */
 final class FanoutDispatchChainHandler implements DispatchChainHandler {
 
-    private final Function<Destination, CompletableFuture<@Nullable Void>> fanout;
+    private static final Logger log = LoggerFactory.getLogger(FanoutDispatchChainHandler.class);
 
-    FanoutDispatchChainHandler(Function<Destination, CompletableFuture<@Nullable Void>> fanout) {
-        this.fanout = fanout;
+    private final Map<Destination, CompletableFuture<@Nullable Void>> consumers = new ConcurrentHashMap<>();
+    private final Set<DispatcherQueue> deletedQueues = ConcurrentHashMap.newKeySet();
+    private final ExecutorService executor;
+    private final DispatchExporter exporter;
+    private final Dispatcher dispatcher;
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    FanoutDispatchChainHandler(
+            ExecutorService executor,
+            DispatchExporter exporter,
+            Dispatcher dispatcher
+    ) {
+        this.executor = executor;
+        this.exporter = exporter;
+        this.dispatcher = dispatcher;
     }
 
     @Override
-    public CompletableFuture<Void> handle(DispatchContext context, DispatchChain chain) {
-        Message routed = context.getRoutedMessage();
-        if (routed != null) {
-            fanout.apply(routed.getDestination());
-        }
+    public DispatchChain handle(DispatchContext context, DispatchChain chain) {
+        Message message = context.getMessage();
+        fanout(message.getDestination());
         return chain.next(context);
+    }
+
+    CompletableFuture<@Nullable Void> fanout(Destination destination) {
+        if (closed.get()) {
+            throw new IllegalStateException("Fanout dispatch handler is closed");
+        }
+        return consumers.computeIfAbsent(destination, this::consume);
+    }
+
+    DispatcherQueueDeleteResult deleteQueue(Destination destination, boolean force) {
+        if (closed.get()) {
+            throw new IllegalStateException("Fanout dispatch handler is closed");
+        }
+
+        DispatcherQueue queue = dispatcher.get(destination);
+        if (queue == null) {
+            return DispatcherQueueDeleteResult.notFound();
+        }
+        int size = queue.size();
+        if (size > 0 && !force) {
+            return DispatcherQueueDeleteResult.notEmpty(size);
+        }
+        if (force) {
+            queue.clear();
+        }
+
+        deletedQueues.add(queue);
+        CompletableFuture<@Nullable Void> consumer = consumers.remove(destination);
+        if (consumer != null) {
+            consumer.cancel(true);
+        }
+        dispatcher.remove(destination);
+        DispatcherQueueMbeans.unregister(queue.getDestination());
+        return DispatcherQueueDeleteResult.deleted(size);
+    }
+
+    void close() {
+        if (closed.compareAndSet(false, true)) {
+            consumers.values().forEach(future -> future.cancel(true));
+            consumers.clear();
+        }
+    }
+
+    private CompletableFuture<@Nullable Void> consume(Destination destination) {
+        DispatcherQueue queue = dispatcher.getOrPut(destination);
+        log.info("Starting fanout consumer for destination={}", destination.path());
+
+        CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
+        executor.execute(() -> {
+            try {
+                while (!closed.get()
+                        && !Thread.currentThread().isInterrupted()
+                        && !deletedQueues.contains(queue)) {
+                    try {
+                        Message message = queue.dispatch(1, TimeUnit.SECONDS);
+                        if (message == null) {
+                            continue;
+                        }
+                        exporter.export(destination, message);
+                    } catch (InterruptedException e) {
+                        log.error("Interrupted while waiting for message to be delivered", e);
+                        Thread.currentThread().interrupt();
+                        break;
+                    } catch (Exception e) {
+                        log.error("Unexpected error while dispatching message", e);
+                        if (closed.get() || executor.isShutdown()) {
+                            break;
+                        }
+                    }
+                }
+                result.complete(null);
+            } catch (Exception e) {
+                result.completeExceptionally(e);
+            } finally {
+                deletedQueues.remove(queue);
+                consumers.remove(destination, result);
+            }
+        });
+        return result;
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/FlowControlDispatchChainHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/FlowControlDispatchChainHandler.java
@@ -27,8 +27,6 @@ import org.traffichunter.titan.core.resilience.flowcontrol.Damper;
 import org.traffichunter.titan.core.resilience.flowcontrol.DamperStatus;
 import org.traffichunter.titan.core.resilience.flowcontrol.FlowControlRejectException;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * @author yun
  */
@@ -41,9 +39,9 @@ public class FlowControlDispatchChainHandler implements DispatchChainHandler {
     }
 
     @Override
-    public CompletableFuture<Void> handle(DispatchContext context, DispatchChain chain) {
+    public DispatchChain handle(DispatchContext context, DispatchChain chain) {
         if (damper.regulate() == DamperStatus.CLOSED) {
-            return CompletableFuture.failedFuture(new FlowControlRejectException());
+            throw new FlowControlRejectException();
         }
 
         return chain.next(context);

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/RouteDispatchChainHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/RouteDispatchChainHandler.java
@@ -23,28 +23,38 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
-import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.traffichunter.titan.core.message.Message;
+import org.traffichunter.titan.core.util.Destination;
 
 /**
- * Routes a published message into memory before later fanout handlers run.
+ * Routes an inbound message into memory before later fanout handlers run.
  *
  * @author yun
  */
 final class RouteDispatchChainHandler implements DispatchChainHandler {
 
-    private final Function<Message, @Nullable Message> route;
+    private static final Logger log = LoggerFactory.getLogger(RouteDispatchChainHandler.class);
 
-    RouteDispatchChainHandler(Function<Message, @Nullable Message> route) {
-        this.route = route;
+    private final Dispatcher dispatcher;
+
+    RouteDispatchChainHandler(Dispatcher dispatcher) {
+        this.dispatcher = dispatcher;
     }
 
     @Override
-    public CompletableFuture<Void> handle(DispatchContext context, DispatchChain chain) {
-        Message routed = route.apply(context.getMessage());
-        context.setRoutedMessage(routed);
+    public DispatchChain handle(DispatchContext context, DispatchChain chain) {
+        Message message = context.getMessage();
+        Destination destination = message.getDestination();
+
+        DispatcherQueue dq = dispatcher.getOrPut(destination);
+
+        if (dq.enqueue(message) == null) {
+            log.warn("Dispatcher queue is full, no message was enqueued = {}", destination);
+            throw new IllegalStateException("Dispatcher queue is full = " + destination);
+        }
+
         return chain.next(context);
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompSendToFanoutHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompSendToFanoutHandler.java
@@ -66,7 +66,7 @@ public final class StompSendToFanoutHandler implements StompServerCommandHandler
         StompClientChannel connection = event.connection();
         String destination = sf.getHeader(StompHeaders.Elements.DESTINATION);
         if (destination == null || destination.isBlank()) {
-            log.warn("Rejected fanout publish due to missing destination. session={}", connection.session());
+            log.warn("Rejected dispatch due to missing destination. session={}", connection.session());
             connection.send(errorFrame("Wrong send.", "Wrong send destination id, Id is required."));
             connection.close();
             return;
@@ -80,28 +80,28 @@ public final class StompSendToFanoutHandler implements StompServerCommandHandler
                 .build();
 
         try {
-            CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);
-            publish.whenComplete((ignored, error) -> {
+            CompletableFuture<@Nullable Void> dispatchResult = dispatchGateway.sparkDispatch(message);
+            dispatchResult.whenComplete((ignored, error) -> {
                 if (error != null) {
-                    handlePublishFailure(connection, destination, unwrap(error));
+                    handleDispatchFailure(connection, destination, unwrap(error));
                     return;
                 }
 
                 context.receipt(sf, connection);
             });
         } catch (Exception e) {
-            handlePublishFailure(connection, destination, e);
+            handleDispatchFailure(connection, destination, e);
         }
     }
 
-    private static void handlePublishFailure(StompClientChannel connection, String destination, Throwable error) {
+    private static void handleDispatchFailure(StompClientChannel connection, String destination, Throwable error) {
         log.error(
-                "Failed to publish fanout message. session={}, destination={}",
+                "Failed to dispatch message. session={}, destination={}",
                 connection.session(),
                 destination,
                 error
         );
-        connection.send(errorFrame("Failed to publish.", "Failed to publish inbound SEND frame."));
+        connection.send(errorFrame("Failed to dispatch.", "Failed to dispatch inbound SEND frame."));
         connection.close();
     }
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/VertxStompSendToFanoutHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/VertxStompSendToFanoutHandler.java
@@ -62,7 +62,7 @@ public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame>
         String destination = frame.getDestination();
         if (destination == null || destination.isBlank()) {
             vertx.runOnContext(v -> {
-                log.warn("Rejected Vert.x fanout publish due to missing destination. session={}", serverConnection.session());
+                log.warn("Rejected Vert.x dispatch due to missing destination. session={}", serverConnection.session());
                 serverConnection.write(Frames.createErrorFrame(
                         "Wrong send.",
                         Headers.create(frame.getHeaders()),
@@ -82,11 +82,11 @@ public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame>
                 .build();
 
         try {
-            CompletableFuture<@Nullable Void> publish = dispatchGateway.publish(message);
-            publish.whenComplete((ignored, error) ->
+            CompletableFuture<@Nullable Void> dispatchResult = dispatchGateway.sparkDispatch(message);
+            dispatchResult.whenComplete((ignored, error) ->
                 vertx.runOnContext(v -> {
                     if (error != null) {
-                        handlePublishFailure(serverConnection, frame, destination, unwrap(error));
+                        handleDispatchFailure(serverConnection, frame, destination, unwrap(error));
                         return;
                     }
 
@@ -94,21 +94,21 @@ public final class VertxStompSendToFanoutHandler implements Handler<ServerFrame>
                 })
             );
         } catch (Exception e) {
-            vertx.runOnContext(v -> handlePublishFailure(serverConnection, frame, destination, e));
+            vertx.runOnContext(v -> handleDispatchFailure(serverConnection, frame, destination, e));
         }
     }
 
-    private static void handlePublishFailure(StompServerConnection serverConnection, Frame frame, String destination, Throwable error) {
+    private static void handleDispatchFailure(StompServerConnection serverConnection, Frame frame, String destination, Throwable error) {
         log.error(
-                "Failed to publish Vert.x fanout message. session={}, destination={}",
+                "Failed to dispatch Vert.x message. session={}, destination={}",
                 serverConnection.session(),
                 destination,
                 error
         );
         serverConnection.write(Frames.createErrorFrame(
-                "Failed to publish.",
+                "Failed to dispatch.",
                 Headers.create(frame.getHeaders()),
-                "Failed to publish inbound SEND frame."
+                "Failed to dispatch inbound SEND frame."
         ));
         serverConnection.close();
     }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/package-info.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/package-info.java
@@ -11,13 +11,13 @@
  * StompSendToFanoutHandler
  *        |
  *        v
- * DispatchGateway.publish(message)
+ * DispatchGateway.sparkDispatch(message)
  *        |
  *        v
  * DispatcherQueue per Destination
  *        |
  *        v
- * DispatchGateway consumer task
+ * FanoutDispatchChainHandler consumer task
  *        |
  *        v
  * DispatchExporter (STOMP, TCP, ...)
@@ -26,10 +26,10 @@
  * subscribed clients
  * }</pre>
  *
- * <p>{@link org.traffichunter.titan.dispatch.DispatchGateway} owns the asynchronous
- * queue consumers. {@link org.traffichunter.titan.dispatch.Dispatcher} resolves destination
- * queues, and exporter implementations own protocol-specific delivery. This keeps message
- * routing independent from the protocol used to write the payload to connected clients.</p>
+ * <p>{@link org.traffichunter.titan.dispatch.DispatchGateway} starts the dispatch chain,
+ * {@link org.traffichunter.titan.dispatch.Dispatcher} resolves destination queues, and exporter
+ * implementations own protocol-specific delivery. This keeps message routing independent from
+ * the protocol used to write the payload to connected clients.</p>
  */
 @NullMarked
 package org.traffichunter.titan.dispatch;

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchChainHandlerChainTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchChainHandlerChainTest.java
@@ -5,14 +5,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.message.Message;
 import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
 class DispatchChainHandlerChainTest {
 
@@ -29,57 +31,51 @@ class DispatchChainHandlerChainTest {
                     return chainContext.next(context);
                 });
 
-        chain.dispatch(new DispatchContext(message("/queue/chain-order"))).join();
+        chain.sparkDispatch(new DispatchContext(message("/queue/chain-order"))).join();
 
         assertThat(calls).containsExactly("first", "second");
     }
 
     @Test
-    void route_handler_sets_routed_message_before_next_handler() {
+    void route_handler_routes_message_before_next_handler() {
         Message message = message("/queue/route");
+        TrieDispatcher dispatcher = new TrieDispatcher();
         DispatchHandlerChain chain = new DispatchHandlerChain(List.of(
-                new RouteDispatchChainHandler(ignored -> message),
+                new RouteDispatchChainHandler(dispatcher),
                 (context, chainContext) -> {
-                    assertThat(context.getRoutedMessage()).isSameAs(message);
+                    DispatcherQueue queue = dispatcher.get(message.getDestination());
+                    assertThat(queue).isNotNull();
+                    assertThat(queue.contains(message)).isTrue();
+                    assertThat(context.getMessage()).isSameAs(message);
                     return chainContext.next(context);
                 }
         ));
 
-        chain.dispatch(new DispatchContext(message)).join();
+        chain.sparkDispatch(new DispatchContext(message)).join();
     }
 
     @Test
-    void dispatch_handler_ignores_unrouted_message() {
-        AtomicInteger fanoutCount = new AtomicInteger();
-        DispatchHandlerChain chain = new DispatchHandlerChain(List.of(
-                new FanoutDispatchChainHandler(ignored -> {
-                    fanoutCount.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                })
-        ));
-
-        chain.dispatch(new DispatchContext(message("/queue/no-route"))).join();
-
-        assertThat(fanoutCount).hasValue(0);
-    }
-
-    @Test
-    void dispatch_handler_uses_routed_destination() {
-        AtomicInteger fanoutCount = new AtomicInteger();
+    void dispatch_handler_fans_out_message_destination() throws Exception {
         Message message = message("/queue/fanout");
-        DispatchContext context = new DispatchContext(message);
-        context.setRoutedMessage(message);
-        DispatchHandlerChain chain = new DispatchHandlerChain(List.of(
-                new FanoutDispatchChainHandler(destination -> {
-                    assertThat(destination).isEqualTo(message.getDestination());
-                    fanoutCount.incrementAndGet();
-                    return CompletableFuture.completedFuture(null);
-                })
-        ));
+        TrieDispatcher dispatcher = new TrieDispatcher();
+        dispatcher.getOrPut(message.getDestination()).enqueue(message);
+        CountDownLatch exported = new CountDownLatch(1);
 
-        chain.dispatch(context).join();
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            FanoutDispatchChainHandler handler = new FanoutDispatchChainHandler(
+                    executor,
+                    exporter(exported, message.getDestination()),
+                    dispatcher
+            );
+            DispatchHandlerChain chain = new DispatchHandlerChain(List.of(handler));
 
-        assertThat(fanoutCount).hasValue(1);
+            try {
+                chain.sparkDispatch(new DispatchContext(message)).join();
+                assertThat(exported.await(1, TimeUnit.SECONDS)).isTrue();
+            } finally {
+                handler.close();
+            }
+        }
     }
 
     @Test
@@ -89,17 +85,33 @@ class DispatchChainHandlerChainTest {
             Thread callerThread = Thread.currentThread();
             AtomicReference<Thread> handlerThread = new AtomicReference<>();
             DispatchHandlerChain chain = new DispatchHandlerChain(executor, List.of(
-                    new RouteDispatchChainHandler(ignored -> {
+                    (context, chainContext) -> {
                         handlerThread.set(Thread.currentThread());
-                        return message;
-                    })
+                        return chainContext.next(context);
+                    }
             ));
 
-            CompletableFuture<?> future = chain.dispatch(new DispatchContext(message));
+            CompletableFuture<?> future = chain.sparkDispatch(new DispatchContext(message));
 
             future.join();
             assertThat(handlerThread.get()).isNotSameAs(callerThread);
         }
+    }
+
+    private static DispatchExporter exporter(CountDownLatch exported, Destination expected) {
+        return new DispatchExporter() {
+            @Override
+            public String name() {
+                return "test";
+            }
+
+            @Override
+            public AggregationResult export(Destination destination, Buffer payload) {
+                assertThat(destination).isEqualTo(expected);
+                exported.countDown();
+                return AggregationResult.completed(List.of(destination), 0, 0, 0);
+            }
+        };
     }
 
     private static Message message(String destination) {

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchGatewayQueueManagementTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchGatewayQueueManagementTest.java
@@ -48,7 +48,7 @@ class DispatchGatewayQueueManagementTest {
         assertThat(result.isDeleted()).isTrue();
         assertThat(dispatcher.get(destination)).isNull();
 
-        gateway.publish(message(destination)).get();
+        gateway.sparkDispatch(message(destination)).get();
 
         assertThat(dispatcher.get(destination)).isNotNull();
         assertThat(dispatcher.get(destination)).isNotSameAs(first);
@@ -57,7 +57,7 @@ class DispatchGatewayQueueManagementTest {
     }
 
     @Test
-    void publish_runs_custom_handler_between_route_and_fanout() throws Exception {
+    void spark_dispatch_runs_custom_handler_between_route_and_fanout() throws Exception {
         TrieDispatcher dispatcher = new TrieDispatcher();
         ThreadPoolExecutorDispatchGateway gateway = new ThreadPoolExecutorDispatchGateway(
                 noopExporter(),
@@ -69,7 +69,7 @@ class DispatchGatewayQueueManagementTest {
             return chainContext.next(context);
         }));
 
-        gateway.publish(message(Destination.create("/queue/publish-fanout-chain"))).get();
+        gateway.sparkDispatch(message(Destination.create("/queue/dispatch-fanout-chain"))).get();
 
         assertThat(customHandlerCalls).hasValue(1);
 

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchHandlerChainTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/DispatchHandlerChainTest.java
@@ -30,7 +30,7 @@ class DispatchHandlerChainTest {
                     return chainContext.next(context);
                 });
 
-        chain.dispatch(new DispatchContext(message("/queue/publish-order"))).join();
+        chain.sparkDispatch(new DispatchContext(message("/queue/dispatch-order"))).join();
 
         assertThat(calls).containsExactly("first", "second");
     }
@@ -48,7 +48,7 @@ class DispatchHandlerChainTest {
                     return chainContext.next(context);
                 });
 
-        chain.dispatch(new DispatchContext(message("/queue/publish-add-first"))).join();
+        chain.sparkDispatch(new DispatchContext(message("/queue/dispatch-add-first"))).join();
 
         assertThat(calls).containsExactly("first", "second");
     }
@@ -72,7 +72,7 @@ class DispatchHandlerChainTest {
                     calls.add("last");
                     return chainContext.next(context);
                 })
-                .dispatch(new DispatchContext(message("/queue/publish-add-all")))
+                .sparkDispatch(new DispatchContext(message("/queue/dispatch-add-all")))
                 .join();
 
         assertThat(calls).containsExactly("first", "middle", "last");
@@ -82,53 +82,29 @@ class DispatchHandlerChainTest {
     void chain_runs_handlers_on_supplied_executor() {
         try (var executor = Executors.newSingleThreadExecutor()) {
             Thread callerThread = Thread.currentThread();
-            CompletableFuture<Void> firstCompletion = new CompletableFuture<>();
+            AtomicInteger submissions = new AtomicInteger();
             AtomicReference<Thread> firstHandlerThread = new AtomicReference<>();
             AtomicReference<Thread> secondHandlerThread = new AtomicReference<>();
-            DispatchHandlerChain chain = DispatchHandlerChain.chain(executor)
+            DispatchHandlerChain chain = DispatchHandlerChain.chain(command -> {
+                        submissions.incrementAndGet();
+                        executor.execute(command);
+                    })
                     .add((context, chainContext) -> {
                         firstHandlerThread.set(Thread.currentThread());
-                        return firstCompletion.thenCompose(ignored -> chainContext.next(context));
+                        return chainContext.next(context);
                     })
                     .add((context, chainContext) -> {
                         secondHandlerThread.set(Thread.currentThread());
                         return chainContext.next(context);
                     });
 
-            CompletableFuture<Void> future = chain.dispatch(new DispatchContext(message("/queue/publish-executor")));
-            firstCompletion.complete(null);
+            CompletableFuture<Void> future = chain.sparkDispatch(new DispatchContext(message("/queue/dispatch-executor")));
 
             future.join();
+            assertThat(submissions).hasValue(1);
             assertThat(firstHandlerThread.get()).isNotSameAs(callerThread);
             assertThat(secondHandlerThread.get()).isSameAs(firstHandlerThread.get());
         }
-    }
-
-    @Test
-    void chain_waits_for_current_handler_before_running_next_handler() {
-        List<String> calls = new ArrayList<>();
-        CompletableFuture<Void> firstCompletion = new CompletableFuture<>();
-        DispatchHandlerChain chain = DispatchHandlerChain.chain()
-                .add((context, chainContext) -> {
-                    calls.add("first");
-                    return firstCompletion.thenCompose(ignored -> chainContext.next(context));
-                })
-                .add((context, chainContext) -> {
-                    calls.add("second");
-                    return chainContext.next(context);
-                });
-
-        CompletableFuture<Void> result = chain.dispatch(
-                new DispatchContext(message("/queue/publish-async-order"))
-        );
-
-        assertThat(calls).containsExactly("first");
-        assertThat(result).isNotDone();
-
-        firstCompletion.complete(null);
-
-        result.join();
-        assertThat(calls).containsExactly("first", "second");
     }
 
     @Test
@@ -136,14 +112,16 @@ class DispatchHandlerChainTest {
         RuntimeException failure = new RuntimeException("dispatch failed");
         AtomicInteger laterHandlerCalls = new AtomicInteger();
         DispatchHandlerChain chain = DispatchHandlerChain.chain()
-                .add((context, chainContext) -> CompletableFuture.failedFuture(failure))
+                .add((context, chainContext) -> {
+                    throw failure;
+                })
                 .add((context, chainContext) -> {
                     laterHandlerCalls.incrementAndGet();
                     return chainContext.next(context);
                 });
 
-        CompletableFuture<Void> result = chain.dispatch(
-                new DispatchContext(message("/queue/publish-failure"))
+        CompletableFuture<Void> result = chain.sparkDispatch(
+                new DispatchContext(message("/queue/dispatch-failure"))
         );
 
         assertThatThrownBy(result::join).hasCause(failure);
@@ -151,16 +129,31 @@ class DispatchHandlerChainTest {
     }
 
     @Test
+    void chain_reports_exception_thrown_by_handler() {
+        RuntimeException failure = new RuntimeException("dispatch failed");
+        DispatchHandlerChain chain = DispatchHandlerChain.chain()
+                .add((context, chainContext) -> {
+                    throw failure;
+                });
+
+        CompletableFuture<Void> result = chain.sparkDispatch(
+                new DispatchContext(message("/queue/dispatch-thrown-failure"))
+        );
+
+        assertThatThrownBy(result::join).hasCause(failure);
+    }
+
+    @Test
     void handler_can_stop_chain_without_failure() {
         AtomicInteger laterHandlerCalls = new AtomicInteger();
         DispatchHandlerChain chain = DispatchHandlerChain.chain()
-                .add((context, chainContext) -> CompletableFuture.completedFuture(null))
+                .add((context, chainContext) -> chainContext)
                 .add((context, chainContext) -> {
                     laterHandlerCalls.incrementAndGet();
                     return chainContext.next(context);
                 });
 
-        chain.dispatch(new DispatchContext(message("/queue/publish-short-circuit"))).join();
+        chain.sparkDispatch(new DispatchContext(message("/queue/dispatch-short-circuit"))).join();
 
         assertThat(laterHandlerCalls).hasValue(0);
     }


### PR DESCRIPTION
## Motivation:

The dispatch gateway owned routing, consumer registration, fanout execution, and queue cleanup while its handlers only invoked gateway callbacks. This made the chain look like a chain of responsibility without giving each handler ownership of its behavior.

## Modification:

- Make dispatch handlers return the remaining chain and schedule one traversal on the configured executor.
- Move queue admission into `RouteDispatchChainHandler`.
- Move destination consumer registration, fanout execution, deletion, and shutdown into `FanoutDispatchChainHandler`.
- Reduce `DispatchGateway` to the `sparkDispatch` entry point, chain configuration, queue management, and lifecycle facade.
- Remove direct fanout and collection overloads, and align STOMP adapters, tests, documentation, and benchmarks with the new API.

## Result:

Dispatch responsibilities now live in their corresponding handlers, while the gateway only sparks and manages the chain lifecycle.

Validated with:

- `./gradlew :dispatch:test --no-configuration-cache`
- `./gradlew :benchmark:compileJmhJava --no-configuration-cache`
- `./gradlew :smoke-test:smoke-titan:compileTestJava --no-configuration-cache`
