### PR TITLE
Control and monitor slow consumers

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/AggregateChannelWriteBufferMetrics.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AggregateChannelWriteBufferMetrics.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.core.channel;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.traffichunter.titan.core.util.management.ChannelWriteBufferMbean;
+import org.traffichunter.titan.core.util.management.ChannelWriteBufferMbeans;
 
 /**
  * Aggregates write buffer state without retaining channel references.
@@ -34,9 +35,15 @@ import org.traffichunter.titan.core.util.management.ChannelWriteBufferMbean;
  */
 final class AggregateChannelWriteBufferMetrics implements ChannelWriteBufferMbean {
 
+    private static final AggregateChannelWriteBufferMetrics PROCESS_WIDE = createProcessWide();
+
     private final AtomicInteger activeBuffers = new AtomicInteger();
     private final AtomicLong pendingBytes = new AtomicLong();
     private final AtomicInteger nonWritableBuffers = new AtomicInteger();
+
+    static AggregateChannelWriteBufferMetrics processWide() {
+        return PROCESS_WIDE;
+    }
 
     void open(long initialPendingBytes, boolean writable) {
         activeBuffers.incrementAndGet();
@@ -83,5 +90,11 @@ final class AggregateChannelWriteBufferMetrics implements ChannelWriteBufferMbea
     @Override
     public int getNonWritableBuffers() {
         return nonWritableBuffers.get();
+    }
+
+    private static AggregateChannelWriteBufferMetrics createProcessWide() {
+        AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
+        ChannelWriteBufferMbeans.register("process", metrics);
+        return metrics;
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoopGroup.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelSecondaryIOEventLoopGroup.java
@@ -23,17 +23,13 @@
  */
 package org.traffichunter.titan.core.channel;
 
-import javax.management.ObjectName;
-import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.concurrent.Promise;
 import org.traffichunter.titan.core.util.concurrent.ScheduledPromise;
-import org.traffichunter.titan.core.util.management.ChannelWriteBufferMbeans;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Event-loop group for connection read/write processing.
@@ -45,13 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopGroup<ChannelSecondaryIOEventLoop> {
 
-    private static final AtomicInteger GROUP_SEQUENCE = new AtomicInteger();
-
     private final RoundRobinSelector<ChannelSecondaryIOEventLoop> selector;
     private final List<ChannelSecondaryIOEventLoop> group;
-    private final String metricsGroup;
-    private final AggregateChannelWriteBufferMetrics writeBufferMetrics;
-    private @Nullable ObjectName writeBufferMetricsName;
 
     public ChannelSecondaryIOEventLoopGroup() {
         this(Runtime.getRuntime().availableProcessors() * 2);
@@ -59,8 +50,6 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
 
     public ChannelSecondaryIOEventLoopGroup(final int size) {
         List<ChannelSecondaryIOEventLoop> eventLoops = new ArrayList<>(size);
-        this.metricsGroup = "secondary-" + GROUP_SEQUENCE.incrementAndGet();
-        this.writeBufferMetrics = new AggregateChannelWriteBufferMetrics();
 
         try {
             for (int i = 0; i < size; i++) {
@@ -81,21 +70,12 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
 
     @Override
     public void start() {
-        writeBufferMetricsName = ChannelWriteBufferMbeans.register(metricsGroup, writeBufferMetrics);
-        try {
-            group.forEach(ChannelSecondaryIOEventLoop::start);
-        } catch (RuntimeException e) {
-            unregisterWriteBufferMetrics();
-            throw e;
-        }
+        group.forEach(ChannelSecondaryIOEventLoop::start);
     }
 
     @Override
     public void register(Channel channel) {
         ChannelSecondaryIOEventLoop eventLoop = selector.next(group);
-        if (channel instanceof NewIONetChannel netChannel) {
-            netChannel.attachWriteBufferMetrics(writeBufferMetrics);
-        }
         eventLoop.register(channel);
     }
 
@@ -142,7 +122,6 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
     @Override
     public void gracefullyShutdown(long timeout, TimeUnit unit) {
         group.forEach(eventLoop -> eventLoop.gracefullyShutdown(timeout, unit));
-        unregisterWriteBufferMetrics();
     }
 
     @Override
@@ -153,7 +132,6 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
     @Override
     public void close() {
         group.forEach(IOEventLoop::close);
-        unregisterWriteBufferMetrics();
     }
 
     @Override
@@ -181,11 +159,4 @@ public final class ChannelSecondaryIOEventLoopGroup implements ChannelEventLoopG
         return group.stream().allMatch(EventLoop::isTerminated);
     }
 
-    private void unregisterWriteBufferMetrics() {
-        ObjectName name = writeBufferMetricsName;
-        if (name != null) {
-            ChannelWriteBufferMbeans.unregister(name);
-            writeBufferMetricsName = null;
-        }
-    }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
@@ -78,6 +78,10 @@ public final class ChannelWriteBuffer {
         this.lowWatermarkBytes = lowWatermarkBytes;
     }
 
+    ChannelWriteBuffer(AggregateChannelWriteBufferMetrics metrics) {
+        this(DEFAULT_MAX_PENDING_BYTES, DEFAULT_HIGH_WATERMARK, DEFAULT_LOW_WATERMARK, metrics);
+    }
+
     ChannelWriteBuffer(
             int maxPendingBytes,
             int highWatermarkBytes,

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelWriteBuffer.java
@@ -23,7 +23,6 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.core.channel;
 
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.util.Assert;
 import org.traffichunter.titan.core.util.buffer.Buffer;
@@ -32,67 +31,71 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 
 /**
+ * Buffers outbound data that could not be written to a channel immediately, up to the configured
+ * maximum pending bytes.
+ *
+ * <p>Tracks pending bytes and controls channel writability through high and low watermarks.</p>
+ *
  * @author yun
  */
 public final class ChannelWriteBuffer {
 
-    /**
-     * default upperPoint and lowerPoint
-     */
     private static final int DEFAULT_HIGH_WATERMARK = 64 * 1024;
     private static final int DEFAULT_LOW_WATERMARK = 32 * 1024;
+    private static final int DEFAULT_MAX_PENDING_BYTES = DEFAULT_HIGH_WATERMARK * 2;
 
     private final Queue<Buffer> writeBuffer;
     private @Nullable AggregateChannelWriteBufferMetrics metrics;
 
     private int pendingBytes;
 
-    private final int highWatermark;
-    private final int lowWatermark;
+    private final int maxPendingBytes;
+    private final int highWatermarkBytes;
+    private final int lowWatermarkBytes;
 
-    private boolean isWritable = true;
+    private volatile boolean isWritable = true;
     private boolean isClosed;
 
     public ChannelWriteBuffer() {
-        this(DEFAULT_HIGH_WATERMARK, DEFAULT_LOW_WATERMARK);
+        this(DEFAULT_MAX_PENDING_BYTES, DEFAULT_HIGH_WATERMARK, DEFAULT_LOW_WATERMARK);
     }
 
-    public ChannelWriteBuffer(int highWatermark, int lowWatermark) {
-        Assert.checkArgument(highWatermark > lowWatermark, "highWatermark must be greater than lowerPoint");
-        Assert.checkArgument(highWatermark > 0, "highWatermark must be greater than 0");
-        Assert.checkArgument(lowWatermark > 0, "lowWatermark must be greater than 0");
+    public ChannelWriteBuffer(int highWatermarkBytes, int lowWatermarkBytes) {
+        this(defaultMaxPendingBytes(highWatermarkBytes), highWatermarkBytes, lowWatermarkBytes);
+    }
+
+    public ChannelWriteBuffer(int maxPendingBytes, int highWatermarkBytes, int lowWatermarkBytes) {
+        Assert.checkArgument(highWatermarkBytes > lowWatermarkBytes, "highWatermark must be greater than lowerPoint");
+        Assert.checkArgument(highWatermarkBytes > 0, "highWatermark must be greater than 0");
+        Assert.checkArgument(lowWatermarkBytes > 0, "lowWatermark must be greater than 0");
+        Assert.checkArgument(maxPendingBytes > 0, "maxPendingBytes must be greater than 0");
+        Assert.checkArgument(maxPendingBytes >= highWatermarkBytes,
+                "maxPendingBytes must be greater than or equal to highWatermark");
 
         this.writeBuffer = new ArrayDeque<>();
-        this.highWatermark = highWatermark;
-        this.lowWatermark = lowWatermark;
+        this.maxPendingBytes = maxPendingBytes;
+        this.highWatermarkBytes = highWatermarkBytes;
+        this.lowWatermarkBytes = lowWatermarkBytes;
     }
 
     ChannelWriteBuffer(
-            int highWatermark,
-            int lowWatermark,
+            int maxPendingBytes,
+            int highWatermarkBytes,
+            int lowWatermarkBytes,
             AggregateChannelWriteBufferMetrics metrics
     ) {
-        this(highWatermark, lowWatermark);
+        this(maxPendingBytes, highWatermarkBytes, lowWatermarkBytes);
         attachMetrics(metrics);
     }
 
-    void attachMetrics(AggregateChannelWriteBufferMetrics metrics) {
+    /**
+     * Appends an outbound buffer and takes ownership of it.
+     *
+     * @param buffer outbound buffer
+     */
+    public void append(Buffer buffer) {
         if (isClosed) {
-            throw new ChannelException("Cannot attach metrics to a closed channel write buffer");
-        }
-        if (this.metrics == metrics) {
-            return;
-        }
-        if (this.metrics != null) {
-            throw new ChannelException("Channel write buffer metrics are already attached");
-        }
-
-        this.metrics = metrics;
-        metrics.open(pendingBytes, isWritable);
-    }
-
-    public void add(Buffer buffer) {
-        if (isClosed) {
+            buffer.release();
             throw new ChannelException("Channel write buffer is closed");
         }
         if(!buffer.hasRemaining()) {
@@ -100,52 +103,85 @@ public final class ChannelWriteBuffer {
             return;
         }
 
+        int contentLength = buffer.length();
+        if (contentLength > maxPendingBytes - pendingBytes) {
+            buffer.release();
+            throw new ChannelException("Channel write buffer is full");
+        }
+
+        pendingBytes += contentLength;
         writeBuffer.add(buffer);
 
-        pendingBytes += buffer.length();
         AggregateChannelWriteBufferMetrics currentMetrics = metrics;
         if (currentMetrics != null) {
             currentMetrics.addPendingBytes(buffer.length());
         }
-        if(isWritable && pendingBytes > highWatermark) {
+        if(isWritable && pendingBytes > highWatermarkBytes) {
             isWritable = false;
             if (currentMetrics != null) {
                 currentMetrics.becameNonWritable();
             }
         }
-
     }
 
     public boolean isEmpty() {
         return writeBuffer.isEmpty();
     }
 
+    /**
+     * Returns the current buffer as a borrowed reference for socket I/O.
+     *
+     * <p>Call {@link #consume(int)} to advance it; callers must not release or advance it
+     * themselves.</p>
+     *
+     * @return the first pending buffer, or {@code null} when the queue is empty
+     */
     public @Nullable Buffer current() {
         return writeBuffer.peek();
     }
 
-    @CanIgnoreReturnValue
-    public @Nullable Buffer poll() {
-        if(writeBuffer.isEmpty()) {
-            return null;
+    /**
+     * Consumes bytes successfully written from the current buffer.
+     *
+     * <p>Advances its reader index, updates pending-byte metrics and writability, and releases
+     * the buffer once fully consumed. The count must not exceed the current buffer's readable
+     * bytes. Zero leaves the queue unchanged. Call only from the owning channel event loop.</p>
+     *
+     * @param bytes number of bytes written to the socket
+     * @throws IllegalArgumentException if the count is negative or exceeds the current buffer
+     * @throws ChannelException if the write buffer is closed
+     */
+    public void consume(int bytes) {
+        if (isClosed) {
+            throw new ChannelException("Channel write buffer is closed");
         }
+        Assert.checkArgument(bytes >= 0, "bytes must not be negative");
+        if (bytes == 0) {
+            return;
+        }
+        Buffer buffer = current();
+        if (buffer == null) {
+            throw new IllegalArgumentException("bytes must not exceed current buffer readable bytes");
+        }
+        Assert.checkArgument(bytes <= buffer.length(), "bytes must not exceed current buffer readable bytes");
 
-        Buffer buffer = writeBuffer.poll();
-
-        int remainingBytes = buffer.length();
-        pendingBytes -= remainingBytes;
+        buffer.skipBytes(bytes);
+        pendingBytes -= bytes;
         AggregateChannelWriteBufferMetrics currentMetrics = metrics;
         if (currentMetrics != null) {
-            currentMetrics.removePendingBytes(remainingBytes);
+            currentMetrics.removePendingBytes(bytes);
         }
-        if(!isWritable && pendingBytes < lowWatermark) {
+        if(!isWritable && pendingBytes < lowWatermarkBytes) {
             isWritable = true;
             if (currentMetrics != null) {
                 currentMetrics.becameWritable();
             }
         }
 
-        return buffer;
+        if (!buffer.isReadable()) {
+            writeBuffer.remove();
+            buffer.release();
+        }
     }
 
     public boolean isWritable() {
@@ -157,27 +193,15 @@ public final class ChannelWriteBuffer {
     }
 
     public int highWatermark() {
-        return highWatermark;
+        return highWatermarkBytes;
+    }
+
+    public int maxPendingBytes() {
+        return maxPendingBytes;
     }
 
     public int lowWatermark() {
-        return lowWatermark;
-    }
-
-    void progress(int bytes) {
-        Assert.checkArgument(bytes >= 0, "bytes must not be negative");
-        Assert.checkArgument(bytes <= pendingBytes, "bytes must not exceed pending bytes");
-        pendingBytes -= bytes;
-        AggregateChannelWriteBufferMetrics currentMetrics = metrics;
-        if (currentMetrics != null) {
-            currentMetrics.removePendingBytes(bytes);
-        }
-        if (!isWritable && pendingBytes < lowWatermark) {
-            isWritable = true;
-            if (currentMetrics != null) {
-                currentMetrics.becameWritable();
-            }
-        }
+        return lowWatermarkBytes;
     }
 
     public void close() {
@@ -199,5 +223,27 @@ public final class ChannelWriteBuffer {
             metrics = null;
         }
         isWritable = false;
+    }
+
+    void attachMetrics(AggregateChannelWriteBufferMetrics metrics) {
+        if (isClosed) {
+            throw new ChannelException("Cannot attach metrics to a closed channel write buffer");
+        }
+        if (this.metrics == metrics) {
+            return;
+        }
+        if (this.metrics != null) {
+            throw new ChannelException("Channel write buffer metrics are already attached");
+        }
+
+        this.metrics = metrics;
+        metrics.open(pendingBytes, isWritable);
+    }
+
+    private static int defaultMaxPendingBytes(int highWatermarkBytes) {
+        if (highWatermarkBytes >= Integer.MAX_VALUE / 2) {
+            return Integer.MAX_VALUE;
+        }
+        return highWatermarkBytes * 2;
     }
 }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/InMemoryNetChannel.java
@@ -215,6 +215,11 @@ public final class InMemoryNetChannel implements NetChannel {
         return connected;
     }
 
+    @Override
+    public boolean isWritable() {
+        return !closed;
+    }
+
     public void enqueueInbound(Buffer buffer) {
         inbound.add(buffer.retain());
     }

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -84,6 +84,8 @@ public interface NetChannel extends Channel {
 
     boolean isConnected();
 
+    boolean isWritable();
+
     /**
      * Raw transport operations that bypass the inbound and outbound channel pipelines.
      *

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -185,6 +185,11 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
     }
 
     @Override
+    public boolean isWritable() {
+        return channelWriteBuffer.isWritable();
+    }
+
+    @Override
     public void close() {
         if (isRegistered()) {
             IOEventLoop owner = eventLoop();
@@ -324,7 +329,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
                 throw new ChannelException("Already channel is closed");
             }
 
-            channelWriteBuffer.add(buffer);
+            channelWriteBuffer.append(buffer);
         }
 
         @Override
@@ -363,15 +368,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
                     break;
                 }
 
-                byteBuf.readerIndex(byteBuf.readerIndex() + written);
-                channelWriteBuffer.progress(written);
-
-                if(!byteBuf.isReadable()) {
-                    Buffer consumed = channelWriteBuffer.poll();
-                    if (consumed != null) {
-                        consumed.release();
-                    }
-                }
+                channelWriteBuffer.consume(written);
             }
 
             if(channelWriteBuffer.isEmpty()) {

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NewIONetChannel.java
@@ -65,11 +65,7 @@ public class NewIONetChannel extends AbstractChannel implements NetChannel {
 
     NewIONetChannel(SocketChannel channel, ChannelHandShakeEventListener initializer) {
         super(channel, initializer);
-        this.channelWriteBuffer = new ChannelWriteBuffer();
-    }
-
-    void attachWriteBufferMetrics(AggregateChannelWriteBufferMetrics metrics) {
-        channelWriteBuffer.attachMetrics(metrics);
+        this.channelWriteBuffer = new ChannelWriteBuffer(AggregateChannelWriteBufferMetrics.processWide());
     }
 
     @Override

--- a/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/websocket/WebSocketChannel.java
@@ -138,6 +138,11 @@ public final class WebSocketChannel implements NetChannel {
     }
 
     @Override
+    public boolean isWritable() {
+        return delegate.isWritable();
+    }
+
+    @Override
     public ChannelHandlerChain chain() {
         return delegate.chain();
     }

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelWriteBufferTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelWriteBufferTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author yun
@@ -34,9 +35,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ChannelWriteBufferTest {
 
     @Test
+    void reject_buffer_that_exceeds_maximum_pending_bytes() {
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(10, 8, 4);
+        Buffer accepted = Buffer.direct().alloc(new byte[8]);
+        Buffer rejected = Buffer.direct().alloc(new byte[3]);
+        try {
+            writeBuffer.append(accepted);
+
+            assertThatThrownBy(() -> writeBuffer.append(rejected))
+                    .isInstanceOf(ChannelException.class)
+                    .hasMessage("Channel write buffer is full");
+
+            assertThat(writeBuffer.maxPendingBytes()).isEqualTo(10);
+            assertThat(writeBuffer.pendingBytes()).isEqualTo(8);
+            assertThat(writeBuffer.current()).isSameAs(accepted);
+            assertThat(accepted.byteBuf().refCnt()).isOne();
+            assertThat(rejected.byteBuf().refCnt()).isZero();
+        } finally {
+            writeBuffer.close();
+        }
+    }
+
+    @Test
     void attach_existing_buffer_state_to_event_loop_group_metrics() {
         ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(8, 4);
-        writeBuffer.add(Buffer.heap().alloc(new byte[9]));
+        writeBuffer.append(Buffer.heap().alloc(new byte[9]));
 
         AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
         writeBuffer.attachMetrics(metrics);
@@ -51,12 +74,12 @@ class ChannelWriteBufferTest {
     @Test
     void expose_pending_bytes_and_watermark_state() {
         AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
-        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(8, 4, metrics);
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(Integer.MAX_VALUE, 8, 4, metrics);
         Buffer first = Buffer.heap().alloc(new byte[5]);
         Buffer second = Buffer.heap().alloc(new byte[4]);
 
-        writeBuffer.add(first);
-        writeBuffer.add(second);
+        writeBuffer.append(first);
+        writeBuffer.append(second);
 
         assertThat(writeBuffer.pendingBytes()).isEqualTo(9);
         assertThat(writeBuffer.highWatermark()).isEqualTo(8);
@@ -72,30 +95,34 @@ class ChannelWriteBufferTest {
     @Test
     void reduce_pending_bytes_as_socket_write_progresses() {
         AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
-        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(8, 4, metrics);
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(Integer.MAX_VALUE, 8, 4, metrics);
         Buffer payload = Buffer.heap().alloc(new byte[9]);
-        writeBuffer.add(payload);
+        writeBuffer.append(payload);
 
-        payload.skipBytes(6);
-        writeBuffer.progress(6);
+        writeBuffer.consume(6);
 
+        assertThat(payload.length()).isEqualTo(3);
+        assertThat(payload.byteBuf().readerIndex()).isEqualTo(6);
+        assertThat(writeBuffer.current()).isSameAs(payload);
         assertThat(writeBuffer.pendingBytes()).isEqualTo(3);
         assertThat(writeBuffer.isWritable()).isTrue();
         assertThat(metrics.getPendingBytes()).isEqualTo(3);
         assertThat(metrics.getNonWritableBuffers()).isZero();
 
-        Buffer remaining = writeBuffer.poll();
-        assertThat(remaining).isSameAs(payload);
+        writeBuffer.consume(3);
+        assertThat(writeBuffer.current()).isNull();
+        assertThat(writeBuffer.isEmpty()).isTrue();
         assertThat(writeBuffer.pendingBytes()).isZero();
-        remaining.release();
+        assertThat(metrics.getPendingBytes()).isZero();
+        assertThat(payload.byteBuf().refCnt()).isZero();
         writeBuffer.close();
     }
 
     @Test
     void close_releases_remaining_metrics_once() {
         AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
-        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(8, 4, metrics);
-        writeBuffer.add(Buffer.heap().alloc(new byte[9]));
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(Integer.MAX_VALUE, 8, 4, metrics);
+        writeBuffer.append(Buffer.heap().alloc(new byte[9]));
 
         writeBuffer.close();
         writeBuffer.close();
@@ -103,5 +130,76 @@ class ChannelWriteBufferTest {
         assertThat(metrics.getActiveBuffers()).isZero();
         assertThat(metrics.getPendingBytes()).isZero();
         assertThat(metrics.getNonWritableBuffers()).isZero();
+    }
+
+    @Test
+    void consume_releases_only_the_completed_buffer() {
+        AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(Integer.MAX_VALUE, 8, 4, metrics);
+        Buffer first = Buffer.direct().alloc(new byte[5]);
+        Buffer second = Buffer.direct().alloc(new byte[4]);
+        try {
+            writeBuffer.append(first);
+            writeBuffer.append(second);
+
+            writeBuffer.consume(5);
+
+            assertThat(first.byteBuf().refCnt()).isZero();
+            assertThat(writeBuffer.current()).isSameAs(second);
+            assertThat(second.length()).isEqualTo(4);
+            assertThat(second.byteBuf().refCnt()).isOne();
+            assertThat(writeBuffer.pendingBytes()).isEqualTo(4);
+            assertThat(metrics.getPendingBytes()).isEqualTo(4);
+            assertThat(writeBuffer.isWritable()).isFalse();
+
+            writeBuffer.consume(1);
+            assertThat(writeBuffer.pendingBytes()).isEqualTo(3);
+            assertThat(writeBuffer.isWritable()).isTrue();
+            assertThat(metrics.getNonWritableBuffers()).isZero();
+        } finally {
+            writeBuffer.close();
+        }
+        assertThat(second.byteBuf().refCnt()).isZero();
+        assertThat(metrics.getPendingBytes()).isZero();
+    }
+
+    @Test
+    void invalid_consume_does_not_change_buffers_or_metrics() {
+        AggregateChannelWriteBufferMetrics metrics = new AggregateChannelWriteBufferMetrics();
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer(Integer.MAX_VALUE, 8, 4, metrics);
+        Buffer first = Buffer.direct().alloc(new byte[5]);
+        Buffer second = Buffer.direct().alloc(new byte[4]);
+        try {
+            writeBuffer.append(first);
+            writeBuffer.append(second);
+
+            assertThatThrownBy(() -> writeBuffer.consume(-1)).isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> writeBuffer.consume(6)).isInstanceOf(IllegalArgumentException.class);
+            writeBuffer.consume(0);
+
+            assertThat(writeBuffer.current()).isSameAs(first);
+            assertThat(first.length()).isEqualTo(5);
+            assertThat(first.byteBuf().refCnt()).isOne();
+            assertThat(second.length()).isEqualTo(4);
+            assertThat(writeBuffer.pendingBytes()).isEqualTo(9);
+            assertThat(metrics.getPendingBytes()).isEqualTo(9);
+            assertThat(metrics.getNonWritableBuffers()).isOne();
+        } finally {
+            writeBuffer.close();
+        }
+    }
+
+    @Test
+    void consume_handles_empty_and_closed_buffers() {
+        ChannelWriteBuffer writeBuffer = new ChannelWriteBuffer();
+        try {
+            writeBuffer.consume(0);
+            assertThatThrownBy(() -> writeBuffer.consume(1)).isInstanceOf(IllegalArgumentException.class);
+            assertThat(writeBuffer.pendingBytes()).isZero();
+            assertThat(writeBuffer.isEmpty()).isTrue();
+        } finally {
+            writeBuffer.close();
+        }
+        assertThatThrownBy(() -> writeBuffer.consume(0)).isInstanceOf(ChannelException.class);
     }
 }

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetrics.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetrics.java
@@ -1,0 +1,57 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.dispatch;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * Process-wide counter for messages skipped because a consumer cannot accept more writes.
+ *
+ * @author yun
+ */
+public final class SlowConsumerMetrics implements SlowConsumerMetricsMbean {
+
+    private static final SlowConsumerMetrics GLOBAL = createGlobal();
+
+    private final LongAdder skippedMessages = new LongAdder();
+
+    public static SlowConsumerMetrics global() {
+        return GLOBAL;
+    }
+
+    public void recordSkippedMessage() {
+        skippedMessages.increment();
+    }
+
+    @Override
+    public long getSkippedMessages() {
+        return skippedMessages.sum();
+    }
+
+    private static SlowConsumerMetrics createGlobal() {
+        SlowConsumerMetrics metrics = new SlowConsumerMetrics();
+        SlowConsumerMetricsMbeans.register(metrics);
+        return metrics;
+    }
+}

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetricsMbean.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetricsMbean.java
@@ -1,0 +1,34 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.dispatch;
+
+/**
+ * Management view of messages skipped to isolate non-writable consumers.
+ *
+ * @author yun
+ */
+public interface SlowConsumerMetricsMbean {
+
+    long getSkippedMessages();
+}

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetricsMbeans.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/SlowConsumerMetricsMbeans.java
@@ -1,0 +1,62 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.dispatch;
+
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+
+/**
+ * Registers process-wide slow-consumer metrics with JMX.
+ *
+ * @author yun
+ */
+public final class SlowConsumerMetricsMbeans {
+
+    public static final String OBJECT_NAME = "org.traffichunter.titan:type=SlowConsumer";
+
+    private SlowConsumerMetricsMbeans() {
+    }
+
+    public static ObjectName objectName() {
+        try {
+            return new ObjectName(OBJECT_NAME);
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid slow consumer MBean name", e);
+        }
+    }
+
+    static void register(SlowConsumerMetricsMbean metrics) {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        ObjectName name = objectName();
+        try {
+            if (!server.isRegistered(name)) {
+                server.registerMBean(new StandardMBean(metrics, SlowConsumerMetricsMbean.class), name);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to register slow consumer MBean", e);
+        }
+    }
+}

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/StompDispatchExporter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/StompDispatchExporter.java
@@ -23,6 +23,7 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.dispatch.exporter;
 
+import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
 import org.traffichunter.titan.core.codec.stomp.StompCommand;
 import org.traffichunter.titan.core.codec.stomp.StompFrame;
 import org.traffichunter.titan.core.codec.stomp.StompHeaders;
@@ -73,12 +74,18 @@ public class StompDispatchExporter implements DispatchExporter {
         );
 
         subscriptions.forEach(subscription -> {
+            StompClientChannel clientChannel = subscription.getConnection();
+            if (!clientChannel.channel().isWritable()) {
+                result.fail();
+                return;
+            }
+
             StompFrame frame = StompFrame.create(StompHeaders.create(), StompCommand.MESSAGE, message.getBytes());
             frame.addHeader(StompHeaders.Elements.DESTINATION, destination.path());
             frame.addHeader(StompHeaders.Elements.SUBSCRIPTION, subscription.id());
             frame.addHeader(StompHeaders.Elements.MESSAGE_ID, IdGenerator.uuid());
 
-            Promise<StompFrame> sendPromise = subscription.getConnection().send(frame);
+            Promise<StompFrame> sendPromise = clientChannel.send(frame);
             sendPromise.addListener(sendFuture -> {
                 if (sendFuture.isSuccess()) {
                     result.success();

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/StompDispatchExporter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/StompDispatchExporter.java
@@ -34,6 +34,7 @@ import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.IdGenerator;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.dispatch.AggregationResult;
+import org.traffichunter.titan.dispatch.SlowConsumerMetrics;
 
 import java.util.List;
 
@@ -53,9 +54,15 @@ import java.util.List;
 public class StompDispatchExporter implements DispatchExporter {
 
     private final StompServerChannel serverConnection;
+    private final SlowConsumerMetrics slowConsumerMetrics;
 
     public StompDispatchExporter(StompServerChannel serverConnection) {
+        this(serverConnection, SlowConsumerMetrics.global());
+    }
+
+    StompDispatchExporter(StompServerChannel serverConnection, SlowConsumerMetrics slowConsumerMetrics) {
         this.serverConnection = serverConnection;
+        this.slowConsumerMetrics = slowConsumerMetrics;
     }
 
     @Override
@@ -76,6 +83,7 @@ public class StompDispatchExporter implements DispatchExporter {
         subscriptions.forEach(subscription -> {
             StompClientChannel clientChannel = subscription.getConnection();
             if (!clientChannel.channel().isWritable()) {
+                slowConsumerMetrics.recordSkippedMessage();
                 result.fail();
                 return;
             }

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/DispatchExporterTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/DispatchExporterTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -139,13 +140,19 @@ class DispatchExporterTest {
         Destination destination = Destination.create("/topic/orders");
 
         StompClientChannel successConn = mock(StompClientChannel.class);
+        NetChannel successChannel = mock(NetChannel.class);
         when(successConn.session()).thenReturn("session-1");
+        when(successConn.channel()).thenReturn(successChannel);
+        when(successChannel.isWritable()).thenReturn(true);
         Promise<StompFrame> successPromise = Promise.newPromise(loop);
         successPromise.success(StompFrame.PING);
         when(successConn.send(any(StompFrame.class))).thenReturn(successPromise);
 
         StompClientChannel failedConn = mock(StompClientChannel.class);
+        NetChannel failedChannel = mock(NetChannel.class);
         when(failedConn.session()).thenReturn("session-2");
+        when(failedConn.channel()).thenReturn(failedChannel);
+        when(failedChannel.isWritable()).thenReturn(true);
         Promise<StompFrame> failedPromise = Promise.newPromise(loop);
         failedPromise.fail(new IllegalStateException("send failed"));
         when(failedConn.send(any(StompFrame.class))).thenReturn(failedPromise);
@@ -170,6 +177,34 @@ class DispatchExporterTest {
         assertThat(result.done()).isEqualTo(2);
         assertThat(result.succeeded()).isEqualTo(1);
         assertThat(result.failed()).isEqualTo(1);
+    }
+
+    @Test
+    void stompFanoutExporter_skips_non_writable_subscriber() {
+        StompServerSubscriptions subscriptions = new StompServerSubscriptions();
+        when(serverConnection.subscriptions()).thenReturn(subscriptions);
+
+        Destination destination = Destination.create("/topic/orders");
+        StompClientChannel connection = mock(StompClientChannel.class);
+        NetChannel channel = mock(NetChannel.class);
+        when(connection.session()).thenReturn("session-1");
+        when(connection.channel()).thenReturn(channel);
+        when(channel.isWritable()).thenReturn(false);
+
+        subscriptions.register(StompServerSubscription.builder()
+                .destination(destination)
+                .id("sub-1")
+                .ackMode(StompFrame.AckMode.AUTO)
+                .connection(connection)
+                .build());
+
+        StompDispatchExporter exporter = new StompDispatchExporter(serverConnection);
+        AggregationResult result = exporter.export(destination, Buffer.heap().alloc("hello".getBytes()));
+
+        verify(connection, never()).send(any(StompFrame.class));
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.succeeded()).isZero();
+        assertThat(result.failed()).isOne();
     }
 
     @Test

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/DispatchExporterTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/DispatchExporterTest.java
@@ -60,6 +60,7 @@ import org.traffichunter.titan.core.util.Destination;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 import org.traffichunter.titan.core.channel.ChannelRegistry;
 import org.traffichunter.titan.dispatch.AggregationResult;
+import org.traffichunter.titan.dispatch.SlowConsumerMetrics;
 
 @ExtendWith(MockitoExtension.class)
 class DispatchExporterTest {
@@ -198,13 +199,15 @@ class DispatchExporterTest {
                 .connection(connection)
                 .build());
 
-        StompDispatchExporter exporter = new StompDispatchExporter(serverConnection);
+        SlowConsumerMetrics metrics = new SlowConsumerMetrics();
+        StompDispatchExporter exporter = new StompDispatchExporter(serverConnection, metrics);
         AggregationResult result = exporter.export(destination, Buffer.heap().alloc("hello".getBytes()));
 
         verify(connection, never()).send(any(StompFrame.class));
         assertThat(result.isDone()).isTrue();
         assertThat(result.succeeded()).isZero();
         assertThat(result.failed()).isOne();
+        assertThat(metrics.getSkippedMessages()).isOne();
     }
 
     @Test

--- a/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/StompSlowConsumerIntegrationTest.java
+++ b/dispatch/src/test/java/org/traffichunter/titan/dispatch/exporter/StompSlowConsumerIntegrationTest.java
@@ -1,0 +1,162 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.dispatch.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
+import org.traffichunter.titan.core.channel.stomp.StompServerChannel;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompServerSubscription;
+import org.traffichunter.titan.core.codec.stomp.StompServerSubscriptions;
+import org.traffichunter.titan.core.transport.InetServer;
+import org.traffichunter.titan.core.transport.option.InetClientOption;
+import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
+import org.traffichunter.titan.core.util.Destination;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.management.ChannelWriteBufferResource;
+import org.traffichunter.titan.core.util.management.ChannelWriteBufferResourceDetector;
+import org.traffichunter.titan.dispatch.AggregationResult;
+import org.traffichunter.titan.dispatch.SlowConsumerMetrics;
+
+/**
+ * Verifies slow-consumer isolation against a real non-blocking socket.
+ *
+ * @author yun
+ */
+class StompSlowConsumerIntegrationTest {
+
+    private InetServer server;
+    private Socket slowConsumer;
+    private Socket healthyConsumer;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (slowConsumer != null) {
+            slowConsumer.close();
+        }
+        if (healthyConsumer != null) {
+            healthyConsumer.close();
+        }
+        if (server != null && !server.isShutdown()) {
+            server.shutdown();
+        }
+    }
+
+    @RepeatedTest(3)
+    @Timeout(20)
+    void skip_dispatch_when_real_socket_write_buffer_is_under_pressure() throws Exception {
+        LinkedBlockingQueue<NetChannel> acceptedChannels = new LinkedBlockingQueue<>();
+        server = InetServer.open(EventLoopGroups.singleGroup())
+                .childOption(InetClientOption.builder().sendBufferSize(1024).build())
+                .onChannel(channel -> acceptedChannels.add((NetChannel) channel));
+        server.start();
+        server.listen("localhost", 0).get(5, TimeUnit.SECONDS);
+
+        int port = ((InetSocketAddress) server.localAddress()).getPort();
+        slowConsumer = new Socket();
+        slowConsumer.setReceiveBufferSize(1024);
+        slowConsumer.connect(new InetSocketAddress("localhost", port));
+
+        NetChannel slowChannel = acceptedChannels.poll(5, TimeUnit.SECONDS);
+        assertThat(slowChannel).isNotNull();
+
+        healthyConsumer = new Socket();
+        healthyConsumer.setSoTimeout(5000);
+        healthyConsumer.connect(new InetSocketAddress("localhost", port));
+        NetChannel healthyChannel = acceptedChannels.poll(5, TimeUnit.SECONDS);
+        assertThat(healthyChannel).isNotNull();
+
+        Destination destination = Destination.create("/topic/slow-consumer");
+        StompClientChannel slowStompChannel = StompClientChannel.wrap(slowChannel, StompSessionOption.DEFAULT);
+        StompClientChannel healthyStompChannel = StompClientChannel.wrap(healthyChannel, StompSessionOption.DEFAULT);
+        StompServerSubscriptions subscriptions = new StompServerSubscriptions();
+        subscriptions.register(StompServerSubscription.builder()
+                .destination(destination)
+                .id("slow-subscription")
+                .ackMode(StompFrame.AckMode.AUTO)
+                .connection(slowStompChannel)
+                .build());
+        subscriptions.register(StompServerSubscription.builder()
+                .destination(destination)
+                .id("healthy-subscription")
+                .ackMode(StompFrame.AckMode.AUTO)
+                .connection(healthyStompChannel)
+                .build());
+
+        StompServerChannel serverChannel = mock(StompServerChannel.class);
+        when(serverChannel.subscriptions()).thenReturn(subscriptions);
+        SlowConsumerMetrics metrics = new SlowConsumerMetrics();
+        StompDispatchExporter exporter = new StompDispatchExporter(serverChannel, metrics);
+
+        byte[] payload = new byte[8 * 1024];
+        AggregationResult result = AggregationResult.create(List.of(destination), 0);
+        for (int pressureCycle = 0; pressureCycle < 20 && metrics.getSkippedMessages() == 0; pressureCycle++) {
+            for (int attempt = 0; attempt < 4096 && slowChannel.isWritable(); attempt++) {
+                slowChannel.writeAndFlush(Buffer.direct().alloc(payload)).get(5, TimeUnit.SECONDS);
+            }
+            Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> !slowChannel.isWritable());
+            Buffer message = Buffer.heap().alloc("message");
+            try {
+                result = exporter.export(destination, message);
+            } finally {
+                message.release();
+            }
+        }
+
+        assertThat(slowChannel.isClosed()).isFalse();
+        assertThat(healthyChannel.isWritable()).isTrue();
+        ChannelWriteBufferResource writeBuffers = new ChannelWriteBufferResourceDetector().detect();
+        assertThat(writeBuffers.pendingBytes()).isPositive();
+        assertThat(writeBuffers.nonWritableBuffers()).isPositive();
+
+        AggregationResult completed = result;
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(completed::isDone);
+        assertThat(result.totalAttempted()).isEqualTo(2);
+        assertThat(result.succeeded()).isOne();
+        assertThat(result.failed()).isOne();
+        assertThat(metrics.getSkippedMessages()).isOne();
+
+        byte[] received = new byte[1024];
+        int read = healthyConsumer.getInputStream().read(received);
+        assertThat(read).isPositive();
+        assertThat(new String(received, 0, read, StandardCharsets.UTF_8))
+                .contains("MESSAGE", "destination:/topic/slow-consumer", "message");
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/MonitoringSnapshotService.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/MonitoringSnapshotService.java
@@ -4,11 +4,13 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import org.traffichunter.titan.monitor.jmx.channel.JmxChannelWriteBufferCollector;
+import org.traffichunter.titan.monitor.jmx.channel.JmxSlowConsumerCollector;
 import org.traffichunter.titan.monitor.jmx.cpu.JmxCpuMbeanCollector;
 import org.traffichunter.titan.monitor.jmx.heap.JmxHeapMbeanCollector;
 import org.traffichunter.titan.monitor.jmx.queue.JmxDispatcherQueueCollector;
 import org.traffichunter.titan.monitor.jmx.thread.JmxThreadMbeanCollector;
 import org.traffichunter.titan.monitor.model.JvmSnapshot;
+import org.traffichunter.titan.monitor.model.ChannelWriteSnapshot;
 import org.traffichunter.titan.monitor.model.MonitoringSnapshot;
 import org.traffichunter.titan.monitor.model.ServerSnapshot;
 
@@ -21,6 +23,7 @@ public final class MonitoringSnapshotService {
     private final JmxHeapMbeanCollector heapCollector;
     private final JmxThreadMbeanCollector threadCollector;
     private final JmxChannelWriteBufferCollector channelWriteCollector;
+    private final JmxSlowConsumerCollector slowConsumerCollector;
     private final JmxDispatcherQueueCollector queueCollector;
 
     public MonitoringSnapshotService(String version) {
@@ -32,6 +35,7 @@ public final class MonitoringSnapshotService {
                 new JmxHeapMbeanCollector(),
                 new JmxThreadMbeanCollector(),
                 new JmxChannelWriteBufferCollector(),
+                new JmxSlowConsumerCollector(),
                 new JmxDispatcherQueueCollector()
         );
     }
@@ -53,6 +57,7 @@ public final class MonitoringSnapshotService {
                 heapCollector,
                 threadCollector,
                 new JmxChannelWriteBufferCollector(),
+                new JmxSlowConsumerCollector(),
                 queueCollector
         );
     }
@@ -67,6 +72,30 @@ public final class MonitoringSnapshotService {
             JmxChannelWriteBufferCollector channelWriteCollector,
             JmxDispatcherQueueCollector queueCollector
     ) {
+        this(
+                clock,
+                startedAt,
+                version,
+                cpuCollector,
+                heapCollector,
+                threadCollector,
+                channelWriteCollector,
+                new JmxSlowConsumerCollector(),
+                queueCollector
+        );
+    }
+
+    public MonitoringSnapshotService(
+            Clock clock,
+            Instant startedAt,
+            String version,
+            JmxCpuMbeanCollector cpuCollector,
+            JmxHeapMbeanCollector heapCollector,
+            JmxThreadMbeanCollector threadCollector,
+            JmxChannelWriteBufferCollector channelWriteCollector,
+            JmxSlowConsumerCollector slowConsumerCollector,
+            JmxDispatcherQueueCollector queueCollector
+    ) {
         this.clock = clock;
         this.startedAt = startedAt;
         this.version = version;
@@ -74,11 +103,13 @@ public final class MonitoringSnapshotService {
         this.heapCollector = heapCollector;
         this.threadCollector = threadCollector;
         this.channelWriteCollector = channelWriteCollector;
+        this.slowConsumerCollector = slowConsumerCollector;
         this.queueCollector = queueCollector;
     }
 
     public MonitoringSnapshot snapshot() {
         Instant timestamp = clock.instant();
+        ChannelWriteSnapshot channelWrites = channelWriteCollector.collect();
         return new MonitoringSnapshot(
                 new ServerSnapshot(
                         version,
@@ -91,7 +122,12 @@ public final class MonitoringSnapshotService {
                         heapCollector.collect(),
                         threadCollector.collect()
                 ),
-                channelWriteCollector.collect(),
+                new ChannelWriteSnapshot(
+                        channelWrites.activeBuffers(),
+                        channelWrites.pendingBytes(),
+                        channelWrites.nonWritableBuffers(),
+                        slowConsumerCollector.collect()
+                ),
                 queueCollector.collect()
         );
     }

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/channel/JmxSlowConsumerCollector.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/jmx/channel/JmxSlowConsumerCollector.java
@@ -1,0 +1,43 @@
+package org.traffichunter.titan.monitor.jmx.channel;
+
+import java.lang.management.ManagementFactory;
+import java.util.function.LongSupplier;
+import javax.management.MBeanServerConnection;
+import org.traffichunter.titan.dispatch.SlowConsumerMetricsMbeans;
+
+/**
+ * Reads the process-wide slow-consumer skip counter from JMX.
+ *
+ * @author yun
+ */
+public final class JmxSlowConsumerCollector {
+
+    private final LongSupplier skippedMessages;
+
+    public JmxSlowConsumerCollector() {
+        this(ManagementFactory.getPlatformMBeanServer());
+    }
+
+    public JmxSlowConsumerCollector(MBeanServerConnection server) {
+        this(() -> collect(server));
+    }
+
+    public JmxSlowConsumerCollector(LongSupplier skippedMessages) {
+        this.skippedMessages = skippedMessages;
+    }
+
+    public long collect() {
+        return skippedMessages.getAsLong();
+    }
+
+    private static long collect(MBeanServerConnection server) {
+        try {
+            if (!server.isRegistered(SlowConsumerMetricsMbeans.objectName())) {
+                return 0;
+            }
+            return (Long) server.getAttribute(SlowConsumerMetricsMbeans.objectName(), "SkippedMessages");
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to collect slow consumer metrics", e);
+        }
+    }
+}

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/model/ChannelWriteSnapshot.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/model/ChannelWriteSnapshot.java
@@ -6,11 +6,17 @@ package org.traffichunter.titan.monitor.model;
  * @param activeBuffers number of open channel write buffers
  * @param pendingBytes bytes not yet written to network sockets
  * @param nonWritableBuffers buffers currently held above their high watermark
+ * @param skippedMessages messages skipped because their target channel was not writable
  * @author yun
  */
 public record ChannelWriteSnapshot(
         int activeBuffers,
         long pendingBytes,
-        int nonWritableBuffers
+        int nonWritableBuffers,
+        long skippedMessages
 ) {
+
+    public ChannelWriteSnapshot(int activeBuffers, long pendingBytes, int nonWritableBuffers) {
+        this(activeBuffers, pendingBytes, nonWritableBuffers, 0);
+    }
 }

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/MonitoringSnapshotServiceTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/MonitoringSnapshotServiceTest.java
@@ -8,6 +8,7 @@ import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.codec.json.Json;
 import org.traffichunter.titan.monitor.jmx.channel.JmxChannelWriteBufferCollector;
+import org.traffichunter.titan.monitor.jmx.channel.JmxSlowConsumerCollector;
 import org.traffichunter.titan.monitor.jmx.cpu.JmxCpuMbeanCollector;
 import org.traffichunter.titan.monitor.jmx.heap.JmxHeapMbeanCollector;
 import org.traffichunter.titan.monitor.jmx.queue.JmxDispatcherQueueCollector;
@@ -27,6 +28,7 @@ class MonitoringSnapshotServiceTest {
                 new JmxHeapMbeanCollector(),
                 new JmxThreadMbeanCollector(),
                 new JmxChannelWriteBufferCollector(() -> new org.traffichunter.titan.core.util.management.ChannelWriteBufferResource(2, 128, 1)),
+                new JmxSlowConsumerCollector(() -> 3),
                 new JmxDispatcherQueueCollector()
         );
 
@@ -37,7 +39,8 @@ class MonitoringSnapshotServiceTest {
         assertThat(snapshot.server().uptimeMillis()).isEqualTo(5000);
         assertThat(snapshot.jvm()).isNotNull();
         assertThat(snapshot.channelWrites().pendingBytes()).isEqualTo(128);
+        assertThat(snapshot.channelWrites().skippedMessages()).isEqualTo(3);
         assertThat(snapshot.queues()).isNotNull();
-        assertThat(json).contains("\"server\"", "\"jvm\"", "\"channelWrites\"", "\"queues\"");
+        assertThat(json).contains("\"server\"", "\"jvm\"", "\"channelWrites\"", "\"skippedMessages\":3", "\"queues\"");
     }
 }

--- a/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/channel/JmxSlowConsumerCollectorTest.java
+++ b/monitor/src/test/java/org/traffichunter/titan/monitor/jmx/channel/JmxSlowConsumerCollectorTest.java
@@ -1,0 +1,26 @@
+package org.traffichunter.titan.monitor.jmx.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.dispatch.SlowConsumerMetrics;
+
+/**
+ * @author yun
+ */
+class JmxSlowConsumerCollectorTest {
+
+    @Test
+    void collect_skipped_message_count_from_jmx() {
+        SlowConsumerMetrics metrics = SlowConsumerMetrics.global();
+        long before = metrics.getSkippedMessages();
+
+        metrics.recordSkippedMessage();
+
+        JmxSlowConsumerCollector collector = new JmxSlowConsumerCollector(
+                ManagementFactory.getPlatformMBeanServer()
+        );
+        assertThat(collector.collect()).isEqualTo(before + 1);
+    }
+}

--- a/titan-cli/internal/monitor/model.go
+++ b/titan-cli/internal/monitor/model.go
@@ -11,6 +11,7 @@ type ChannelWriteSnapshot struct {
 	ActiveBuffers      int   `json:"activeBuffers"`
 	PendingBytes       int64 `json:"pendingBytes"`
 	NonWritableBuffers int   `json:"nonWritableBuffers"`
+	SkippedMessages    int64 `json:"skippedMessages"`
 }
 
 type ServerSnapshot struct {

--- a/titan-cli/internal/render/render.go
+++ b/titan-cli/internal/render/render.go
@@ -98,6 +98,10 @@ func Status(w io.Writer, snapshot monitor.Snapshot, options Options) {
 		snapshot.ChannelWrites.ActiveBuffers,
 		snapshot.ChannelWrites.NonWritableBuffers,
 	)
+	fmt.Fprintf(w, "  %s %d messages\n",
+		label("slow skips", 11, options),
+		snapshot.ChannelWrites.SkippedMessages,
+	)
 	fmt.Fprintf(w, "  %s %d destinations\n", label("queues", 11, options), len(snapshot.Queues))
 }
 

--- a/titan-cli/internal/render/render_test.go
+++ b/titan-cli/internal/render/render_test.go
@@ -14,7 +14,7 @@ func TestStatusRendersCoreFields(t *testing.T) {
 	Status(&out, fixture(), NoColor)
 
 	text := out.String()
-	for _, expected := range []string{"version     0.6.1", "cpu", "heap", "channel I/O 2.0KiB pending   3 active   1 non-writable", "queues      1 destinations"} {
+	for _, expected := range []string{"version     0.6.1", "cpu", "heap", "channel I/O 2.0KiB pending   3 active   1 non-writable", "slow skips  2 messages", "queues      1 destinations"} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("expected %q in output:\n%s", expected, text)
 		}
@@ -59,6 +59,7 @@ func fixture() monitor.Snapshot {
 			ActiveBuffers:      3,
 			PendingBytes:       2048,
 			NonWritableBuffers: 1,
+			SkippedMessages:    2,
 		},
 		Queues: []monitor.QueueSnapshot{
 			{Destination: "/queue/orders", Size: 5, PendingBytes: 20, MaxPendingBytes: 40, Paused: true},

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannel.java
@@ -25,7 +25,6 @@ package org.traffichunter.titan.core.channel.stomp;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -205,7 +204,7 @@ public class StompServerTcpChannel implements StompServerChannel {
         }
 
         try {
-            Collection<StompClientChannel> activeConnections = connections.values();
+            List<StompClientChannel> activeConnections = List.copyOf(connections.values());
             activeConnections.forEach(this::cleanUp);
             activeConnections.forEach(StompClientChannel::close);
             connections.clear();

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannelTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompServerTcpChannelTest.java
@@ -1,0 +1,62 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.stomp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.NetServerChannel;
+import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
+
+/**
+ * @author yun
+ */
+class StompServerTcpChannelTest {
+
+    @Test
+    void close_closes_every_registered_client_connection() {
+        NetServerChannel serverChannel = mock(NetServerChannel.class);
+        StompClientChannel first = mock(StompClientChannel.class);
+        StompClientChannel second = mock(StompClientChannel.class);
+        when(first.session()).thenReturn("first");
+        when(second.session()).thenReturn("second");
+
+        StompServerTcpChannel channel = new StompServerTcpChannel(
+                serverChannel,
+                StompServerOption.builder().build()
+        );
+        channel.register(first);
+        channel.register(second);
+
+        channel.close();
+
+        verify(first).close();
+        verify(second).close();
+        verify(serverChannel).close();
+        assertThat(channel.connections()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Motivation:

Slow consumers can accumulate outbound data until the channel reaches its hard pending-byte limit. Titan needs an explicit soft-pressure policy that protects channel memory while preserving delivery to writable consumers, together with enough visibility to diagnose skipped messages.

## Modification:

- Add high and low watermarks plus a hard `maxPendingBytes` limit to channel write buffers.
- Skip STOMP delivery to non-writable consumer channels while continuing delivery to writable subscriptions.
- Track pending bytes, non-writable channels, and skipped slow-consumer messages through JMX.
- Surface slow-consumer metrics in the monitor snapshot and Titan CLI.
- Add unit tests and a real TCP integration test covering slow and healthy consumers.

## Result:

Slow consumer backlogs are bounded before the hard channel limit, healthy consumers continue receiving messages, and operators can inspect pressure and skipped-message counts.

Validation:

- `./gradlew test`
- `cd titan-cli && go test ./...`
