### PR TITLE
fix: prevent duplicate frame emission on non-consuming decode

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
+++ b/core/src/main/java/org/traffichunter/titan/core/codec/ChannelDecoder.java
@@ -91,9 +91,9 @@ public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoClose
         while (pending.isReadable()) {
             int beforeReaderIndex = pending.byteBuf().readerIndex();
 
-            Buffer decode = decode(channel, pending);
-            if (decode != null) {
-                chain.sparkChannelRead(channel, decode);
+            Buffer frame = decode(channel, pending);
+            if (frame != null) {
+                chain.sparkChannelRead(channel, frame);
             }
 
             // decode(), or a handler it triggers, may close the channel (for example a
@@ -106,6 +106,14 @@ public abstract class ChannelDecoder implements ChannelInBoundHandler, AutoClose
 
             int afterReaderIndex = pending.byteBuf().readerIndex();
             if (afterReaderIndex == beforeReaderIndex) {
+                // No bytes were consumed this iteration. When a frame was still produced the
+                // decoder violated its contract: the same bytes would be decoded again on the
+                // next read, emitting duplicate frames forever. Fail fast instead of looping.
+                if (frame != null) {
+                    throw new ChannelDecoderException(
+                            getClass().getSimpleName()
+                                    + ".decode() produced a frame without consuming any bytes");
+                }
                 break;
             }
         }

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/codec/ChannelDecoderTest.java
@@ -8,6 +8,7 @@ import org.traffichunter.titan.core.channel.InMemoryNetChannel;
 import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
+import org.traffichunter.titan.core.codec.ChannelDecoderException;
 import org.traffichunter.titan.core.util.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
@@ -125,6 +126,31 @@ class ChannelDecoderTest {
 
         assertThat(input.byteBuf().refCnt()).isZero();
         assertThat(chain.frames).containsExactly(decoded);
+        decoded.release();
+    }
+
+    @Test
+    void throws_when_decode_produces_frame_without_consuming_bytes() {
+        Buffer input = Buffer.heap().alloc("frame");
+        Buffer decoded = Buffer.heap().alloc("frame");
+        InMemoryNetChannel channel = new InMemoryNetChannel();
+        CollectingChain chain = new CollectingChain();
+
+        ChannelDecoder decoder = new ChannelDecoder() {
+            @Override
+            protected Buffer decode(@NonNull NetChannel ch, @NonNull Buffer buffer) {
+                // Returns a frame but never advances the reader index: a contract violation
+                // that would otherwise re-emit the same frame on every subsequent read.
+                return decoded;
+            }
+        };
+        channel.chain().add(decoder);
+
+        assertThatThrownBy(() -> decoder.sparkChannelRead(channel, input, chain))
+                .isInstanceOf(ChannelDecoderException.class)
+                .hasMessageContaining("without consuming any bytes");
+
+        input.release();
         decoded.release();
     }
 


### PR DESCRIPTION
## Motivation:

`ChannelDecoder.relayingDecode()` stops its decode loop with a no-progress check (`afterReaderIndex == beforeReaderIndex`). This correctly handles the "need more bytes" case where `decode()` returns `null` without advancing the reader index.

But when a `decode()` implementation returns a **non-null frame without consuming any bytes** (a contract violation), the loop just `break`s. The retained bytes stay unconsumed, so on the next read the same bytes are decoded again from the same position, emitting the **same frame repeatedly** — silently, with no error. The failure then surfaces far from the faulty decoder, making it hard to diagnose.

## Modification:

Distinguish the two no-progress cases in the loop:

- frame produced + no bytes consumed -> throw `ChannelDecoderException` (decoder contract violation)
- no frame + no bytes consumed -> `break` (normal, more bytes required)

This mirrors Netty's `ByteToMessageDecoder.callDecode`, which throws `DecoderException` in the same situation ("did not read anything but decoded a message"). A local variable was also renamed (`decode` -> `frame`) to stop shadowing the `decode()` method name.

Added `ChannelDecoderTest#throws_when_decode_produces_frame_without_consuming_bytes` covering the new behavior. All existing `ChannelDecoderTest` cases still pass.

## Result:

Fixes #126.
