### PR TITLE
Handle transport failures consistently through promises

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelTasks.java
@@ -69,33 +69,46 @@ final class ChannelTasks {
     static Promise<NetChannel> accept(NetServerChannel channel) {
         IOEventLoop eventLoop = channel.eventLoop();
         Promise<NetChannel> result = Promise.newPromise(eventLoop);
-        Runnable acceptTask = () -> {
+        try {
+            Runnable acceptTask = () -> {
+                try {
+                    result.success(channel.internal().accept());
+                } catch (Throwable error) {
+                    result.fail(error);
+                }
+            };
+
+            if (eventLoop.inEventLoop()) {
+                acceptTask.run();
+            } else {
+                eventLoop.execute(acceptTask);
+            }
+        } catch (RuntimeException e) {
+            result.fail(e);
+        }
+
+        return result;
+    }
+
+    static Promise<Void> execute(IOEventLoop eventLoop, Runnable task) {
+        Promise<Void> result = Promise.newPromise(eventLoop);
+        Runnable operation = () -> {
             try {
-                result.success(channel.internal().accept());
+                task.run();
+                result.success();
             } catch (Throwable error) {
                 result.fail(error);
             }
         };
 
         if (eventLoop.inEventLoop()) {
-            acceptTask.run();
+            operation.run();
         } else {
-            eventLoop.execute(acceptTask);
-        }
-        return result;
-    }
-
-    static Promise<Void> execute(IOEventLoop eventLoop, Runnable task) {
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
-        Promise<Void> result = Promise.newPromise(eventLoop);
-        try {
-            task.run();
-            result.success();
-        } catch (Throwable error) {
-            result.fail(error);
+            try {
+                eventLoop.execute(operation);
+            } catch (RuntimeException error) {
+                result.fail(error);
+            }
         }
         return result;
     }
@@ -125,15 +138,23 @@ final class ChannelTasks {
     }
 
     static <T> Promise<T> execute(IOEventLoop eventLoop, Callable<T> task) {
-        if (!eventLoop.inEventLoop()) {
-            return eventLoop.submit(task);
-        }
-
         Promise<T> result = Promise.newPromise(eventLoop);
-        try {
-            result.success(task.call());
-        } catch (Throwable error) {
-            result.fail(error);
+        Runnable operation = () -> {
+            try {
+                result.success(task.call());
+            } catch (Throwable error) {
+                result.fail(error);
+            }
+        };
+
+        if (eventLoop.inEventLoop()) {
+            operation.run();
+        } else {
+            try {
+                eventLoop.execute(operation);
+            } catch (RuntimeException error) {
+                result.fail(error);
+            }
         }
         return result;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/InetClient.java
@@ -35,7 +35,6 @@ import org.jspecify.annotations.Nullable;
 import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.ChannelHandShakeEventListener;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
-import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.NewIONetChannel;
 import org.traffichunter.titan.core.util.concurrent.Promise;
@@ -168,35 +167,43 @@ public class InetClient extends AbstractTransport<NetChannel> {
             return validate;
         }
 
-        NetChannel channel = createChannel();
-        IOEventLoop loop = channel.eventLoop();
-
-        TlsContext tlsCtx = tlsContext;
-        TlsHandler tlsHandler = null;
-        if (tlsCtx != null) {
-            tlsHandler = tlsCtx.newHandler(remoteAddress.getHostString(), remoteAddress.getPort());
-            channel.chain().addFirst(tlsHandler);
+        NetChannel channel;
+        try {
+            channel = createChannel();
+        } catch (RuntimeException error) {
+            return Promise.failedPromise(groups().secondaryGroup(), error);
         }
 
-        Promise<NetChannel> connectResult = Promise.newPromise(loop);
+        Promise<NetChannel> connectResult = Promise.newPromise(channel.eventLoop());
         connectResult.addListener(done -> {
             if (!done.isSuccess()) {
                 destroyChannel(channel);
             }
         });
 
-        TlsHandler configuredTlsHandler = tlsHandler;
-        channel.connect(remoteAddress, timeOut, timeUnit)
-                .onSuccess(promise -> {
-                    if (configuredTlsHandler == null) {
-                        connectResult.success(channel);
-                        return;
-                    }
+        try {
+            TlsContext tlsCtx = tlsContext;
+            TlsHandler tlsHandler = null;
+            if (tlsCtx != null) {
+                tlsHandler = tlsCtx.newHandler(remoteAddress.getHostString(), remoteAddress.getPort());
+                channel.chain().addFirst(tlsHandler);
+            }
 
-                    configuredTlsHandler.handshake(channel)
-                            .onSuccess(ignored -> connectResult.success(channel))
-                            .onFailure(connectResult::fail);
-                }).onFailure(connectResult::fail);
+            TlsHandler configuredTlsHandler = tlsHandler;
+            channel.connect(remoteAddress, timeOut, timeUnit)
+                    .onSuccess(promise -> {
+                        if (configuredTlsHandler == null) {
+                            connectResult.success(channel);
+                            return;
+                        }
+
+                        configuredTlsHandler.handshake(channel)
+                                .onSuccess(ignored -> connectResult.success(channel))
+                                .onFailure(connectResult::fail);
+                    }).onFailure(connectResult::fail);
+        } catch (RuntimeException error) {
+            connectResult.fail(error);
+        }
 
         return connectResult;
     }
@@ -289,10 +296,23 @@ public class InetClient extends AbstractTransport<NetChannel> {
 
     private NetChannel createChannel() {
         NetChannel channel = newChannel(new ClientChannelConnector());
-        channelHandler.handle(channel);
-        applyClientOption(channel, option);
-        groups().register(channel);
-        return channel;
+        try {
+            channelHandler.handle(channel);
+            applyClientOption(channel, option);
+            groups().register(channel);
+            return channel;
+        } catch (RuntimeException error) {
+            try {
+                destroyChannel(channel);
+            } catch (RuntimeException closeError) {
+                if (closeError != error) {
+                    error.addSuppressed(closeError);
+                }
+            } finally {
+                channelRegistry.removeChannel(channel);
+            }
+            throw error;
+        }
     }
 
     @Noop

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshaker.java
@@ -76,27 +76,36 @@ public final class WebSocketClientHandshaker extends AbstractWebSocketHandshaker
 
     @Override
     public Promise<NetChannel> handshake(NetChannel channel) {
-        String key = generateKey();
-        HttpRequest request = new HttpRequest()
-                .uri(path)
-                .header(HOST, host)
-                .header(UPGRADE, WEBSOCKET)
-                .header(CONNECTION, UPGRADE)
-                .header(SEC_WEBSOCKET_KEY, key)
-                .header(SEC_WEBSOCKET_PROTOCOL, subProtocol())
-                .header(SEC_WEBSOCKET_VERSION, version());
-
         Promise<NetChannel> upgradeResult = Promise.newPromise(channel.eventLoop());
-        channel.chain().add(new WebSocketUpgradeHandler(this, key, upgradeResult));
+        try {
+            String key = generateKey();
+            HttpRequest request = new HttpRequest()
+                    .uri(path)
+                    .header(HOST, host)
+                    .header(UPGRADE, WEBSOCKET)
+                    .header(CONNECTION, UPGRADE)
+                    .header(SEC_WEBSOCKET_KEY, key)
+                    .header(SEC_WEBSOCKET_PROTOCOL, subProtocol())
+                    .header(SEC_WEBSOCKET_VERSION, version());
 
-        channel.writeAndFlush(Buffer.heap().alloc(request.toString())).addListener(result -> {
-            if (result.isFailed() && !upgradeResult.isDone()) {
-                Throwable error = result.error();
-                upgradeResult.fail(error == null
-                        ? new WebSocketHandshakeException("Failed to write WebSocket upgrade request")
-                        : error);
+            channel.chain().add(new WebSocketUpgradeHandler(this, key, upgradeResult));
+            Buffer requestBuffer = Buffer.heap().alloc(request.toString());
+            try {
+                channel.writeAndFlush(requestBuffer).addListener(result -> {
+                    if (result.isFailed() && !upgradeResult.isDone()) {
+                        Throwable error = result.error();
+                        upgradeResult.fail(error == null
+                                ? new WebSocketHandshakeException("Failed to write WebSocket upgrade request")
+                                : error);
+                    }
+                });
+            } catch (RuntimeException error) {
+                requestBuffer.release();
+                throw error;
             }
-        });
+        } catch (RuntimeException error) {
+            upgradeResult.fail(error);
+        }
 
         return upgradeResult;
     }

--- a/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/websocket/WebSocketServerHandshaker.java
@@ -69,7 +69,11 @@ public final class WebSocketServerHandshaker extends AbstractWebSocketHandshaker
     @Override
     public Promise<NetChannel> handshake(NetChannel channel) {
         Promise<NetChannel> upgradeResult = Promise.newPromise(channel.eventLoop());
-        channel.chain().add(new WebSocketUpgradeHandler(this, upgradeResult));
+        try {
+            channel.chain().add(new WebSocketUpgradeHandler(this, upgradeResult));
+        } catch (RuntimeException error) {
+            upgradeResult.fail(error);
+        }
         return upgradeResult;
     }
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/concurrent/Promise.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/concurrent/Promise.java
@@ -87,6 +87,10 @@ public interface Promise<C> extends RunnableFuture<C>, Completable<C> {
      * Registers a listener that will be notified on the owning event loop.
      *
      * <p>Do not run blocking code in the listener.</p>
+     *
+     * <p>If the executor rejects notification, the rejection is logged and the listener is not
+     * invoked on the caller thread. The completed result remains available through this promise;
+     * callback delivery after executor shutdown is not guaranteed.</p>
      */
     @CanIgnoreReturnValue
     Promise<C> addListener(AsyncListener<C> listener);

--- a/core/src/main/java/org/traffichunter/titan/core/util/concurrent/PromiseImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/concurrent/PromiseImpl.java
@@ -38,9 +38,9 @@ import org.traffichunter.titan.core.util.Assert;
  * Default {@link Promise} implementation.
  *
  * <p>The implementation is synchronized around completion state and waiters, but listener
- * execution is always redirected to the owning {@link EventExecutorService}. This keeps callbacks in
- * the same thread-affinity model as channel I/O and avoids running transport callbacks on
- * arbitrary caller threads.</p>
+ * execution stays on the owning {@link EventExecutorService}. Rejected notifications are logged
+ * without running callbacks on the caller thread or changing the completed result. Owners must
+ * complete pending promises and drain their notifications before shutting down the executor.</p>
  *
  * @author yungwang-o
  */
@@ -363,8 +363,18 @@ public class PromiseImpl<C> implements Promise<C> {
     }
 
     private void notifyListeners() {
+        synchronized (this) {
+            if (listeners.isEmpty()) {
+                return;
+            }
+        }
+
         if(!executor.inEventLoop()) {
-            executor.execute(this::notifyListeners);
+            try {
+                executor.execute(this::notifyListeners);
+            } catch (RejectedExecutionException error) {
+                log.warn("Promise listener notification rejected by executor", error);
+            }
             return;
         }
 

--- a/core/src/test/java/org/traffichunter/titan/core/channel/ChannelTasksTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/channel/ChannelTasksTest.java
@@ -1,0 +1,76 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.util.concurrent.Promise;
+
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author yun
+ */
+class ChannelTasksTest {
+
+    @Test
+    void return_failed_promise_when_event_loop_rejects_channel_task() {
+        IOEventLoop eventLoop = rejectingEventLoop();
+
+        Promise<Void> result = ChannelTasks.execute(eventLoop, () -> { });
+
+        assertRejected(result);
+    }
+
+    @Test
+    void return_failed_promise_when_event_loop_rejects_accept() {
+        IOEventLoop eventLoop = rejectingEventLoop();
+        NetServerChannel channel = mock(NetServerChannel.class);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+
+        Promise<NetChannel> result = ChannelTasks.accept(channel);
+
+        assertRejected(result);
+    }
+
+    private static IOEventLoop rejectingEventLoop() {
+        IOEventLoop eventLoop = mock(IOEventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doThrow(new RejectedExecutionException("event loop stopped"))
+                .when(eventLoop).execute(any(Runnable.class));
+        return eventLoop;
+    }
+
+    private static void assertRejected(Promise<?> result) {
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.error())
+                .isInstanceOf(RejectedExecutionException.class)
+                .hasMessage("event loop stopped");
+    }
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/PromiseTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/PromiseTest.java
@@ -6,13 +6,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.traffichunter.titan.core.channel.EventLoop;
+import org.traffichunter.titan.core.channel.TaskEventLoop;
 import org.traffichunter.titan.core.util.concurrent.AsyncListener;
 import org.traffichunter.titan.core.util.concurrent.Promise;
 import org.traffichunter.titan.core.util.concurrent.PromiseException;
 import org.traffichunter.titan.core.util.concurrent.PromiseImpl;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -356,6 +359,59 @@ class PromiseTest {
     }
 
     @Test
+    void rejected_notification_should_preserve_failure_without_running_listener() {
+        given(eventLoop.inEventLoop()).willReturn(false);
+        willThrow(new RejectedExecutionException("executor stopped"))
+                .given(eventLoop).execute(any(Runnable.class));
+        Promise<String> promise = Promise.newPromise(eventLoop);
+        IllegalStateException failure = new IllegalStateException("send failed");
+        AtomicBoolean invoked = new AtomicBoolean();
+        promise.onFailure(error -> invoked.set(true));
+
+        assertTrue(promise.tryFail(failure));
+
+        assertThat(promise.isFailed()).isTrue();
+        assertThat(promise.error()).isSameAs(failure);
+        assertThatThrownBy(promise::get).isInstanceOf(ExecutionException.class).hasCause(failure);
+        assertThat(invoked).isFalse();
+        verify(eventLoop).execute(any(Runnable.class));
+    }
+
+    @Test
+    void late_success_listener_should_not_run_when_notification_is_rejected() throws Exception {
+        given(eventLoop.inEventLoop()).willReturn(false);
+        willThrow(new RejectedExecutionException("executor stopped"))
+                .given(eventLoop).execute(any(Runnable.class));
+        Promise<String> promise = Promise.newPromise(eventLoop);
+        AtomicBoolean invoked = new AtomicBoolean();
+        promise.success("completed");
+        verify(eventLoop, never()).execute(any(Runnable.class));
+
+        promise.onSuccess(value -> invoked.set(true));
+
+        assertThat(promise.get()).isEqualTo("completed");
+        assertThat(invoked).isFalse();
+        verify(eventLoop).execute(any(Runnable.class));
+    }
+
+    @Test
+    void late_failure_listener_should_not_run_when_notification_is_rejected() {
+        given(eventLoop.inEventLoop()).willReturn(false);
+        willThrow(new RejectedExecutionException("executor stopped"))
+                .given(eventLoop).execute(any(Runnable.class));
+        IllegalStateException failure = new IllegalStateException("send failed");
+        Promise<String> promise = Promise.failedPromise(eventLoop, failure);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        promise.onFailure(error -> invoked.set(true));
+
+        assertThat(promise.isFailed()).isTrue();
+        assertThat(promise.error()).isSameAs(failure);
+        assertThat(invoked).isFalse();
+        verify(eventLoop).execute(any(Runnable.class));
+    }
+
+    @Test
     void trySuccess_should_report_completion_state_test() {
         Promise<String> promise = new TestPromiseImpl<>(eventLoop, NOOP);
 
@@ -373,6 +429,57 @@ class PromiseTest {
         assertThat(promise.tryFail(new IllegalArgumentException())).isFalse();
         assertThat(promise.isFailed()).isTrue();
         assertThat(promise.error()).isSameAs(failure);
+    }
+
+    @Test
+    @Timeout(10)
+    void notify_early_and_late_listeners_on_the_real_event_loop() throws Exception {
+        TaskEventLoop loop = new TaskEventLoop();
+        loop.start();
+        try {
+            Thread owner = loop.submit(Thread::currentThread).get(3, TimeUnit.SECONDS);
+            Promise<String> promise = Promise.newPromise(loop);
+            CompletableFuture<Thread> early = new CompletableFuture<>();
+            CompletableFuture<Thread> late = new CompletableFuture<>();
+            promise.onSuccess(value -> early.complete(Thread.currentThread()));
+
+            promise.success("completed");
+            assertThat(early.get(3, TimeUnit.SECONDS)).isSameAs(owner).isNotSameAs(Thread.currentThread());
+            promise.onSuccess(value -> late.complete(Thread.currentThread()));
+            assertThat(late.get(3, TimeUnit.SECONDS)).isSameAs(owner);
+        } finally {
+            loop.gracefullyShutdown(1, TimeUnit.SECONDS);
+            assertThat(loop.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void preserve_failure_without_caller_thread_callbacks_after_executor_termination() throws Exception {
+        TaskEventLoop loop = new TaskEventLoop();
+        loop.start();
+        try {
+            loop.submit(() -> { }).get(3, TimeUnit.SECONDS);
+            Promise<String> promise = Promise.newPromise(loop);
+            AtomicBoolean early = new AtomicBoolean();
+            AtomicBoolean late = new AtomicBoolean();
+            promise.onFailure(error -> early.set(true));
+            loop.gracefullyShutdown(1, TimeUnit.SECONDS);
+            assertThat(loop.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
+
+            IllegalStateException failure = new IllegalStateException("send failed");
+            assertThat(promise.tryFail(failure)).isTrue();
+            promise.onFailure(error -> late.set(true));
+
+            assertThat(promise.error()).isSameAs(failure);
+            assertThatThrownBy(() -> promise.get(1, TimeUnit.SECONDS))
+                    .isInstanceOf(ExecutionException.class).hasCause(failure);
+            assertThat(early).isFalse();
+            assertThat(late).isFalse();
+        } finally {
+            loop.shutdownNow();
+            assertThat(loop.awaitTermination(3, TimeUnit.SECONDS)).isTrue();
+        }
     }
 
     private static final class TestPromiseImpl<V> extends PromiseImpl<V> {

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/InetClientFailureIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/InetClientFailureIntegrationTest.java
@@ -1,0 +1,48 @@
+package org.traffichunter.titan.core.test.integration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.core.channel.Channel;
+import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.transport.InetClient;
+import org.traffichunter.titan.core.util.concurrent.Promise;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author yun
+ */
+@Timeout(10)
+class InetClientFailureIntegrationTest {
+
+    @Test
+    void remove_created_channel_when_initializer_fails() {
+        EventLoopGroups groups = EventLoopGroups.group(1);
+        InetClient client = InetClient.open(groups);
+        IllegalStateException failure = new IllegalStateException("initializer failed");
+        AtomicReference<Channel> created = new AtomicReference<>();
+        client.onChannel(channel -> {
+            created.set(channel);
+            throw failure;
+        });
+        client.start();
+        try {
+            Promise<NetChannel> result = client.connect("localhost", 1, 1, TimeUnit.SECONDS);
+
+            assertThat(result.isFailed()).isTrue();
+            assertThat(result.error()).isSameAs(failure);
+            assertThat(client.channels()).isEmpty();
+            assertThat(created.get()).isNotNull().satisfies(channel -> {
+                assertThat(channel.isClosed()).isTrue();
+                assertThat(channel.isOpen()).isFalse();
+            });
+        } finally {
+            client.shutdown(1, TimeUnit.SECONDS);
+        }
+    }
+
+}

--- a/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/integration/TlsTransportIntegrationTest.java
@@ -26,6 +26,7 @@ package org.traffichunter.titan.core.test.integration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.core.channel.Channel;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandler;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.EventLoopGroups;
@@ -33,6 +34,7 @@ import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.websocket.WebSocketChannel;
 import org.traffichunter.titan.core.net.JdkTlsContext;
 import org.traffichunter.titan.core.net.TlsClientAuth;
+import org.traffichunter.titan.core.net.TlsContext;
 import org.traffichunter.titan.core.net.TlsOptions;
 import org.traffichunter.titan.core.net.TlsSide;
 import org.traffichunter.titan.core.net.TlsVersion;
@@ -41,15 +43,19 @@ import org.traffichunter.titan.core.transport.InetServer;
 import org.traffichunter.titan.core.transport.websocket.WebSocketClient;
 import org.traffichunter.titan.core.util.Protocol;
 import org.traffichunter.titan.core.util.buffer.Buffer;
+import org.traffichunter.titan.core.util.concurrent.Promise;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author yun
@@ -75,6 +81,32 @@ class TlsTransportIntegrationTest {
                 .tls(context(TlsSide.CLIENT, keyStore)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("server-side");
+    }
+
+    @Test
+    @Timeout(10)
+    void remove_created_channel_when_tls_handler_creation_fails() throws Exception {
+        EventLoopGroups groups = EventLoopGroups.group(1);
+        TlsContext tls = mock(TlsContext.class);
+        IllegalStateException failure = new IllegalStateException("TLS handler creation failed");
+        when(tls.side()).thenReturn(TlsSide.CLIENT);
+        when(tls.newHandler("localhost", 1)).thenThrow(failure);
+        client = InetClient.open(groups).tls(tls);
+        AtomicReference<Channel> created = new AtomicReference<>();
+        client.onChannel(created::set);
+        client.start();
+
+        Promise<NetChannel> result = client.connect("localhost", 1, 1, TimeUnit.SECONDS);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.error()).isSameAs(failure);
+        // Drain previously submitted cleanup before inspecting the registry.
+        groups.secondaryGroup().submit(() -> { }).get(3, TimeUnit.SECONDS);
+        assertThat(client.channels()).isEmpty();
+        assertThat(created.get()).isNotNull().satisfies(channel -> {
+            assertThat(channel.isClosed()).isTrue();
+            assertThat(channel.isOpen()).isFalse();
+        });
     }
 
     @AfterEach

--- a/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/transport/websocket/WebSocketClientHandshakerTest.java
@@ -25,7 +25,10 @@ package org.traffichunter.titan.core.transport.websocket;
 
 import org.junit.jupiter.api.Test;
 import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
+import org.traffichunter.titan.core.channel.ChannelException;
+import org.traffichunter.titan.core.channel.ChannelHandlerChain;
 import org.traffichunter.titan.core.channel.InMemoryNetChannel;
+import org.traffichunter.titan.core.channel.IOEventLoop;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.TaskEventLoop;
 import org.traffichunter.titan.core.util.concurrent.Promise;
@@ -38,6 +41,9 @@ import java.util.List;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author yun
@@ -85,6 +91,23 @@ class WebSocketClientHandshakerTest {
                 .validateResponse(response, KEY))
                 .isInstanceOf(WebSocketHandshakeException.class)
                 .hasMessageContaining("Invalid Sec-WebSocket-Protocol");
+    }
+
+    @Test
+    void return_failed_promise_when_upgrade_write_throws() {
+        NetChannel channel = mock(NetChannel.class);
+        IOEventLoop eventLoop = mock(IOEventLoop.class);
+        when(channel.eventLoop()).thenReturn(eventLoop);
+        when(channel.chain()).thenReturn(new ChannelHandlerChain());
+        when(channel.writeAndFlush(any(Buffer.class))).thenThrow(new ChannelException("write rejected"));
+
+        Promise<NetChannel> result = new WebSocketClientHandshaker("localhost", Protocol.STOMP)
+                .handshake(channel);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.error())
+                .isInstanceOf(ChannelException.class)
+                .hasMessage("write rejected");
     }
 
     @Test

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannel.java
@@ -148,11 +148,15 @@ public class StompClientTcpChannel implements StompClientChannel {
         if (netChannel.isActive()) {
             send(frame, framePromise);
             framePromise.addListener(f -> close());
-            eventLoop().schedule(() -> {
-                if (framePromise.trySuccess(frame)) {
-                    close();
-                }
-            }, 100, TimeUnit.MILLISECONDS);
+            try {
+                eventLoop().schedule(() -> {
+                    if (framePromise.trySuccess(frame)) {
+                        close();
+                    }
+                }, 100, TimeUnit.MILLISECONDS);
+            } catch (RuntimeException error) {
+                framePromise.tryFail(error);
+            }
         } else {
             return framePromise.fail(new IllegalStateException("Channel is not active"));
         }
@@ -425,57 +429,65 @@ public class StompClientTcpChannel implements StompClientChannel {
     }
 
     private void send(StompFrame frame, Completable<StompFrame> receiptPromise) {
-        if (!eventLoop().inEventLoop()) {
-            eventLoop().execute(() -> send(frame, receiptPromise));
-            return;
-        }
-
-        if (!netChannel.isActive() || !netChannel.isConnected()) {
-            close();
-            receiptPromise.fail(new StompNetChannelException("Channel is closed"));
-            return;
-        }
-
-        byte[] body = frame.body();
-        if (body.length > 0 && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
-            frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length));
-        }
-
-        String receiptId = frame.getHeader(Elements.RECEIPT);
-        if (receiptId != null && !receiptId.isBlank()) {
-            Promise<Void> resultPromise = Promise.newPromise(eventLoop());
-            resultPromise.addListener(future -> {
-                if (future.isSuccess()) {
-                    receiptPromise.success(frame);
-                } else {
-                    receiptPromise.fail(new StompNetChannelException("Failed to receive receipt"));
-                }
-            });
-            receiptMap.put(receiptId, resultPromise);
-        }
-
         try {
+            IOEventLoop eventLoop = eventLoop();
+            if (!eventLoop.inEventLoop()) {
+                eventLoop.execute(() -> send(frame, receiptPromise));
+                return;
+            }
+
+            if (!netChannel.isActive() || !netChannel.isConnected()) {
+                receiptPromise.fail(new StompNetChannelException("Channel is closed"));
+                close();
+                return;
+            }
+
+            byte[] body = frame.body();
+            if (body.length > 0 && !frame.getHeaders().containsKey(Elements.CONTENT_LENGTH)) {
+                frame.addHeader(Elements.CONTENT_LENGTH, String.valueOf(body.length));
+            }
+
+            String receiptId = frame.getHeader(Elements.RECEIPT);
+            if (receiptId != null && !receiptId.isBlank()) {
+                Promise<Void> resultPromise = Promise.newPromise(eventLoop);
+                resultPromise.addListener(future -> {
+                    if (future.isSuccess()) {
+                        receiptPromise.success(frame);
+                    } else {
+                        receiptPromise.fail(new StompNetChannelException("Failed to receive receipt"));
+                    }
+                });
+                receiptMap.put(receiptId, resultPromise);
+            }
+
             Promise<Void> write = netChannel.writeAndFlush(frame.toBuffer());
             write.onFailure(error -> {
                 if (receiptId != null && !receiptId.isBlank()) {
                     receiptMap.remove(receiptId);
                 }
+                receiptPromise.tryFail(new StompNetChannelException("Failed to write STOMP frame", error));
                 log.error("Failed to write STOMP frame. session={}, command={}", sessionId, frame.getCommand(), error);
-                exceptionHandler.handle(error);
-                close();
-                receiptPromise.fail(new StompNetChannelException("Failed to write STOMP frame", error));
+                try {
+                    exceptionHandler.handle(error);
+                } finally {
+                    close();
+                }
             });
             if (receiptId == null || receiptId.isBlank()) {
                 write.onSuccess(ignored -> receiptPromise.success(frame));
             }
-        } catch (Exception e) {
-            if (receiptId != null && !receiptId.isBlank()) {
-                receiptMap.remove(receiptId);
+        } catch (RuntimeException e) {
+            String failedReceiptId = frame.getHeader(Elements.RECEIPT);
+            if (failedReceiptId != null && !failedReceiptId.isBlank()) {
+                receiptMap.remove(failedReceiptId);
             }
+            receiptPromise.tryFail(new StompNetChannelException("Failed to write STOMP frame", e));
             log.error("Failed to write STOMP frame. session={}, command={}", sessionId, frame.getCommand(), e);
-            exceptionHandler.handle(e);
-            close();
-            receiptPromise.fail(new StompNetChannelException("Failed to write STOMP frame", e));
+            try {
+                exceptionHandler.handle(e);
+            } finally {
+                close();
+            }
         }
     }
 

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannelTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/channel/stomp/StompClientTcpChannelTest.java
@@ -1,0 +1,73 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.core.channel.stomp;
+
+import org.junit.jupiter.api.Test;
+import org.traffichunter.titan.core.channel.IOEventLoop;
+import org.traffichunter.titan.core.channel.NetChannel;
+import org.traffichunter.titan.core.codec.stomp.StompCommand;
+import org.traffichunter.titan.core.codec.stomp.StompFrame;
+import org.traffichunter.titan.core.codec.stomp.StompHeaders;
+import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
+import org.traffichunter.titan.core.util.concurrent.Promise;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author yun
+ */
+class StompClientTcpChannelTest {
+
+    @Test
+    void return_failed_promise_when_event_loop_rejects_send() {
+        IOEventLoop eventLoop = mock(IOEventLoop.class);
+        NetChannel netChannel = mock(NetChannel.class);
+        when(netChannel.eventLoop()).thenReturn(eventLoop);
+        when(netChannel.isActive()).thenReturn(true);
+        when(netChannel.isConnected()).thenReturn(true);
+        when(eventLoop.inEventLoop()).thenReturn(false);
+        doThrow(new RejectedExecutionException("event loop stopped"))
+                .when(eventLoop).execute(any(Runnable.class));
+
+        StompClientTcpChannel channel = new StompClientTcpChannel(netChannel, StompSessionOption.DEFAULT);
+        StompFrame frame = StompFrame.create(StompHeaders.create(), StompCommand.SEND);
+        Promise<StompFrame> result = assertDoesNotThrow(() -> channel.send(frame));
+        AtomicReference<Throwable> notified = new AtomicReference<>();
+        assertDoesNotThrow(() -> result.onFailure(notified::set));
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.error())
+                .isInstanceOf(StompNetChannelException.class)
+                .hasCauseInstanceOf(RejectedExecutionException.class);
+        assertThat(notified.get()).isNull();
+    }
+}


### PR DESCRIPTION
## Motivation:

Channel task rejection and synchronous transport setup failures could escape Promise-based APIs or leave channels registered. Failure cleanup could also prevent STOMP send promises from completing.

## Modification:

- Preserve completed Promise results when listener notification is rejected, without executing callbacks outside the owning event loop.
- Return failed promises for rejected channel tasks and WebSocket handshake setup failures.
- Close and unregister channels when client initialization fails, and install failure cleanup before TLS handler creation.
- Complete STOMP send promises before invoking failure handlers and closing the channel.
- Add regression coverage and consolidate related cases into existing Promise and TLS test classes.

## Result:

Operational failures are exposed through promises more consistently, while listener event-loop affinity is preserved and failed initialization cleans up channels. Listener delivery after executor shutdown remains explicitly unsupported.

Validation passed:
- `./gradlew test --rerun-tasks` before test consolidation.
- `./gradlew :core:test :titan-stomp:test --rerun-tasks` after test consolidation.
- `git diff --check`.