### PR TITLE
Add Docker runtime and CLI images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.gradle
+.idea
+.run
+.vscode
+**/build
+**/.gradle
+titan-cli/dist
+*.iml
+*.log
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,48 @@ jobs:
           path: |
             **/build/reports/tests/test/
             **/build/test-results/test/
+
+  container:
+    name: Build and run container
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          push: false
+          build-args: VERSION=ci
+          tags: titan:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify container startup
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --detach --name titan-ci \
+            --publish 61613:61613 \
+            --publish 7777:7777 \
+            --volume "${PWD}/docker/titan-env.yml:/etc/titan/titan-env.yml:ro" \
+            titan:ci
+
+          trap 'docker logs titan-ci; docker rm --force titan-ci' EXIT
+
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:7777/titan/monitor/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,17 @@ jobs:
 
           docker network create titan-ci
 
+          cleanup() {
+            docker logs titan-ci || true
+            docker rm --force titan-ci || true
+            docker network rm titan-ci || true
+          }
+          trap cleanup EXIT
+
           docker run --detach --name titan-ci --network titan-ci \
             --publish 61613:61613 \
             --publish 7777:7777 \
-            --volume "${PWD}/docker/titan-env.yml:/etc/titan/titan-env.yml:ro" \
             titan:ci
-
-          trap 'docker logs titan-ci; docker rm --force titan-ci; docker network rm titan-ci' EXIT
 
           for attempt in {1..30}; do
             if curl --fail --silent http://127.0.0.1:7777/titan/monitor/health; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,21 +81,36 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build CLI container image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./titan-cli
+          load: true
+          push: false
+          build-args: VERSION=ci
+          tags: titan-cli:ci
+          cache-from: type=gha,scope=titan-cli
+          cache-to: type=gha,mode=max,scope=titan-cli
+
       - name: Verify container startup
         shell: bash
         run: |
           set -euo pipefail
 
-          docker run --detach --name titan-ci \
+          docker network create titan-ci
+
+          docker run --detach --name titan-ci --network titan-ci \
             --publish 61613:61613 \
             --publish 7777:7777 \
             --volume "${PWD}/docker/titan-env.yml:/etc/titan/titan-env.yml:ro" \
             titan:ci
 
-          trap 'docker logs titan-ci; docker rm --force titan-ci' EXIT
+          trap 'docker logs titan-ci; docker rm --force titan-ci; docker network rm titan-ci' EXIT
 
           for attempt in {1..30}; do
             if curl --fail --silent http://127.0.0.1:7777/titan/monitor/health; then
+              docker run --rm --network titan-ci titan-cli:ci \
+                --addr http://titan-ci:7777 --once --no-clear --no-color
               exit 0
             fi
             sleep 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,16 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Generate CLI container metadata
+        id: cli_container_meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}-cli
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
       - name: Build and publish container image
         uses: docker/build-push-action@v7
         with:
