### PR TITLE
Prepare documentation for 0.8.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Titan requires JDK 21 or newer. Download the standalone JAR from
 [GitHub Releases](https://github.com/traffic-hunter/titan/releases), or use:
 
 ```bash
-curl -LO https://github.com/traffic-hunter/titan/releases/download/0.8.0/titan-server-0.8.0.jar
+curl -LO https://github.com/traffic-hunter/titan/releases/download/0.8.1/titan-server-0.8.1.jar
 ```
 
 ### 2. Create `titan-env.yml`
@@ -67,7 +67,7 @@ titan:
 
 ```bash
 java -Dtitan.environment.path=./titan-env.yml \
-  -jar titan-server-0.8.0.jar
+  -jar titan-server-0.8.1.jar
 ```
 
 The STOMP server now listens on `localhost:61613`. Verify the node through the
@@ -150,13 +150,13 @@ repositories {
 For a Spring Boot application:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.8.0")
+implementation("org.traffichunter.titan:titan-spring-client:0.8.1")
 ```
 
 For a standalone Java client:
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-client:0.8.0")
+implementation("org.traffichunter.titan:titan-client:0.8.1")
 ```
 
 Low-level server and extension artifacts:
@@ -169,7 +169,7 @@ Low-level server and extension artifacts:
 | `titan-bootstrap` | Standalone runtime bootstrap |
 | `titan-core` | Core transport and runtime primitives |
 
-Use the same `0.8.0` version for each artifact. The native client is selected
+Use the same `0.8.1` version for each artifact. The native client is selected
 by default; call `implementation(TitanClient.Implementation.VERTX)` on the
 client builder to select Vert.x without changing the messaging API.
 
@@ -177,7 +177,7 @@ client builder to select Vert.x without changing the messaging API.
 
 ```bash
 # Start the standalone server
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.8.0.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.8.1.jar
 
 # Check health and inspect a snapshot
 curl http://localhost:7777/titan/monitor/health
@@ -194,7 +194,7 @@ curl http://localhost:7777/titan/monitor/snapshot
 Prebuilt releases also contain the terminal monitor CLI:
 
 ```bash
-tar -xzf titan-cli-0.8.0-linux-amd64.tar.gz
+tar -xzf titan-cli-0.8.1-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 ./titan --addr http://localhost:7777 --view queues
 ./titan --addr http://localhost:7777 queue list

--- a/docs/README.md
+++ b/docs/README.md
@@ -114,4 +114,4 @@ before using Titan for reliability-sensitive workloads.
 </tr>
 </tbody></table>
 
-<sub>Documentation examples target Titan `0.8.0` and JDK 21 or newer.</sub>
+<sub>Documentation examples target Titan `0.8.1` and JDK 21 or newer.</sub>

--- a/docs/examples/client.md
+++ b/docs/examples/client.md
@@ -13,7 +13,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-client:0.8.0")
+implementation("org.traffichunter.titan:titan-client:0.8.1")
 ```
 
 ## Connect, Subscribe, Send

--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -18,10 +18,10 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-bootstrap:0.8.0")
-implementation("org.traffichunter.titan:titan-core:0.8.0")
-implementation("org.traffichunter.titan:titan-stomp:0.8.0")
-implementation("org.traffichunter.titan:titan-dispatch:0.8.0")
+implementation("org.traffichunter.titan:titan-bootstrap:0.8.1")
+implementation("org.traffichunter.titan:titan-core:0.8.1")
+implementation("org.traffichunter.titan:titan-stomp:0.8.1")
+implementation("org.traffichunter.titan:titan-dispatch:0.8.1")
 ```
 
 ### `titan-env.yml`

--- a/docs/examples/spring-client.md
+++ b/docs/examples/spring-client.md
@@ -14,7 +14,7 @@ repositories {
 ```
 
 ```kotlin
-implementation("org.traffichunter.titan:titan-spring-client:0.8.0")
+implementation("org.traffichunter.titan:titan-spring-client:0.8.1")
 ```
 
 ## Enable Titan

--- a/docs/operate/monitoring.md
+++ b/docs/operate/monitoring.md
@@ -34,7 +34,7 @@ capacity or pressure.
 Prebuilt releases include `titan-cli-<version>-<os>-<arch>.tar.gz` archives.
 
 ```bash
-tar -xzf titan-cli-0.8.0-linux-amd64.tar.gz
+tar -xzf titan-cli-0.8.1-linux-amd64.tar.gz
 ./titan --addr http://localhost:7777
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Run a Titan server and verify it from the monitoring API.
 ## Requirements
 
 * JDK 21 or newer
-* A Titan `0.8.0` standalone server JAR from GitHub Releases
+* A Titan `0.8.1` standalone server JAR from GitHub Releases
 
 ## 1. Create the environment
 
@@ -37,7 +37,7 @@ titan:
 
 ```bash
 java -Dtitan.environment.path=./titan-env.yml \
-  -jar titan-server-0.8.0.jar
+  -jar titan-server-0.8.1.jar
 ```
 
 Titan now accepts STOMP connections on `61613` and exposes its local monitor on

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -4,7 +4,7 @@ Titan reads its standalone runtime configuration from `titan-env.yml`. Pass the
 path with the `titan.environment.path` system property.
 
 ```bash
-java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.8.0.jar
+java -Dtitan.environment.path=./titan-env.yml -jar titan-server-0.8.1.jar
 ```
 
 ## Server

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.traffichunter.titan:titan-client:0.8.0")
+    implementation("org.traffichunter.titan:titan-client:0.8.1")
 }
 ```
 


### PR DESCRIPTION
## Motivation:

Keep the public installation and usage documentation aligned with the Titan 0.8.1 release.

## Modification:

Updated README and documentation examples from 0.8.0 to 0.8.1, including server artifacts, client dependencies, and CLI archives.

## Result:

Titan documentation now consistently references version 0.8.1 and satisfies the release workflow documentation check.

Validated with:

- `./gradlew --no-daemon -PversionName=0.8.1 clean build --stacktrace`
- `cd titan-cli && go test ./...`
