### PR TITLE
Close the channel when a socket read fails

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -313,6 +313,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
                 return read;
             } catch (IOException e) {
                 log.warn("Failed to read from socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
+                close();
                 return -1;
             }
         }


### PR DESCRIPTION
## Motivation:

`NewIONetChannel.NewIOInternal.read(...)` closes the channel on EOF (`read < 0`) but not when the socket read throws. A connection reset makes `SocketChannel.read` throw `IOException`, which is only logged before returning `-1`:

```java
try {
    int read = channel().read(dst);
    if (read > 0) {
        byteBuf.writerIndex(byteBuf.writerIndex() + read);
    } else if (read < 0) {
        close();                 // EOF handled
    }
    return read;
} catch (IOException e) {         // connection reset, etc.
    log.warn("Failed to read from socket...", e);
    return -1;                    // channel is left open and still registered
}
```

Because the channel is not closed, its socket stays registered for `OP_READ` and the selector keeps reporting it readable. The secondary event loop then repeats `select → read → IOException → log → return -1` without end. One event-loop thread is pinned at ~100% CPU and the log grows without bound. Since a channel is bound to a single event-loop thread for its lifetime, every other connection on that thread stops being serviced.

Observed on 0.8.1 (JDK 21, native TCP transport): a reset connection pinned a `SecondaryEventLoopThread` at ~100% CPU, with a thread dump stuck in `NewIONetChannel$NewIOInternal.read` and the log growing by millions of lines per second.

## Modification:

Close the channel on the read failure path, matching the existing `read < 0` branch. Closing unregisters the socket from the selector and tears down the handler chain, so the loop stops.

```java
} catch (IOException e) {
    log.warn("Failed to read from socket. channelId={}, remoteAddress={}", id(), remoteAddress(), e);
    close();
    return -1;
}
```

## Result:

After the change, reset connections leave CPU at 0% and produce exactly one log line per connection. Normal SEND / SUBSCRIBE / DISCONNECT traffic is unaffected.

Validation:

```bash
./gradlew test
```
