### PR TITLE
Bound incomplete STOMP frame accumulation

### DIFF
--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -38,7 +38,7 @@ titan:
         child-tcp-no-delay: "true"
       protocol-options:
         supported-versions: "1.2"
-        max-body-length: "1048576"
+        max-frame-length: "1048576"
         heartbeat-x: "1000"
         heartbeat-y: "1000"
         fanout-mode: "virtual"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ titan:
         child-tcp-no-delay: "true"
       protocol-options:
         supported-versions: "1.2"
-        max-body-length: "1048576"
+        max-frame-length: "1048576"
         heartbeat-x: "1000"
         heartbeat-y: "1000"
         fanout-mode: "virtual"

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,7 +35,7 @@ format.
 | Key | Purpose | Example |
 | --- | --- | --- |
 | `supported-versions` | Accepted STOMP versions | `"1.2"` |
-| `max-body-length` | Maximum frame body size in bytes | `"1048576"` |
+| `max-frame-length` | Maximum STOMP frame size in bytes | `"1048576"` |
 | `heartbeat-x` | Outgoing heartbeat interval in milliseconds | `"1000"` |
 | `heartbeat-y` | Expected incoming heartbeat interval in milliseconds | `"1000"` |
 | `fanout-mode` | Optional fanout implementation | `"virtual"` |