@@ -134,6 +144,18 @@ jobs:
           labels: ${{ steps.container_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build and publish CLI container image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./titan-cli
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ github.ref_name }}
+          tags: ${{ steps.cli_container_meta.outputs.tags }}
+          labels: ${{ steps.cli_container_meta.outputs.labels }}
+          cache-from: type=gha,scope=titan-cli
+          cache-to: type=gha,mode=max,scope=titan-cli
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -16,7 +17,7 @@ jobs:
   release:
     name: Build and publish GitHub release
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -98,6 +99,41 @@ jobs:
           cp titan-cli/dist/titan-cli-"${GITHUB_REF_NAME}"-*.zip release-assets/
 
           ls -la release-assets
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate container metadata
+        id: container_meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and publish container image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: VERSION=${{ github.ref_name }}
+          tags: ${{ steps.container_meta.outputs.tags }}
+          labels: ${{ steps.container_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create GitHub release
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS builder
+
+ARG VERSION=1.0-SNAPSHOT
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew --no-daemon -PversionName="${VERSION}" :bootstrap:shadowJar \
+    && cp "bootstrap/build/libs/titan-server-${VERSION}.jar" /workspace/titan-server.jar
+
+FROM eclipse-temurin:21-jre-jammy
+
+RUN groupadd --gid 10001 titan \
+    && useradd --uid 10001 --gid titan --create-home titan
+
+WORKDIR /opt/titan
+
+COPY --from=builder --chown=titan:titan /workspace/titan-server.jar ./titan-server.jar
+
+USER titan
+
+EXPOSE 61613 7777
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["java", "-Dtitan.environment.path=/etc/titan/titan-env.yml", "-jar", "/opt/titan/titan-server.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,14 @@ RUN groupadd --gid 10001 titan \
 WORKDIR /opt/titan
 
 COPY --from=builder --chown=titan:titan /workspace/titan-server.jar ./titan-server.jar
+COPY --chown=titan:titan docker/titan-env.yml /etc/titan/titan-env.yml
 
 USER titan
 
 EXPOSE 61613 7777
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+    CMD bash -c "exec 3<>/dev/tcp/127.0.0.1/7777 && printf 'GET /titan/monitor/health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && grep -q '200 OK' <&3"
 
 STOPSIGNAL SIGTERM
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS builder
 
 ARG VERSION=1.0-SNAPSHOT
 
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -107,25 +107,39 @@ Released container images are available from GitHub Container Registry:
 
 ```bash
 docker pull ghcr.io/traffic-hunter/titan:latest
-docker run --rm \
+docker run --rm --name titan \
+  -p 61613:61613 \
+  -p 127.0.0.1:7777:7777 \
+  ghcr.io/traffic-hunter/titan:latest
+```
+
+The image includes a container-ready default configuration. Override it when
+you need custom server or monitor settings:
+
+```bash
+docker run --rm --name titan \
   -p 61613:61613 \
   -p 127.0.0.1:7777:7777 \
   -v "$PWD/titan-env.yml:/etc/titan/titan-env.yml:ro" \
   ghcr.io/traffic-hunter/titan:latest
 ```
 
-The terminal monitor is published as a separate image. Attach it to the
-server's Docker network and pass the monitor address:
-
-```bash
-docker run --rm -it --network titan_default \
-  ghcr.io/traffic-hunter/titan-cli:latest \
-  --addr http://titan:7777
-```
-
 The mounted configuration must bind Titan servers and the monitor endpoint to
 `0.0.0.0` so Docker can publish their ports. Pin a release tag instead of
 `latest` for production deployments.
+
+The terminal monitor is published as a separate image. Run both images on one
+Docker network when using the CLI without Compose:
+
+```bash
+docker network create titan
+docker run --detach --name titan --network titan \
+  -p 61613:61613 -p 127.0.0.1:7777:7777 \
+  ghcr.io/traffic-hunter/titan:latest
+docker run --rm -it --network titan \
+  ghcr.io/traffic-hunter/titan-cli:latest \
+  --addr http://titan:7777
+```
 
 ```kotlin
 repositories {

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ The Compose configuration exposes STOMP on `61613` and binds the monitor API
 to `127.0.0.1:7777`. Edit `docker/titan-env.yml` to change the server transport
 or runtime settings.
 
+Open the terminal dashboard in a second terminal:
+
+```bash
+docker compose --profile tools run --rm titan-cli
+```
+
 Continue with the [Java client](./docs/examples/client.md) or
 [Spring Boot client](./docs/examples/spring-client.md) to subscribe and send a
 message. The complete walkthrough is available in the
@@ -106,6 +112,15 @@ docker run --rm \
   -p 127.0.0.1:7777:7777 \
   -v "$PWD/titan-env.yml:/etc/titan/titan-env.yml:ro" \
   ghcr.io/traffic-hunter/titan:latest
+```
+
+The terminal monitor is published as a separate image. Attach it to the
+server's Docker network and pass the monitor address:
+
+```bash
+docker run --rm -it --network titan_default \
+  ghcr.io/traffic-hunter/titan-cli:latest \
+  --addr http://titan:7777
 ```
 
 The mounted configuration must bind Titan servers and the monitor endpoint to
@@ -170,6 +185,9 @@ tar -xzf titan-cli-0.8.0-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777 --view queues
 ./titan --addr http://localhost:7777 queue list
 ```
+
+The same CLI is available as `ghcr.io/traffic-hunter/titan-cli` for Linux
+`amd64` and `arm64` containers.
 
 See [Monitoring and CLI](./docs/operate/monitoring.md) for queue management,
 authentication, and platform-specific archives.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ curl http://localhost:7777/titan/monitor/health
 curl http://localhost:7777/titan/monitor/snapshot
 ```
 
+Alternatively, start the standalone server with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The Compose configuration exposes STOMP on `61613` and binds the monitor API
+to `127.0.0.1:7777`. Edit `docker/titan-env.yml` to change the server transport
+or runtime settings.
+
 Continue with the [Java client](./docs/examples/client.md) or
 [Spring Boot client](./docs/examples/spring-client.md) to subscribe and send a
 message. The complete walkthrough is available in the
@@ -86,6 +96,21 @@ message. The complete walkthrough is available in the
 ## Installation
 
 Titan artifacts are published to Maven Central.
+
+Released container images are available from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/traffic-hunter/titan:latest
+docker run --rm \
+  -p 61613:61613 \
+  -p 127.0.0.1:7777:7777 \
+  -v "$PWD/titan-env.yml:/etc/titan/titan-env.yml:ro" \
+  ghcr.io/traffic-hunter/titan:latest
+```
+
+The mounted configuration must bind Titan servers and the monitor endpoint to
+`0.0.0.0` so Docker can publish their ports. Pin a release tag instead of
+`latest` for production deployments.
 
 ```kotlin
 repositories {

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  titan:
+    image: titan:local
+    build:
+      context: .
+      args:
+        VERSION: local
+    ports:
+      - "61613:61613"
+      - "127.0.0.1:7777:7777"
+    volumes:
+      - ./docker/titan-env.yml:/etc/titan/titan-env.yml:ro
+    healthcheck:
+      test:
+        - CMD
+        - bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/7777 &&
+          printf 'GET /titan/monitor/health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+          grep -q '200 OK' <&3
+      interval: 10s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
+    stop_grace_period: 30s
+    restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,3 +25,20 @@ services:
       retries: 3
     stop_grace_period: 30s
     restart: unless-stopped
+
+  titan-cli:
+    image: titan-cli:local
+    build:
+      context: ./titan-cli
+      args:
+        VERSION: local
+    profiles:
+      - tools
+    depends_on:
+      titan:
+        condition: service_healthy
+    command:
+      - --addr
+      - http://titan:7777
+    stdin_open: true
+    tty: true

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,19 +10,6 @@ services:
       - "127.0.0.1:7777:7777"
     volumes:
       - ./docker/titan-env.yml:/etc/titan/titan-env.yml:ro
-    healthcheck:
-      test:
-        - CMD
-        - bash
-        - -c
-        - >-
-          exec 3<>/dev/tcp/127.0.0.1/7777 &&
-          printf 'GET /titan/monitor/health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
-          grep -q '200 OK' <&3
-      interval: 10s
-      timeout: 3s
-      start_period: 10s
-      retries: 3
     stop_grace_period: 30s
     restart: unless-stopped
 

--- a/docker/titan-env.yml
+++ b/docker/titan-env.yml
@@ -1,0 +1,14 @@
+titan:
+  monitor:
+    enabled: true
+    host: 0.0.0.0
+    port: 7777
+  servers:
+    - name: stomp-dispatch
+      protocol: stomp
+      transport: tcp
+      host: 0.0.0.0
+      port: 61613
+      protocol-options:
+        supported-versions: "1.2"
+        fanout-mode: "virtual"

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -46,6 +46,19 @@ with:
 docker compose --profile tools run --rm titan-cli
 ```
 
+For standalone containers, place the server and CLI on the same Docker network
+and address the server by its container name:
+
+```bash
+docker network create titan
+docker run --detach --name titan --network titan \
+  -p 61613:61613 -p 127.0.0.1:7777:7777 \
+  ghcr.io/traffic-hunter/titan:latest
+docker run --rm -it --network titan \
+  ghcr.io/traffic-hunter/titan-cli:latest \
+  --addr http://titan:7777
+```
+
 Select a view or produce automation-friendly output:
 
 ```bash

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -38,6 +38,14 @@ tar -xzf titan-cli-0.8.0-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 ```
 
+The CLI is also published as `ghcr.io/traffic-hunter/titan-cli`. When Titan is
+running through this repository's Compose configuration, start the dashboard
+with:
+
+```bash
+docker compose --profile tools run --rm titan-cli
+```
+
 Select a view or produce automation-friendly output:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,10 +52,20 @@ start Titan with:
 docker compose up --build
 ```
 
-To run a released image with your own configuration:
+To run a released image as a standalone container with its default
+configuration:
 
 ```bash
-docker run --rm \
+docker run --rm --name titan \
+  -p 61613:61613 \
+  -p 127.0.0.1:7777:7777 \
+  ghcr.io/traffic-hunter/titan:latest
+```
+
+Mount your own configuration when the defaults are not sufficient:
+
+```bash
+docker run --rm --name titan \
   -p 61613:61613 \
   -p 127.0.0.1:7777:7777 \
   -v "$PWD/titan-env.yml:/etc/titan/titan-env.yml:ro" \
@@ -69,6 +79,18 @@ Run the containerized terminal dashboard against the Compose server:
 
 ```bash
 docker compose --profile tools run --rm titan-cli
+```
+
+Without Compose, attach the server and CLI containers to the same network:
+
+```bash
+docker network create titan
+docker run --detach --name titan --network titan \
+  -p 61613:61613 -p 127.0.0.1:7777:7777 \
+  ghcr.io/traffic-hunter/titan:latest
+docker run --rm -it --network titan \
+  ghcr.io/traffic-hunter/titan-cli:latest \
+  --addr http://titan:7777
 ```
 
 ## 3. Verify the node

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,6 +65,12 @@ docker run --rm \
 Server and monitor bind addresses in the mounted configuration must use
 `0.0.0.0` when their ports need to be published by Docker.
 
+Run the containerized terminal dashboard against the Compose server:
+
+```bash
+docker compose --profile tools run --rm titan-cli
+```
+
 ## 3. Verify the node
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,6 +43,28 @@ java -Dtitan.environment.path=./titan-env.yml \
 Titan now accepts STOMP connections on `61613` and exposes its local monitor on
 `127.0.0.1:7777`.
 
+### Docker
+
+The repository includes a container-ready configuration. Build the image and
+start Titan with:
+
+```bash
+docker compose up --build
+```
+
+To run a released image with your own configuration:
+
+```bash
+docker run --rm \
+  -p 61613:61613 \
+  -p 127.0.0.1:7777:7777 \
+  -v "$PWD/titan-env.yml:/etc/titan/titan-env.yml:ro" \
+  ghcr.io/traffic-hunter/titan:latest
+```
+
+Server and monitor bind addresses in the mounted configuration must use
+`0.0.0.0` when their ports need to be published by Docker.
+
 ## 3. Verify the node
 
 ```bash

--- a/titan-cli/.dockerignore
+++ b/titan-cli/.dockerignore
@@ -1,0 +1,4 @@
+dist
+titan
+*.log
+.DS_Store

--- a/titan-cli/Dockerfile
+++ b/titan-cli/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION=dev
+
+WORKDIR /workspace
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY main.go ./
+COPY internal ./internal
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" \
+    go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/titan .
+
+FROM alpine:3.22
+
+RUN apk add --no-cache ca-certificates \
+    && addgroup --gid 10001 titan \
+    && adduser --uid 10001 --ingroup titan --disabled-password titan
+
+COPY --from=builder --chown=titan:titan /out/titan /usr/local/bin/titan
+
+USER titan
+
+ENTRYPOINT ["/usr/local/bin/titan"]


### PR DESCRIPTION
## Motivation:

Titan needs a reproducible container runtime for local evaluation and release distribution. Users should be able to start the standalone server without assembling the Java runtime and application JAR manually.

## Modification:

- Added a multi-stage, non-root Docker image and a Docker Compose configuration with STOMP and monitor health checks.
- Embedded a container-ready default configuration and health check so the server also starts directly with `docker run` without a bind mount.
- Added a separate multi-stage, non-root `titan-cli` image and Compose tools profile for the live terminal dashboard.
- Added Docker usage and GHCR installation instructions to the README and quickstart guide.
- Added CI coverage for building both images and querying a live Titan snapshot from the CLI container.
- Added multi-architecture GHCR publishing for the server and CLI images to the release workflow.
- Installed Git in the builder stage because the Gradle build reads repository metadata during configuration.

## Result:

Titan supports both Docker Compose and standalone `docker run` workflows. Its terminal monitor remains an independently deployable container, and release tags publish `linux/amd64` and `linux/arm64` server and CLI images to GHCR.

Validated with:

- `./gradlew --no-daemon test`
- `docker compose build`
- `docker compose up -d`
- monitor health response `{"status":"UP"}`
- STOMP port availability on `61613`
- `go test ./...`
- containerized CLI snapshot query over the Compose network
- standalone server startup without a mounted configuration
- standalone server and CLI communication over a Docker network
- graceful SIGTERM shutdown
