### PR TITLE
Normalize WebSocket default paths

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -119,7 +119,7 @@ public class InetClient extends AbstractTransport<NetChannel> {
      * client connects.</p>
      *
      * @param subProtocol application protocol advertised by the WebSocket handshake
-     * @param path HTTP request path, beginning with {@code /}
+     * @param path HTTP request path; a leading slash is optional
      * @return a WebSocket transport backed by this client
      */
     @CanIgnoreReturnValue

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetServer.java
@@ -122,7 +122,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
     }
 
     /**
-     * Enables WebSocket upgrade handling at the default {@code /titan} path.
+     * Enables WebSocket upgrade handling at the default root path.
      *
      * <p>This setting must be applied before {@link #start()}.</p>
      */
@@ -132,7 +132,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
             throw new IllegalStateException("Cannot configure WebSocket upgrade after server start");
         }
 
-        return upgradeWebSocket("/titan");
+        return upgradeWebSocket("/");
     }
 
     /**
@@ -141,7 +141,7 @@ public class InetServer extends AbstractTransport<NetServerChannel> {
      * <p>The server still listens on its normal TCP socket. Each accepted connection must finish
      * the WebSocket handshake before the configured child channel handler is invoked.</p>
      *
-     * @param path HTTP request path accepted by the WebSocket handshaker
+     * @param path HTTP request path accepted by the WebSocket handshaker; a leading slash is optional
      * @return this server
      */
     @CanIgnoreReturnValue

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClient.java
@@ -52,16 +52,13 @@ public final class WebSocketClient {
     private final ChannelRegistry<WebSocketChannel> channels = new ChannelRegistry<>();
 
     public WebSocketClient(InetClient inetClient, Protocol subProtocol) {
-        this(inetClient, subProtocol, "/titan");
+        this(inetClient, subProtocol, WebSocketPaths.ROOT);
     }
 
     public WebSocketClient(InetClient inetClient, Protocol subProtocol, String path) {
         this.inetClient = inetClient;
         this.subProtocol = subProtocol;
-        if (path.isBlank() || !path.startsWith("/")) {
-            throw new IllegalArgumentException("WebSocket path must start with '/'");
-        }
-        this.path = path;
+        this.path = WebSocketPaths.normalize(path);
     }
 
     public void start() {

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -59,23 +59,19 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
     private static final String CONNECTION = "Connection";
     private static final String VERSION = "13";
 
-    private static final String WEBSOCKET_URI = "/titan";
     private static final String STATUS_SWITCHING_PROTOCOLS = "HTTP/1.1 101";
 
     private final String host;
     private final String path;
 
     public WebSocketClientHandshaker(String host, Protocol subProtocol) {
-        this(host, subProtocol, WEBSOCKET_URI);
+        this(host, subProtocol, WebSocketPaths.ROOT);
     }
 
     public WebSocketClientHandshaker(String host, Protocol subProtocol, String path) {
         super(subProtocol.getSubProtocol(), VERSION);
-        if (path.isBlank() || !path.startsWith("/")) {
-            throw new IllegalArgumentException("WebSocket path must start with '/'");
-        }
         this.host = host;
-        this.path = path;
+        this.path = WebSocketPaths.normalize(path);
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketPaths.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketPaths.java
@@ -1,0 +1,44 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.websocket;
+
+/**
+ * Normalizes the HTTP request path used during a WebSocket upgrade.
+ *
+ * @author yun
+ */
+final class WebSocketPaths {
+
+    static final String ROOT = "/";
+
+    private WebSocketPaths() {
+    }
+
+    static String normalize(String path) {
+        if (path.isBlank()) {
+            return ROOT;
+        }
+        return path.startsWith(ROOT) ? path : ROOT + path;
+    }
+}

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -55,20 +55,15 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
     private static final String UPGRADE_CONNECTION = "Upgrade";
     private static final String VERSION = "13";
     private static final String STOMP_SUB_PROTOCOL = "v12.stomp";
-    private static final String DEFAULT_PATH = "/titan";
-
     private final String path;
 
     public WebSocketServerHandshaker() {
-        this(DEFAULT_PATH);
+        this(WebSocketPaths.ROOT);
     }
 
     public WebSocketServerHandshaker(String path) {
         super(STOMP_SUB_PROTOCOL, VERSION);
-        if (path.isBlank() || !path.startsWith("/")) {
-            throw new IllegalArgumentException("WebSocket path must start with '/'");
-        }
-        this.path = path;
+        this.path = WebSocketPaths.normalize(path);
     }
 
     @Override

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshakerTest.java
@@ -52,7 +52,7 @@ class WebSocketServerHandshakerTest {
             new ChannelSecondaryIOEventLoop("websocket-server-handshaker-test");
     private static final String KEY = "dGhlIHNhbXBsZSBub25jZQ==";
     private static final String ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
-    private static final String REQUEST = "GET /titan HTTP/1.1\r\n"
+    private static final String REQUEST = "GET / HTTP/1.1\r\n"
             + "Host: localhost:8080\r\n"
             + "Upgrade: websocket\r\n"
             + "Connection: keep-alive, Upgrade\r\n"
@@ -75,15 +75,15 @@ class WebSocketServerHandshakerTest {
     void parse_request_extracts_websocket_upgrade_headers() {
         HttpRequest request = new WebSocketServerHandshaker().parseRequest(REQUEST);
 
-        assertThat(request.uri()).isEqualTo("/titan");
+        assertThat(request.uri()).isEqualTo("/");
         assertThat(request.header("Sec-WebSocket-Key")).isEqualTo(KEY);
         assertThat(request.header("Sec-WebSocket-Protocol")).isEqualTo("v12.stomp");
     }
 
     @Test
     void parse_request_accepts_configured_path() {
-        HttpRequest request = new WebSocketServerHandshaker("/stomp")
-                .parseRequest(REQUEST.replace("GET /titan", "GET /stomp"));
+        HttpRequest request = new WebSocketServerHandshaker("stomp")
+                .parseRequest(REQUEST.replace("GET / ", "GET /stomp "));
 
         assertThat(request.uri()).isEqualTo("/stomp");
     }
@@ -138,7 +138,7 @@ class WebSocketServerHandshakerTest {
     void upgrade_handler_completes_when_request_arrives_fragmented() {
         UpgradeHarness harness = new UpgradeHarness();
 
-        harness.read("GET /titan HTTP/1.1\r\nHost: localhost:8080\r\n");
+        harness.read("GET / HTTP/1.1\r\nHost: localhost:8080\r\n");
         assertThat(harness.promise.isDone()).isFalse();
 
         harness.read("Upgrade: websocket\r\nConnection: keep-alive, Upgrade\r\n");

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -54,6 +54,9 @@ path:
         path: "/stomp"
 ```
 
+The path is optional and defaults to `/`. A leading slash is also optional for
+an explicitly configured path.
+
 See [Configuration](../reference/configuration.md) for TLS key-store settings.
 Custom WebSocket clients must request the `v12.stomp` subprotocol.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -66,6 +66,9 @@ Native and Vert.x clients use the same STOMP behavior after the WebSocket
 upgrade. Spring clients can connect with
 `spring.titan.endpoint=ws://localhost:8080/stomp`.
 Custom WebSocket clients must negotiate the `v12.stomp` subprotocol.
+When `transport-options.path` is omitted or blank, Titan uses `/`. A configured
+path may be written as either `stomp` or `/stomp`; Titan normalizes both to
+`/stomp` before the HTTP upgrade.
 
 ## TLS
 

--- a/titan-client/src/main/java/org/traffichunter/titan/client/ClientConfiguration.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/ClientConfiguration.java
@@ -93,9 +93,16 @@ public record ClientConfiguration(
         if (connectTimeout.toMillis() > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("connectTimeout must not exceed Integer.MAX_VALUE milliseconds");
         }
-        if (webSocketPath != null && (webSocketPath.isBlank() || !webSocketPath.startsWith("/"))) {
-            throw new IllegalArgumentException("WebSocket path must start with '/'");
+        if (webSocketPath != null) {
+            webSocketPath = normalizeWebSocketPath(webSocketPath);
         }
+    }
+
+    private static String normalizeWebSocketPath(String path) {
+        if (path.isBlank()) {
+            return "/";
+        }
+        return path.startsWith("/") ? path : "/" + path;
     }
 
     /** Returns the optional CONNECT login from the session settings. */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/StompEndpoint.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/StompEndpoint.java
@@ -67,7 +67,7 @@ public record StompEndpoint(
             if (path.isBlank()) {
                 path = "/";
             } else if (!path.startsWith("/")) {
-                throw new IllegalArgumentException("WebSocket endpoint path must start with '/'");
+                path = "/" + path;
             }
         } else if (!path.isEmpty()) {
             throw new IllegalArgumentException("TCP endpoint cannot have a path");
@@ -119,7 +119,7 @@ public record StompEndpoint(
      *
      * @param host remote host
      * @param port remote port
-     * @param path HTTP upgrade path
+     * @param path HTTP upgrade path; a leading slash is optional
      * @return WebSocket endpoint
      */
     public static StompEndpoint webSocket(String host, int port, String path) {

--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
@@ -356,7 +356,7 @@ public interface TitanClient {
         /**
          * Selects WebSocket transport and records the HTTP upgrade path.
          *
-         * @param path absolute WebSocket endpoint path
+         * @param path WebSocket endpoint path; blank selects {@code /} and a leading slash is optional
          * @return this builder
          */
         @CanIgnoreReturnValue

--- a/titan-client/src/test/java/org/traffichunter/titan/client/StompEndpointTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/StompEndpointTest.java
@@ -66,6 +66,13 @@ class StompEndpointTest {
     }
 
     @Test
+    void normalize_websocket_path_without_leading_slash() {
+        StompEndpoint endpoint = StompEndpoint.webSocket("localhost", 8080, "stomp");
+
+        assertThat(endpoint.path()).isEqualTo("/stomp");
+    }
+
+    @Test
     void reject_tcp_endpoint_path() {
         assertThatThrownBy(() -> StompEndpoint.parse("tcp://localhost:61613/stomp"))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/titan-client/src/test/java/org/traffichunter/titan/client/StompWebSocketIntegrationTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/StompWebSocketIntegrationTest.java
@@ -44,14 +44,14 @@ class StompWebSocketIntegrationTest {
 
     @Test
     @Timeout(10)
-    void connect_stomp_client_over_websocket() throws Exception {
+    void connect_stomp_client_over_default_websocket_path() throws Exception {
         StompServer server = StompServer.open(
                 EventLoopGroups.group(1, 1),
                 StompServerOption.builder().build()
-        ).webSocket("/stomp");
+        ).webSocket("");
         TitanStompClientDriver client = new TitanStompClientDriver(
                 EventLoopGroups.group(1, 1),
-                ClientConfiguration.builder().webSocket("/stomp").build()
+                ClientConfiguration.builder().webSocket("").build()
         );
 
         try {
@@ -160,17 +160,4 @@ class StompWebSocketIntegrationTest {
         }
     }
 
-    @Test
-    void reject_invalid_websocket_paths() {
-        StompServer server = StompServer.open(
-                EventLoopGroups.group(1, 1),
-                StompServerOption.builder().build()
-        );
-        assertThatThrownBy(() -> server.webSocket("stomp"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("start with '/'");
-        assertThatThrownBy(() -> ClientConfiguration.builder().webSocket("").build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("start with '/'");
-    }
 }

--- a/titan-client/src/test/java/org/traffichunter/titan/client/TitanClientBuilderTest.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/TitanClientBuilderTest.java
@@ -134,9 +134,18 @@ class TitanClientBuilderTest {
     }
 
     @Test
-    void rejects_invalid_websocket_path_when_building_client() {
-        assertThatThrownBy(() -> TitanClient.builder().webSocket("stomp").build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("WebSocket path must start with '/'");
+    void normalizes_websocket_path_when_building_client() {
+        TitanClient relativePathClient = TitanClient.builder().webSocket("stomp").build();
+        TitanClient rootPathClient = TitanClient.builder().webSocket("").build();
+
+        try {
+            assertThat(((DefaultTitanClient) relativePathClient).configuration().webSocketPath())
+                    .isEqualTo("/stomp");
+            assertThat(((DefaultTitanClient) rootPathClient).configuration().webSocketPath())
+                    .isEqualTo("/");
+        } finally {
+            relativePathClient.shutdown(5, java.util.concurrent.TimeUnit.SECONDS);
+            rootPathClient.shutdown(5, java.util.concurrent.TimeUnit.SECONDS);
+        }
     }
 }

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -27,7 +27,7 @@ public final class TitanProperties {
 
     private Transport transport = Transport.TCP;
 
-    private String websocketPath = "/stomp";
+    private String websocketPath = "/";
 
     private final Ssl ssl = new Ssl();
 
@@ -228,7 +228,11 @@ public final class TitanProperties {
     }
 
     public void setWebsocketPath(String websocketPath) {
-        this.websocketPath = websocketPath;
+        if (websocketPath.isBlank()) {
+            this.websocketPath = "/";
+            return;
+        }
+        this.websocketPath = websocketPath.startsWith("/") ? websocketPath : "/" + websocketPath;
     }
 
     public Ssl getSsl() {

--- a/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
+++ b/titan-spring-client/src/test/java/org/traffichunter/titan/springframework/stomp/TitanPropertiesTest.java
@@ -19,7 +19,7 @@ class TitanPropertiesTest {
         assertEquals(TitanProperties.Client.TITAN, properties.getClient());
         assertNull(properties.getEndpoint());
         assertEquals(TitanProperties.Transport.TCP, properties.getTransport());
-        assertEquals("/stomp", properties.getWebsocketPath());
+        assertEquals("/", properties.getWebsocketPath());
         assertNull(properties.getSsl().getBundle());
         assertTrue(properties.getSsl().isVerifyHostname());
         assertEquals("127.0.0.1", properties.getHost());
@@ -48,6 +48,17 @@ class TitanPropertiesTest {
         properties.setWorker(4);
 
         assertEquals(4, properties.getWorker());
+    }
+
+    @Test
+    void normalize_websocket_path() {
+        TitanProperties properties = new TitanProperties();
+
+        properties.setWebsocketPath("stomp");
+        assertEquals("/stomp", properties.getWebsocketPath());
+
+        properties.setWebsocketPath("");
+        assertEquals("/", properties.getWebsocketPath());
     }
 
     @Test

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
@@ -81,7 +81,7 @@ public class StompServerEngineProvider implements NetworkServerEngineProvider {
         InetServerOption inetOption = buildInetOption(settings.resolvedTransportOptions());
         StompServerOption stompServerOption = buildOption(settings.resolvedProtocolOptions(), inetOption);
 
-        String path = settings.resolvedTransportOptions().getOrDefault("path", "/stomp");
+        String path = settings.resolvedTransportOptions().getOrDefault("path", "/");
         InetServer inetServer = InetServer.open(groups);
         if (settings.tls().enabled()) {
             inetServer.tls(TlsContextFactory.create(settings.tls()));

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -129,7 +129,12 @@ public class VertxStompServerEngineProvider implements NetworkServerEngineProvid
         long heartbeatX = longOption(protocolOptions, "heartbeat-x", options.getHeartbeat().getLong("x"));
         long heartbeatY = longOption(protocolOptions, "heartbeat-y", options.getHeartbeat().getLong("y"));
         List<String> supportedVersions = stringListOption(protocolOptions, options.getSupportedVersions());
-        String websocketPath = stringOption(protocolOptions, "websocket-path", options.getWebsocketPath());
+        String websocketPath = stringOption(
+                transportOptions,
+                "path",
+                stringOption(protocolOptions, "websocket-path", "/")
+        );
+        websocketPath = websocketPath.startsWith("/") ? websocketPath : "/" + websocketPath;
 
         options.setMaxHeaderLength(maxHeaderLength);
         options.setMaxHeaders(maxHeaders);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -94,7 +94,7 @@ public final class StompServer {
      * HTTP Upgrade handling during {@link #start()}, and the STOMP decoder receives bytes only
      * after the WebSocket handshake succeeds.</p>
      *
-     * @param path HTTP upgrade path, beginning with {@code /}
+     * @param path HTTP upgrade path; blank selects {@code /} and a leading slash is optional
      * @return this server
      */
     @CanIgnoreReturnValue
@@ -102,10 +102,7 @@ public final class StompServer {
         if (inetServer.isStarted()) {
             throw new IllegalStateException("Cannot change STOMP server transport after start");
         }
-        if (path.isBlank() || !path.startsWith("/")) {
-            throw new IllegalArgumentException("WebSocket path must start with '/'");
-        }
-        this.webSocketPath = path;
+        this.webSocketPath = path.isBlank() ? "/" : path.startsWith("/") ? path : "/" + path;
         return this;
     }
 


### PR DESCRIPTION
## Motivation:

WebSocket defaults were inconsistent across the native transport, STOMP server, Titan client, Vert.x adapter, and Spring configuration. Omitting a path could select `/`, `/stomp`, or `/titan`, while paths without a leading slash were rejected.

## Modification:

- Use `/` as the default WebSocket upgrade path across all supported entry points.
- Normalize blank paths to `/` and relative paths such as `stomp` to `/stomp`.
- Align native, Vert.x, endpoint, standalone server, and Spring client configuration behavior.
- Add unit and network integration coverage and document the normalization rule.

## Result:

WebSocket clients and servers can omit the path or its leading slash while producing a valid, consistent HTTP upgrade path.

Validated with:

`./gradlew build --no-configuration-cache`
