### PR TITLE
Deprecate Vert.x integrations

### DIFF
--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
@@ -259,7 +259,12 @@ public interface TitanClient {
     enum Implementation {
         /** Titan's native channel and event-loop implementation. */
         TITAN,
-        /** Vert.x STOMP client adapter. */
+        /**
+         * Vert.x STOMP client adapter.
+         *
+         * @deprecated use {@link #TITAN}; Vert.x compatibility is retained only for migration
+         */
+        @Deprecated(since = "0.9.0")
         VERTX
     }
 

--- a/titan-client/src/main/java/org/traffichunter/titan/client/VertxStompClientDriver.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/VertxStompClientDriver.java
@@ -60,8 +60,12 @@ import java.util.concurrent.TimeoutException;
  * <p>The no-argument-runtime constructor creates and owns a Vert.x instance. Constructors and
  * factories receiving an existing Vert.x object preserve the caller-owned runtime on close.</p>
  *
+ * @deprecated use Titan's native client through {@link TitanClient#builder()}; this driver is
+ * retained only for migration compatibility
+ *
  * @author yun
  */
+@Deprecated(since = "0.9.0")
 public final class VertxStompClientDriver implements StompClientDriver {
 
     private final ClientConfiguration configuration;

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/TitanProperties.java
@@ -267,6 +267,10 @@ public final class TitanProperties {
 
     public enum Client {
         TITAN("titan"),
+        /**
+         * @deprecated use {@link #TITAN}; Vert.x compatibility is retained only for migration
+         */
+        @Deprecated(since = "0.9.0")
         VERTX("vertx"),
         ;
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -42,8 +42,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * Provides the legacy Vert.x STOMP server transport.
+ *
+ * @deprecated use Titan's native STOMP server transport; this provider is retained only for
+ * migration compatibility
+ *
  * @author yun
  */
+@Deprecated(since = "0.9.0")
 public class VertxStompServerEngineProvider implements NetworkServerEngineProvider {
 
     private static final Logger log = LoggerFactory.getLogger(VertxStompServerEngineProvider.class);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompWebSocketServerEngineProvider.java
@@ -32,8 +32,14 @@ import org.traffichunter.titan.bootstrap.ServerSettings;
 import org.traffichunter.titan.core.spi.ManagedServer;
 
 /**
+ * Provides the legacy Vert.x WebSocket STOMP server transport.
+ *
+ * @deprecated use Titan's native WebSocket STOMP server transport; this provider is retained only
+ * for migration compatibility
+ *
  * @author yun
  */
+@Deprecated(since = "0.9.0")
 public final class VertxStompWebSocketServerEngineProvider extends VertxStompServerEngineProvider {
 
     @Override


### PR DESCRIPTION
## Motivation:

Titan's native networking implementation is now the preferred client and server runtime. Maintaining Vert.x as an equal implementation would expand the compatibility surface while the project prepares for 0.9.0.

## Modification:

- Deprecated the Vert.x client implementation selector and Spring client property.
- Deprecated the public Vert.x client driver and server engine providers since 0.9.0.
- Kept the existing Vert.x runtime behavior available for migration compatibility.

## Result:

New users receive compile-time guidance toward Titan's native implementation, while existing Vert.x configurations continue to work.

Validated with:

`./gradlew :titan-client:test :titan-stomp:test :titan-spring-client:test --no-daemon`
