### PR TITLE
Stop reusing the retained buffer after decode closes the channel

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
@@ -96,6 +96,14 @@ public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoClose
                 chain.sparkChannelRead(channel, decode);
             }
 
+            // decode(), or a handler it triggers, may close the channel (for example a
+            // DISCONNECT frame). Closing releases and clears the retained buffer through
+            // close(), leaving `pending` as a dangling reference. Stop here instead of
+            // reading its reader index or releasing it a second time.
+            if (mergeBuffer != pending) {
+                return;
+            }
+
             int afterReaderIndex = pending.byteBuf().readerIndex();
             if (afterReaderIndex == beforeReaderIndex) {
                 break;

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
@@ -81,6 +81,54 @@ class ChannelDecoderTest {
     }
 
     @Test
+    void does_not_re_release_pending_buffer_when_decode_closes_channel() {
+        Buffer input = Buffer.heap().alloc("DISCONNECT");
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        CollectingChain chain = new CollectingChain();
+
+        ChannelDecoder decoder = new ChannelDecoder() {
+            @Override
+            protected Buffer decode(@NonNull NetChannel ch, @NonNull Buffer buffer) {
+                buffer.skipBytes(buffer.length());
+                ch.close();
+                return null;
+            }
+        };
+        channel.chain().add(decoder);
+
+        assertThatCode(() -> decoder.sparkChannelRead(channel, input, chain))
+                .doesNotThrowAnyException();
+
+        assertThat(input.byteBuf().refCnt()).isZero();
+        assertThat(chain.frames).isEmpty();
+    }
+
+    @Test
+    void forwards_final_frame_and_releases_once_when_decode_closes_channel() {
+        Buffer input = Buffer.heap().alloc("DISCONNECT");
+        Buffer decoded = Buffer.heap().alloc("frame");
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        CollectingChain chain = new CollectingChain();
+
+        ChannelDecoder decoder = new ChannelDecoder() {
+            @Override
+            protected Buffer decode(@NonNull NetChannel ch, @NonNull Buffer buffer) {
+                buffer.skipBytes(buffer.length());
+                ch.close();
+                return decoded;
+            }
+        };
+        channel.chain().add(decoder);
+
+        assertThatCode(() -> decoder.sparkChannelRead(channel, input, chain))
+                .doesNotThrowAnyException();
+
+        assertThat(input.byteBuf().refCnt()).isZero();
+        assertThat(chain.frames).containsExactly(decoded);
+        decoded.release();
+    }
+
+    @Test
     void schedule_decoder_cleanup_on_channel_event_loop() {
         AtomicReference<Runnable> cleanup = new AtomicReference<>();
         IOEventLoop eventLoop = mock(IOEventLoop.class);


### PR DESCRIPTION
## Motivation:

`ChannelDecoder.relayingDecode` keeps a local `pending` reference to `mergeBuffer` while it drains frames. When a decoded frame causes the channel to close inside `decode()` — the normal path for a STOMP `DISCONNECT` — the close runs synchronously on the event-loop thread:

```
decode() → handler.handle(DISCONNECT) → channel.close()
        → chain.close() → ChannelDecoder.close() → mergeBuffer.release(); mergeBuffer = null
```

Control then returns to the `relayingDecode` loop, which still holds the now-released buffer in `pending`. It reads `pending.byteBuf().readerIndex()` and, once the buffer is fully consumed, calls `pending.release()` a second time:

```java
if (!pending.isReadable()) {
    pending.release();      // buffer already released by close()
    mergeBuffer = null;
}
```

`InternalBuffer.release()` detects `refCnt() == 0` and throws, which surfaces as an `ERROR` on every clean disconnect:

```
ERROR ChannelHandlerChain - Failed to process read
java.lang.IllegalStateException: Buffer has been released!
    at InternalBuffer.release(InternalBuffer.java:68)
    at ChannelDecoder.relayingDecode(ChannelDecoder.java:106)
    at ChannelDecoder.sparkChannelRead(ChannelDecoder.java:76)
    ...
```

The client still receives its `RECEIPT` and the connection closes correctly, so there is no functional regression — but every graceful `DISCONNECT` logs a full error stack trace. Under load this pollutes operational logs and adds avoidable stack-trace construction on the hot path. It also reads through a released pooled buffer, which is undefined behavior once that buffer is recycled.

Reproduction (STOMP over TCP, `fanout-mode: virtual`): 20/20 clean `DISCONNECT` frames each produced one `Failed to process read` error in the server log.

## Modification:

In `relayingDecode`, after each `decode()` call, check whether the decoder still owns the same retained buffer. `decode()` (or a handler it triggers) may have closed the channel, which releases and clears `mergeBuffer` via `close()`. When `mergeBuffer` is no longer the `pending` reference, the loop returns instead of reading the reader index or releasing the buffer again. `close()` has already performed the release, so the buffer is freed exactly once.

The final decoded frame is still forwarded to the chain before the check, preserving existing delivery behavior.

## Result:

Fixes the `Buffer has been released!` error logged on every graceful `DISCONNECT`.

Added two tests to `ChannelDecoderTest` covering a `decode()` that closes the channel — one returning `null`, one returning a final frame. Both fail before the change (`IllegalStateException`) and pass after. The final-frame case asserts the frame is still delivered downstream and the retained buffer is released exactly once.

Validation:

```bash
./gradlew :core:test --tests "*ChannelDecoderTest"
./gradlew test
```
