### PR TITLE
Prepare documentation for 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,38 +43,38 @@ repositories {
 Spring client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.4")
+implementation("org.traffichunter.titan:titan-spring-client:0.8.0")
 ```
 
 Standalone Java client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-client:0.7.4")
+implementation("org.traffichunter.titan:titan-client:0.8.0")
 ```
 
 STOMP server and low-level transport APIs:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-stomp:0.7.4")
+implementation("org.traffichunter.titan:titan-stomp:0.8.0")
 ```
 
 Fanout support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-dispatch:0.7.4")
+implementation("org.traffichunter.titan:titan-dispatch:0.8.0")
 ```
 
 Monitoring support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-monitor:0.7.4")
+implementation("org.traffichunter.titan:titan-monitor:0.8.0")
 ```
 
 Bootstrap/runtime support:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.4")
-implementation("org.traffichunter.titan:titan-core:0.7.4")
+implementation("org.traffichunter.titan:titan-bootstrap:0.8.0")
+implementation("org.traffichunter.titan:titan-core:0.8.0")
 ```
 
 The native implementation is selected by default. Use

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,4 +114,4 @@ before using Titan for reliability-sensitive workloads.
 </tr>
 </tbody></table>
 
-<sub>Documentation examples target Titan `0.7.4` and JDK 21 or newer.</sub>
+<sub>Documentation examples target Titan `0.8.0` and JDK 21 or newer.</sub>

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -13,7 +13,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-client:0.7.4")
+implementation("org.traffichunter.titan:titan-client:0.8.0")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.7.4")
-implementation("org.traffichunter.titan:titan-core:0.7.4")
-implementation("org.traffichunter.titan:titan-stomp:0.7.4")
-implementation("org.traffichunter.titan:titan-dispatch:0.7.4")
+implementation("org.traffichunter.titan:titan-bootstrap:0.8.0")
+implementation("org.traffichunter.titan:titan-core:0.8.0")
+implementation("org.traffichunter.titan:titan-stomp:0.8.0")
+implementation("org.traffichunter.titan:titan-dispatch:0.8.0")
 ```
 
 ### `titan-env.yml`

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.7.4")
+implementation("org.traffichunter.titan:titan-spring-client:0.8.0")
 ```
 
 ## Enable Titan

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -34,7 +34,7 @@ capacity or pressure.
 Prebuilt releases include `titan-cli-<version>-<os>-<arch>.tar.gz` archives.
 
 ```bash
-tar -xzf titan-cli-0.7.4-linux-amd64.tar.gz
+tar -xzf titan-cli-0.8.0-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Run a Titan server and verify it from the monitoring API.
 ## Requirements
 
 * JDK 21 or newer
-* A Titan `0.7.4` standalone server JAR from GitHub Releases
+* A Titan `0.8.0` standalone server JAR from GitHub Releases
 
 ## 1. Create the environment
 
@@ -37,7 +37,7 @@ titan:
 
 ```bash
 java -Dtitan.environment.path=./titan-env.yml \
-  -jar titan-server-0.7.4.jar
+  -jar titan-server-0.8.0.jar
 ```
 
 Titan now accepts STOMP connections on `61613` and exposes its local monitor on

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,7 +4,7 @@ Titan reads its standalone runtime configuration from `titan-env.yml`. Pass the
 path with the `titan.environment.path` system property.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.7.4.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.8.0.jar
 ```
 
 ## Server

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.traffichunter.titan:titan-stomp:0.7.4")
+    implementation("org.traffichunter.titan:titan-stomp:0.8.0")
 }
 ```
 


### PR DESCRIPTION
## Motivation:

Keep release-facing documentation synchronized before publishing Titan 0.8.0.

## Modification:

Update dependency examples, standalone commands, CLI archive names, and documentation version references from 0.7.4 to 0.8.0.

## Result:

Titan documentation now consistently references the 0.8.0 release.

Validated with:
- `./gradlew -PversionName=0.8.0 clean build --no-configuration-cache`
- `cd titan-cli && go test ./...`