--- a/titan-client/src/test/java/org/traffichunter/titan/client/StompTestServer.java
+++ b/titan-client/src/test/java/org/traffichunter/titan/client/StompTestServer.java
@@ -91,7 +91,7 @@ public final class StompTestServer implements AutoCloseable {
                 .childReuseAddress(true)
                 .build();
         StompServerOption serverOption = StompServerOption.builder()
-                .maxBodyLength(configuration.maxFrameLength())
+                .maxFrameLength(configuration.maxFrameLength())
                 .inetServerOption(inetOption)
                 .build();
         StompServer startedServer = StompServer.open(groups, serverOption);

--- a/titan-env.yml
+++ b/titan-env.yml
@@ -23,9 +23,7 @@ titan:
         child-receive-buffer-size: "65536"
         child-reuse-address: "true"
       protocol-options:
-        max-header-length: "10240"
-        max-headers: "1000"
-        max-body-length: "1048576"
+        max-frame-length: "1048576"
         max-frame-in-transaction: "1000"
         supported-versions: "1.2"
         send-error-on-no-subscriptions: "false"

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -31,6 +31,7 @@ import org.traffichunter.titan.core.channel.stomp.StompHandler;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
 import org.traffichunter.titan.core.codec.LineFrameChannelDecoder;
+import org.traffichunter.titan.core.codec.TooLongFrameException;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import java.util.LinkedList;
@@ -59,8 +60,11 @@ public class StompChannelDecoder extends ChannelDecoder {
         this(DEFAULT_MAX_LENGTH, stompChannel, handler);
     }
 
-    public StompChannelDecoder(int maxLength, StompClientChannel stompChannel, StompHandler handler) {
-        this.stompParser = new StompParser(maxLength);
+    public StompChannelDecoder(int maxFrameLength, StompClientChannel stompChannel, StompHandler handler) {
+        if (maxFrameLength <= 0) {
+            throw new IllegalArgumentException("STOMP decoder limit must be greater than zero");
+        }
+        this.stompParser = new StompParser(maxFrameLength);
         this.stompChannel = stompChannel;
         this.handler = handler;
     }
@@ -81,13 +85,14 @@ public class StompChannelDecoder extends ChannelDecoder {
 
         private static final String NULL = StompDelimiter.NUL.getString();
         private static final String COLON = StompDelimiter.COLON.getString();
-
         private static final String CONTENT_LENGTH = "content-length";
 
         private final LineFrameChannelDecoderWrapper lineFrameDecoder;
+        private final int maxFrameLength;
 
-        private StompParser(int maxLength) {
-            this.lineFrameDecoder = new LineFrameChannelDecoderWrapper(maxLength);
+        private StompParser(int maxFrameLength) {
+            this.lineFrameDecoder = new LineFrameChannelDecoderWrapper(maxFrameLength);
+            this.maxFrameLength = maxFrameLength;
         }
 
         private @Nullable StompFrame parse(NetChannel channel, Buffer buffer) {
@@ -102,20 +107,15 @@ public class StompChannelDecoder extends ChannelDecoder {
                 return StompFrame.PING;
             }
 
-            final int eol = findEol(buffer);
-            if(eol == -1) {
+            int frameEnd = findFrameEnd(buffer);
+            if (frameEnd == -1) {
+                validateFrameLength(buffer.length());
                 return null;
             }
 
-            readerIndex = buffer.byteBuf().readerIndex();
-            int length = eol - readerIndex;
-            if (length < 0) {
-                return null;
-            }
-
+            int length = frameEnd - readerIndex;
+            validateFrameLength(length);
             Buffer sliceBuffer = buffer.readSlice(length);
-
-            // Skip stomp last delimiter (null)
             buffer.skipBytes(1);
 
             Buffer stompFrame = Buffer.heap().alloc(sliceBuffer.length() + 1);
@@ -162,19 +162,18 @@ public class StompChannelDecoder extends ChannelDecoder {
             }
         }
 
-        private int findEol(Buffer buffer) {
-            final int totalLength = buffer.length();
-            final int readIdx = buffer.byteBuf().readerIndex();
-
-            int idx = buffer.indexOf(readIdx, readIdx + totalLength, NULL.charAt(0));
-            if(idx >= 0) {
-                if(idx > 0 && buffer.getByte(idx - 1) == (byte) NULL.charAt(0)) {
-                    return idx - 1;
-                }
-                return idx;
+        private void validateFrameLength(int frameLength) {
+            if (frameLength > maxFrameLength) {
+                throw new TooLongFrameException(
+                        "STOMP frame exceeds " + maxFrameLength + ": " + frameLength
+                );
             }
+        }
 
-            return idx;
+        private int findFrameEnd(Buffer buffer) {
+            int totalLength = buffer.length();
+            int readIdx = buffer.byteBuf().readerIndex();
+            return buffer.indexOf(readIdx, readIdx + totalLength, NULL.charAt(0));
         }
     }
 

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/StompServerEngineProvider.java
@@ -114,9 +114,7 @@ public class StompServerEngineProvider implements NetworkServerEngineProvider {
 
     private static StompServerOption buildOption(final Map<String, String> options, final InetServerOption inetOption) {
         return StompServerOption.builder()
-                .maxHeaderLength(intOption(options, "max-header-length"))
-                .maxHeaders(intOption(options, "max-headers"))
-                .maxBodyLength(intOption(options, "max-body-length"))
+                .maxFrameLength(intOption(options, "max-frame-length"))
                 .maxFrameInTransaction(intOption(options, "max-frame-in-transaction"))
                 .supportedVersions(stringOption(options, "supported-versions"))
                 .heartbeatX(longOption(options, "heartbeat-x"))

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/spi/vertx/VertxStompServerEngineProvider.java
@@ -100,9 +100,7 @@ public class VertxStompServerEngineProvider implements NetworkServerEngineProvid
     protected static StompServerOptions buildOption(Map<String, String> protocolOptions, Map<String, String> transportOptions) {
         StompServerOptions options = new StompServerOptions();
 
-        int maxHeaderLength = intOption(protocolOptions, "max-header-length", options.getMaxHeaderLength());
-        int maxHeaders = intOption(protocolOptions, "max-headers", options.getMaxHeaders());
-        int maxBodyLength = intOption(protocolOptions, "max-body-length", options.getMaxBodyLength());
+        int maxFrameLength = intOption(protocolOptions, "max-frame-length", options.getMaxBodyLength());
         int maxFrameInTransaction = intOption(
                 protocolOptions,
                 "max-frame-in-transaction",
@@ -142,9 +140,7 @@ public class VertxStompServerEngineProvider implements NetworkServerEngineProvid
         );
         websocketPath = websocketPath.startsWith("/") ? websocketPath : "/" + websocketPath;
 
-        options.setMaxHeaderLength(maxHeaderLength);
-        options.setMaxHeaders(maxHeaders);
-        options.setMaxBodyLength(maxBodyLength);
+        options.setMaxBodyLength(maxFrameLength);
         options.setMaxFrameInTransaction(maxFrameInTransaction);
         options.setSupportedVersions(supportedVersions);
         options.setTimeFactor(timeFactor);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/StompServer.java
@@ -168,8 +168,8 @@ public final class StompServer {
                     }
                     serverConnection.register(stompConnection);
 
-                    netChannel.chain()
-                            .add(new StompChannelDecoder(option.maxBodyLength(), stompConnection, stompServerHandler));
+                    netChannel.chain().add(new StompChannelDecoder(
+                            option.maxFrameLength(), stompConnection, stompServerHandler));
 
                     channelHandler.handle(stompConnection.channel());
                 });
@@ -261,7 +261,7 @@ public final class StompServer {
                 .autoComputeContentLength(childOption.autoComputeContentLength())
                 .heartbeatX(option.heartbeatX())
                 .heartbeatY(option.heartbeatY())
-                .maxFrameLength(option.maxBodyLength())
+                .maxFrameLength(option.maxFrameLength())
                 .build();
     }
 }

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOption.java
@@ -27,9 +27,7 @@ import org.traffichunter.titan.core.codec.stomp.StompVersion;
 import org.traffichunter.titan.core.transport.option.InetServerOption;
 
 public record StompServerOption(
-        int maxHeaderLength,
-        int maxHeaders,
-        int maxBodyLength,
+        int maxFrameLength,
         int maxFrameInTransaction,
         String supportedVersions,
         boolean secured,
@@ -44,9 +42,7 @@ public record StompServerOption(
         InetServerOption inetServerOption
 ) {
 
-    public static final int DEFAULT_MAX_HEADER_LENGTH = 1024 * 10;
-    public static final int DEFAULT_MAX_HEADERS = 1000;
-    public static final int DEFAULT_MAX_BODY_LENGTH = 1024 * 1024 * 100;
+    public static final int DEFAULT_MAX_FRAME_LENGTH = 1024 * 1024;
     public static final int DEFAULT_MAX_FRAME_IN_TRANSACTION = 1000;
     public static final int DEFAULT_TRANSACTION_CHUNK_SIZE = 1000;
     public static final int DEFAULT_MAX_SUBSCRIPTIONS_BY_CLIENT = 1000;
@@ -54,8 +50,8 @@ public record StompServerOption(
     public static final String SUPPORTED_VERSION = "1.2";
 
     public StompServerOption {
-        if (maxHeaderLength <= 0 || maxHeaders <= 0 || maxBodyLength <= 0) {
-            throw new IllegalArgumentException("Frame/header limits must be greater than zero");
+        if (maxFrameLength <= 0) {
+            throw new IllegalArgumentException("maxFrameLength must be greater than zero");
         }
         if (maxFrameInTransaction <= 0 || transactionChunkSize <= 0 || maxSubscriptionsByClient <= 0) {
             throw new IllegalArgumentException("Transaction/subscription limits must be greater than zero");
@@ -72,9 +68,7 @@ public record StompServerOption(
     }
 
     public static StompServerOption of(
-            Integer maxHeaderLength,
-            Integer maxHeaders,
-            Integer maxBodyLength,
+            Integer maxFrameLength,
             Integer maxFrameInTransaction,
             String supportedVersions,
             Boolean secured,
@@ -88,9 +82,7 @@ public record StompServerOption(
             InetServerOption inetServerOption
     ) {
         return new StompServerOption(
-                maxHeaderLength == null ? DEFAULT_MAX_HEADER_LENGTH : maxHeaderLength,
-                maxHeaders == null ? DEFAULT_MAX_HEADERS : maxHeaders,
-                maxBodyLength == null ? DEFAULT_MAX_BODY_LENGTH : maxBodyLength,
+                maxFrameLength == null ? DEFAULT_MAX_FRAME_LENGTH : maxFrameLength,
                 maxFrameInTransaction == null ? DEFAULT_MAX_FRAME_IN_TRANSACTION : maxFrameInTransaction,
                 supportedVersions == null ? SUPPORTED_VERSION : supportedVersions,
                 secured != null && secured,
@@ -112,9 +104,7 @@ public record StompServerOption(
 
     public static final class StompServerOptionBuilder {
 
-        private Integer maxHeaderLength;
-        private Integer maxHeaders;
-        private Integer maxBodyLength;
+        private Integer maxFrameLength;
         private Integer maxFrameInTransaction;
         private String supportedVersions;
         private Boolean secured;
@@ -130,18 +120,8 @@ public record StompServerOption(
         private StompServerOptionBuilder() {
         }
 
-        public StompServerOptionBuilder maxHeaderLength(Integer value) {
-            this.maxHeaderLength = value;
-            return this;
-        }
-
-        public StompServerOptionBuilder maxHeaders(Integer value) {
-            this.maxHeaders = value;
-            return this;
-        }
-
-        public StompServerOptionBuilder maxBodyLength(Integer value) {
-            this.maxBodyLength = value;
+        public StompServerOptionBuilder maxFrameLength(Integer value) {
+            this.maxFrameLength = value;
             return this;
         }
 
@@ -202,9 +182,7 @@ public record StompServerOption(
 
         public StompServerOption build() {
             return StompServerOption.of(
-                    maxHeaderLength,
-                    maxHeaders,
-                    maxBodyLength,
+                    maxFrameLength,
                     maxFrameInTransaction,
                     supportedVersions,
                     secured,

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -3,12 +3,14 @@ package org.traffichunter.titan.core.codec.stomp;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.InMemoryNetChannel;
 import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.StompHandler;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
+import org.traffichunter.titan.core.codec.TooLongFrameException;
 import org.traffichunter.titan.core.util.concurrent.ChannelPromise;
 import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
 import org.traffichunter.titan.core.util.IdGenerator;
@@ -18,6 +20,7 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.DisplayNameGenerator.*;
@@ -174,6 +177,166 @@ class StompChannelDecoderTest {
         }
     }
 
+    @Test
+    @Timeout(5)
+    void reject_oversized_frame_without_nul_before_handling_frame() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        Buffer input = Buffer.direct().alloc("SEND\ndestination:/queue/a\n\n" + "A".repeat(65));
+
+        // Issue #125: no CONNECT or NUL is needed to reach the accumulation path.
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64,
+                (frame, connection) -> handled.add(frame))) {
+            assertThatThrownBy(() -> decoder.sparkChannelRead(new InMemoryNetChannel(), input, chain))
+                    .isInstanceOf(TooLongFrameException.class);
+            assertThat(handled).isEmpty();
+            assertThat(chain.frames).isEmpty();
+        } finally {
+            chain.releaseAll();
+        }
+        assertThat(input.byteBuf().refCnt()).isZero();
+    }
+
+    @Test
+    @Timeout(5)
+    void reject_oversized_frame_accumulated_across_reads_without_nul() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        NetChannel channel = new InMemoryNetChannel();
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64,
+                (frame, connection) -> handled.add(frame))) {
+            decoder.sparkChannelRead(channel,
+                    Buffer.direct().alloc("SEND\ndestination:/queue/a\n\n"), chain);
+
+            // Bound the reproduction instead of exhausting the JVM heap.
+            assertThatThrownBy(() -> {
+                for (int i = 0; i < 8; i++) {
+                    decoder.sparkChannelRead(channel, Buffer.direct().alloc("A".repeat(16)), chain);
+                }
+            }).isInstanceOf(TooLongFrameException.class);
+            assertThat(handled).isEmpty();
+            assertThat(chain.frames).isEmpty();
+        } finally {
+            chain.releaseAll();
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void reject_oversized_completed_frame() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        Buffer input = Buffer.direct().alloc("SEND\n\n" + "A".repeat(59) + "\0");
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64,
+                (frame, connection) -> handled.add(frame))) {
+            assertThatThrownBy(() -> decoder.sparkChannelRead(new InMemoryNetChannel(), input, chain))
+                    .isInstanceOf(TooLongFrameException.class)
+                    .hasMessageContaining("STOMP frame exceeds 64: 65");
+            assertThat(handled).isEmpty();
+            assertThat(chain.frames).isEmpty();
+        } finally {
+            chain.releaseAll();
+        }
+        assertThat(input.byteBuf().refCnt()).isZero();
+    }
+
+    @Test
+    @Timeout(5)
+    void enforce_frame_limit_by_encoded_byte_length() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        String payload = "한".repeat(20);
+        Buffer input = Buffer.direct().alloc("SEND\n\n" + payload);
+
+        assertThat(payload.length()).isLessThan(64);
+        assertThat(input.length()).isGreaterThan(64);
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64,
+                (frame, connection) -> handled.add(frame))) {
+            assertThatThrownBy(() -> decoder.sparkChannelRead(new InMemoryNetChannel(), input, chain))
+                    .isInstanceOf(TooLongFrameException.class);
+            assertThat(handled).isEmpty();
+            assertThat(chain.frames).isEmpty();
+        } finally {
+            chain.releaseAll();
+        }
+        assertThat(input.byteBuf().refCnt()).isZero();
+    }
+
+    @Test
+    @Timeout(5)
+    void decode_fragmented_frame_at_limit_only_after_nul_arrives() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        NetChannel channel = new InMemoryNetChannel();
+        String head = "SEND\ndestination:/queue/a\ncontent-length:64\n\n";
+        String body = "A".repeat(64);
+        int maxFrameLength = head.length() + body.length();
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(maxFrameLength,
+                (frame, connection) -> handled.add(frame))) {
+            decoder.sparkChannelRead(channel, Buffer.direct().alloc(head), chain);
+            for (int i = 0; i < 4; i++) {
+                decoder.sparkChannelRead(channel, Buffer.direct().alloc("A".repeat(16)), chain);
+                assertThat(handled).isEmpty();
+                assertThat(chain.frames).isEmpty();
+            }
+
+            decoder.sparkChannelRead(channel, Buffer.direct().alloc(new byte[]{0}), chain);
+
+            assertThat(handled).singleElement().satisfies(frame -> {
+                assertThat(frame.command()).isEqualTo(StompCommand.SEND);
+                assertThat(frame.body()).isEqualTo(body.getBytes(StandardCharsets.US_ASCII));
+            });
+            assertThat(chain.frames).hasSize(1);
+        } finally {
+            chain.releaseAll();
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void decode_multiple_valid_frames_when_combined_read_exceeds_limit() {
+        List<StompFrame> handled = new ArrayList<>();
+        CollectingChain chain = new CollectingChain();
+        String frameText = "SEND\ndestination:/queue/a\ncontent-length:16\n\n" + "A".repeat(16) + "\0";
+        Buffer input = Buffer.direct().alloc(frameText.repeat(8));
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64,
+                (frame, connection) -> handled.add(frame))) {
+            assertThat(input.length()).isGreaterThan(64);
+            decoder.sparkChannelRead(new InMemoryNetChannel(), input, chain);
+
+            assertThat(handled).hasSize(8).allSatisfy(frame -> {
+                assertThat(frame.command()).isEqualTo(StompCommand.SEND);
+                assertThat(frame.body()).isEqualTo("A".repeat(16).getBytes(StandardCharsets.US_ASCII));
+            });
+            assertThat(chain.frames).hasSize(8);
+            assertThat(input.byteBuf().refCnt()).isZero();
+        } finally {
+            chain.releaseAll();
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    void release_incomplete_frame_when_decoder_closes() {
+        CollectingChain chain = new CollectingChain();
+        Buffer input = Buffer.direct().alloc("SEND\ndestination:/queue/a\n\npartial");
+
+        try (TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, (frame, connection) -> {})) {
+            decoder.sparkChannelRead(new InMemoryNetChannel(), input, chain);
+            assertThat(chain.frames).isEmpty();
+            assertThat(input.byteBuf().refCnt()).isOne();
+        } finally {
+            chain.releaseAll();
+        }
+
+        assertThat(input.byteBuf().refCnt()).isZero();
+    }
+
     // ── refCnt leak regression tests ──────────────────────────────────────────
 
     @Test
@@ -207,7 +370,7 @@ class StompChannelDecoderTest {
         // Leak 3 regression: stompFrame and frames list inside StompParser.parse()
         // must be released even when ERR_STOMP_FRAME is returned early.
         StompHeaders headers = StompHeaders.create();
-        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "999");
+        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "10");
         StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
 

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOptionTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/transport/stomp/option/StompServerOptionTest.java
@@ -1,0 +1,58 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.transport.stomp.option;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author yun
+ */
+class StompServerOptionTest {
+
+    @Test
+    void use_one_megabyte_as_default_max_frame_length() {
+        StompServerOption option = StompServerOption.builder().build();
+
+        assertThat(option.maxFrameLength()).isEqualTo(1024 * 1024);
+    }
+
+    @Test
+    void configure_max_frame_length() {
+        StompServerOption option = StompServerOption.builder()
+                .maxFrameLength(4096)
+                .build();
+
+        assertThat(option.maxFrameLength()).isEqualTo(4096);
+    }
+
+    @Test
+    void reject_non_positive_max_frame_length() {
+        assertThatThrownBy(() -> StompServerOption.builder().maxFrameLength(0).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxFrameLength");
+    }
+}


### PR DESCRIPTION
## Motivation:

STOMP decoding retained inbound bytes without a bound until a NUL delimiter arrived. A client could therefore bypass the configured frame limit and continuously grow the retained buffer before authentication completed.

## Modification:

- Enforce a byte-based limit on both incomplete and completed STOMP frames.
- Replace the separate header and body limits with a single `max-frame-length` option.
- Use a conservative 1 MiB default and apply the setting to native and Vert.x server engines.
- Add regression coverage for fragmented input, completed oversized frames, exact boundaries, multiple frames per read, UTF-8 byte length, and option validation.
- Update server configuration examples and reference documentation.

## Result:

Fixes #125.

Incomplete STOMP frames can no longer grow without bound, while valid fragmented and batched frames remain supported.

Validation:

- `./gradlew :titan-stomp:test :titan-client:test`
