### PR TITLE
Clarify Javadoc across Titan modules

### DIFF
--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/ServerSettings.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/ServerSettings.java
@@ -32,15 +32,14 @@ import java.util.Map;
 /**
  * Normalized configuration for one managed server.
  *
- * <p>The YAML layer is permissive and mostly mirrors user input. This record is
- * the stricter runtime shape: it applies defaults, validates required values,
+ * <p>The YAML layer largely preserves user input. This record applies defaults,
+ * validates required values,
  * and separates shared options from transport- and protocol-specific overrides.</p>
  *
  * <p>Option resolution is shallow and deterministic. Values in
  * {@code transportOptions} override {@code options} for transport providers,
  * and values in {@code protocolOptions} override {@code options} for protocol
- * providers. This lets common settings be declared once while preserving a
- * precise override point for each provider layer.</p>
+ * providers. Common settings can be declared once and overridden for each provider.</p>
  */
 @NullUnmarked
 public record ServerSettings(

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/Settings.java
@@ -29,10 +29,9 @@ import org.jspecify.annotations.Nullable;
 /**
  * Immutable runtime settings resolved from the bootstrap environment.
  *
- * <p>The record separates server definitions from process-wide facilities such
- * as monitoring, backup, and flow control. Server definitions are defensively
- * copied, and every optional section is normalized to a non-null disabled or
- * default value before settings reach runtime components.</p>
+ * <p>Server definitions are separate from process-wide monitoring, backup, and
+ * flow control settings. The constructor copies server definitions and replaces
+ * omitted sections with non-null disabled or default values.</p>
  */
 public record Settings(
         List<ServerSettings> servers,

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/TitanBootstrap.java
@@ -32,16 +32,13 @@ import org.traffichunter.titan.bootstrap.Configurations.Property;
 import org.traffichunter.titan.bootstrap.environment.ConfigurationInitializer;
 
 /**
- * Coordinates process startup from raw configuration to core application start.
+ * Loads configuration and starts the core application.
  *
- * <p>This class is the boundary between the bootstrap module and the core
- * runtime. It loads environment settings, prints the banner, prevents duplicate
- * start attempts through {@link BootState}, and finally invokes the core
- * application by reflection.</p>
+ * <p>It loads environment settings, prints the banner, uses {@link BootState}
+ * to reject duplicate starts, and invokes the core application by reflection.</p>
  *
- * <p>The reflective call is intentional: bootstrap is the first module loaded
- * by the process, but it should not depend directly on all core transport and
- * protocol packages. The only contract shared across that boundary is
+ * <p>Bootstrap loads first. Reflection lets it start the core application without
+ * depending directly on core transport and protocol packages. The modules share only
  * {@link ApplicationStarter#start(Settings)}.</p>
  */
 public final class TitanBootstrap {

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/environment/YamlConfigurationInitializer.java
@@ -49,8 +49,8 @@ import org.yaml.snakeyaml.constructor.Constructor;
  *
  * <p>The loader binds YAML into {@link RootYamlProperty} using
  * {@link RelaxedBindingUtils}, then maps server and process-wide configuration
- * into {@link Settings}. Keeping the mapping step explicit makes it clear where
- * defaults and validation move from parser DTOs into runtime records.</p>
+ * into {@link Settings}. Runtime records apply defaults and validation during
+ * this mapping step.</p>
  *
  * <pre>{@code
  * titan-env.yml

--- a/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/package-info.java
+++ b/bootstrap/src/main/java/org/traffichunter/titan/bootstrap/package-info.java
@@ -1,11 +1,11 @@
 /**
  * Titan process bootstrap and runtime settings model.
  *
- * <p>The bootstrap module is intentionally small. It owns process startup,
- * environment loading, and shutdown hook registration, then hands the resolved
+ * <p>This module handles process startup, environment loading, and shutdown
+ * hook registration, then passes the resolved
  * {@link org.traffichunter.titan.bootstrap.Settings} to the core application.
- * Core server construction stays outside this module to avoid coupling the
- * command-line entry point to transport and protocol implementations.</p>
+ * The core module constructs servers, so the command-line entry point does not
+ * depend on transport or protocol implementations.</p>
  *
  * <pre>{@code
  * Titan.main

--- a/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
+++ b/core/src/main/java/org/traffichunter/titan/core/TitanApplication.java
@@ -41,16 +41,13 @@ import org.traffichunter.titan.core.spi.RuntimeLauncher;
 /**
  * Core runtime entry point invoked by {@link org.traffichunter.titan.bootstrap.TitanBootstrap}.
  *
- * <p>{@code TitanApplication} is the first core class reached after bootstrap
- * has loaded and normalized external configuration. Bootstrap calls this class
- * through the narrow {@link ApplicationStarter} contract so the startup module
- * does not need a compile-time dependency on transport, protocol, or fanout
- * implementations.</p>
+ * <p>Bootstrap calls {@code TitanApplication} after loading and normalizing external configuration.
+ * The {@link ApplicationStarter} contract lets bootstrap start the core runtime without
+ * compile-time dependencies on transport, protocol, or fanout implementations.</p>
  *
- * <p>For each configured server, a transport/protocol pair is resolved by SPI
- * providers, optional fanout behavior is installed by matching launchers, and
- * the resulting managed server is started and registered for process shutdown
- * cleanup.</p>
+ * <p>For each configured server, SPI providers resolve its transport and protocol.
+ * Matching launchers install optional fanout support. The application then starts
+ * the managed server and registers it for cleanup on process shutdown.</p>
  */
 @NullMarked
 @SuppressWarnings("unused")

--- a/core/src/main/java/org/traffichunter/titan/core/channel/AbstractLinkedHandlerChain.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/AbstractLinkedHandlerChain.java
@@ -32,13 +32,12 @@ import java.util.function.Predicate;
 /**
  * Base implementation for handler chains backed by a singly linked list.
  *
- * <p>The supplied head is a sentinel node and is never exposed by iteration. Keeping a sentinel
- * makes first insertion and removal uniform, while the cached tail keeps append operations
- * constant-time. Subclasses remain responsible for wrapping domain handlers in nodes and for
- * defining how execution enters and advances through those nodes.</p>
+ * <p>Iteration skips the supplied sentinel head. The sentinel removes special cases when
+ * inserting or removing the first handler; the cached tail makes appends constant-time.
+ * Subclasses wrap handlers in nodes and define how execution starts and moves between nodes.</p>
  *
- * <p>Structural operations are intentionally unsynchronized. Channel chains are expected to be
- * configured before use or mutated only by their owning event loop. Dispatch chains follow the
+ * <p>Changes to the links are unsynchronized. Channel chains should be configured before use
+ * or changed only by their owning event loop. Dispatch chains follow the
  * same rule unless an external synchronization policy is provided.</p>
  *
  * <p>{@link #clear()} detaches all user nodes and restores the sentinel as the tail. It only

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelDuplexHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelDuplexHandler.java
@@ -26,14 +26,12 @@ package org.traffichunter.titan.core.channel;
 /**
  * Handles both inbound and outbound events for a channel.
  *
- * <p>A duplex handler represents one logical position in the channel pipeline. Inbound events
+ * <p>A duplex handler occupies one logical position in the channel pipeline. Inbound events
  * flow from the transport toward the application, while outbound events flow from the
- * application toward the transport. Implementations may therefore share state across both
- * directions, as required by protocols such as TLS.</p>
+ * application toward the transport. Both directions can share state, as TLS requires.</p>
  *
- * <p>This interface describes bidirectional handler capability. It does not itself provide
- * thread safety or guarantee concurrent execution; handlers follow the channel event-loop
- * execution model.</p>
+ * <p>Handlers run on the channel event loop. Implementing both directions does not make a handler
+ * thread-safe or make its callbacks run concurrently.</p>
  *
  * @author yun
  */

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandler.java
@@ -3,15 +3,15 @@ package org.traffichunter.titan.core.channel;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * Handler for channel events flowing from transport I/O toward protocol/application code.
+ * Handles channel events from transport I/O before they reach protocol or application code.
  *
  * <p>Implementations receive a chain context and may call the matching {@code spark*} method
- * to pass the event to the next inbound handler. Not forwarding an event is a valid
- * short-circuiting operation, but a handler that keeps a read buffer must retain and eventually
+ * to pass the event to the next inbound handler. A handler may stop forwarding an event,
+ * but one that keeps a read buffer must retain and eventually
  * release it according to the buffer ownership policy.</p>
  *
- * <p>Callbacks run under the channel event-loop execution model. Implementations must avoid
- * blocking work and should preserve event ordering when asynchronous work is unavoidable.</p>
+ * <p>Callbacks run on the channel event loop and must not block. Asynchronous work should
+ * preserve event order.</p>
  *
  * @author yun
  */

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelInBoundHandlerChainImpl.java
@@ -33,15 +33,13 @@ import java.util.function.Consumer;
 /**
  * Linked inbound chain owned by a {@link ChannelHandlerChain}.
  *
- * <p>The chain uses a no-op sentinel head so insertion and removal do not require special handling
- * for the first user handler. Each node serves both as the holder of a
- * {@link ChannelInBoundHandler} and as the continuation passed to that handler. Consequently, a
- * handler invoking a {@code spark*} method advances exactly one position and cannot accidentally
- * restart the full channel pipeline.</p>
+ * <p>A no-op sentinel head removes special cases when inserting or removing the first handler.
+ * Each node holds a {@link ChannelInBoundHandler} and provides the continuation passed to it.
+ * Calling a {@code spark*} method advances to the next handler without restarting the pipeline.</p>
  *
  * <p>Connection, read, and exception events preserve handler order. When a read reaches the
- * terminal node without being consumed, the chain releases the buffer because no downstream owner
- * exists. A handler that terminates propagation earlier is responsible for any buffer it retains
+ * terminal node without being consumed, the chain releases the buffer. A handler that stops
+ * propagation earlier is responsible for any buffer it retains
  * or consumes.</p>
  *
  * <p>This implementation is not synchronized. Registration and removal must happen before

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandler.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandler.java
@@ -10,8 +10,7 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  * position, preventing earlier encoders from running again. A handler that intentionally stops a
  * write or replaces its input must follow the channel buffer ownership policy.</p>
  *
- * <p>Callbacks run under the channel event-loop execution model and must not perform blocking
- * work.</p>
+ * <p>Callbacks run on the channel event loop and must not block.</p>
  *
  * @author yun
  */

--- a/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/ChannelOutBoundHandlerChainImpl.java
@@ -34,12 +34,12 @@ import java.util.function.Consumer;
  * Linked outbound chain owned by a {@link ChannelHandlerChain}.
  *
  * <p>Writes enter through a no-op sentinel head and visit handlers in chain order. Each node is the
- * continuation for the handler stored immediately after it, which ensures that forwarding resumes
- * from the current position instead of reapplying earlier encoders.</p>
+ * continuation for the handler stored immediately after it. Forwarding resumes from the current
+ * position without running earlier encoders again.</p>
  *
  * <p>At the terminal node, the resulting buffer is written through {@link NetChannel.Internal}.
- * This raw write is intentional: entering the public channel write API would recurse through the
- * same outbound handlers. If the raw write fails synchronously before ownership is transferred,
+ * Calling the public channel write API here would run the same outbound handlers again.
+ * If the raw write fails synchronously before ownership is transferred,
  * the terminal node releases the buffer and rethrows the failure.</p>
  *
  * <p>This implementation is not synchronized. Registration and removal must happen before

--- a/core/src/main/java/org/traffichunter/titan/core/channel/LinkedNode.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/LinkedNode.java
@@ -26,15 +26,14 @@ package org.traffichunter.titan.core.channel;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Structural contract for a node in a singly linked handler chain.
+ * Node in a singly linked handler chain.
  *
- * <p>The self-referential type keeps links strongly typed for each concrete chain and avoids
- * exposing handler-specific state to the common linked-list implementation. A {@code null} next
- * node marks the end of the chain.</p>
+ * <p>Each link uses the chain's concrete node type. The shared linked-list implementation does
+ * not need access to handler-specific state. A {@code null} next node marks the end of the chain.</p>
  *
- * <p>Implementations are mutable because insertion and removal reconnect adjacent nodes. They are
- * not required to be thread-safe; a chain should be assembled before it becomes concurrently
- * visible, or mutations must be confined to its owning event loop.</p>
+ * <p>Insertion and removal change links between adjacent nodes. Implementations need not be
+ * thread-safe. Assemble a chain before sharing it across threads, or change it only on its
+ * owning event loop.</p>
  *
  * @param <NODE> concrete node type
  *

--- a/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/NetChannel.java
@@ -54,13 +54,12 @@ public interface NetChannel extends Channel {
     ChannelPromise connect(String host, int port, long timeOut, TimeUnit timeUnit);
 
     /**
-     * Returns raw transport operations intended for Titan's internal channel machinery.
+     * Returns raw transport operations for use inside Titan.
      *
      * <p>Internal operations bypass the channel pipeline. They are used by I/O event loops,
      * pipeline terminals, and protocol handlers that already hold transport-ready bytes, such
-     * as an encoded WebSocket frame or encrypted TLS record. This distinction is independent
-     * of scheduling: an internal operation is not the synchronous counterpart of a public
-     * channel operation.</p>
+     * as an encoded WebSocket frame or encrypted TLS record. Bypassing the pipeline does not
+     * imply synchronous execution; scheduling is a separate concern.</p>
      */
     Internal internal();
 

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/Buffer.java
@@ -32,8 +32,8 @@ import org.traffichunter.titan.core.util.Clearable;
 /**
  * Reference-counted byte buffer used inside Titan codecs and transports.
  *
- * <p>{@code Buffer} wraps Netty's {@link ByteBuf} while keeping the rest of the codebase
- * independent from direct Netty APIs. It preserves the familiar reader/writer index model:
+ * <p>{@code Buffer} wraps Netty's {@link ByteBuf}, so other Titan code can use buffers without
+ * calling Netty APIs directly. It uses separate reader and writer indexes:
  * read operations consume or inspect readable bytes, and {@code accumulate*} operations append
  * bytes at the writer index.</p>
  *

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocator.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/BufferAllocator.java
@@ -32,8 +32,8 @@ import java.nio.charset.Charset;
  * direct implementations use pooled Netty storage, so every returned buffer must be released or
  * transferred to another owner.</p>
  *
- * <p>Heap buffers are intended for short-lived codec and protocol work. Direct buffers are
- * intended for native transport boundaries such as socket reads and TLS processing. Long-lived
+ * <p>Use heap buffers for short-lived codec and protocol work, and direct buffers for socket
+ * reads and TLS processing. Long-lived
  * message and queue data should use byte arrays instead of this API.</p>
  *
  * @author yun

--- a/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/buffer/InternalBuffer.java
@@ -34,10 +34,9 @@ import org.traffichunter.titan.core.util.Assert;
 /**
  * Internal {@link Buffer} wrapper backed by a Netty {@link ByteBuf}.
  *
- * <p>This class does not choose an initial allocation policy. {@link BufferAllocator}
- * implementations create the underlying storage and this wrapper delegates primitive access,
- * reader/writer indexes, slicing, copying and reference counting to it. Internal growth preserves
- * the current buffer's heap or direct memory type.</p>
+ * <p>{@link BufferAllocator} implementations choose and allocate the underlying storage.
+ * This wrapper delegates primitive access, reader/writer indexes, slicing, copying, and reference
+ * counting to that storage. Growing a buffer preserves its heap or direct memory type.</p>
  *
  * <p>The class is package-private so callers cannot bypass {@link Buffer#heap()} and
  * {@link Buffer#direct()} when creating buffers.</p>

--- a/core/src/main/java/org/traffichunter/titan/core/util/concurrent/PromiseImpl.java
+++ b/core/src/main/java/org/traffichunter/titan/core/util/concurrent/PromiseImpl.java
@@ -37,9 +37,9 @@ import org.traffichunter.titan.core.util.Assert;
 /**
  * Default {@link Promise} implementation.
  *
- * <p>The implementation is synchronized around completion state and waiters, but listener
- * execution stays on the owning {@link EventExecutorService}. Rejected notifications are logged
- * without running callbacks on the caller thread or changing the completed result. Owners must
+ * <p>Synchronization protects completion state and waiters. Listeners run on the owning
+ * {@link EventExecutorService}. If it rejects a notification, the promise logs the rejection,
+ * leaves the completed result unchanged, and does not run callbacks on the caller thread. Owners must
  * complete pending promises and drain their notifications before shutting down the executor.</p>
  *
  * @author yungwang-o

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/AbstractExecutorDispatchGateway.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/AbstractExecutorDispatchGateway.java
@@ -38,15 +38,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Executor-backed {@link DispatchGateway} facade shared by platform and virtual-thread variants.
+ * Base {@link DispatchGateway} for platform and virtual-thread executors.
  *
- * <p>The gateway owns the executor and the public lifecycle, while concrete dispatch work belongs
- * to the handlers. {@link RouteDispatchChainHandler} admits messages to destination queues and
- * {@link FanoutDispatchChainHandler} owns destination consumers and fanout lifecycle. Optional
- * handlers run between those two boundaries.</p>
+ * <p>The gateway owns the executor and manages startup and shutdown. Its handlers do the dispatch
+ * work: {@link RouteDispatchChainHandler} admits messages to destination queues, and
+ * {@link FanoutDispatchChainHandler} manages destination consumers and fanout. Custom handlers
+ * run between them.</p>
  *
- * <p>Queue deletion delegates to the terminal fanout handler so consumer state remains within its
- * owner. Queue creation remains a direct dispatcher registry operation.</p>
+ * <p>The fanout handler deletes queues and manages their consumers. Queue creation uses the
+ * dispatcher registry directly.</p>
  *
  * <pre>{@code
  * sparkDispatch(message)

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChainHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchChainHandler.java
@@ -24,15 +24,13 @@ THE SOFTWARE.
 package org.traffichunter.titan.dispatch;
 
 /**
- * Handles one ordered step in the message dispatch lifecycle.
+ * Handles one step in message dispatch.
  *
- * <p>The handler receives the mutable {@link DispatchContext} and a continuation
- * representing the remaining chain. It must invoke
- * {@link DispatchChain#next(DispatchContext)} to propagate the operation. Not
- * invoking the continuation is an intentional short circuit.</p>
+ * <p>The handler receives a mutable {@link DispatchContext} and the remaining chain.
+ * Call {@link DispatchChain#next(DispatchContext)} to continue dispatch, or return
+ * the supplied chain without calling it to stop.</p>
  *
- * <p>Handlers run sequentially on the dispatch executor selected by the gateway. A handler may
- * stop propagation by returning the supplied continuation without invoking it.</p>
+ * <p>Handlers run sequentially on the dispatch executor selected by the gateway.</p>
  *
  * @author yun
  */

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchGateway.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchGateway.java
@@ -33,11 +33,10 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.dispatch.exporter.DispatchExporter;
 
 /**
- * Asynchronous ingress and routing facade for fanout delivery.
+ * Starts asynchronous message dispatch for fanout delivery.
  *
- * <p>The gateway is the public entry point for one message dispatch lifecycle. Dispatching starts
- * the configured handler chain; routing and fanout remain internal handler responsibilities. The
- * returned future represents completion of that chain, not remote protocol acknowledgement from
+ * <p>Each dispatch starts the configured handler chain. Its handlers perform routing and fanout.
+ * The returned future completes when the chain finishes, not when acknowledgements arrive from
  * every subscribed client.</p>
  *
  * @author yungwang-o

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchHandlerChain.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatchHandlerChain.java
@@ -35,18 +35,17 @@ import org.traffichunter.titan.core.channel.LinkedNode;
 /**
  * Asynchronous linked handler chain for message dispatch work.
  *
- * <p>The gateway normally assembles routing first, optional user handlers in the middle, and
- * fanout activation last. This permits cross-cutting stages such as validation, persistence, or
- * metrics to participate without coupling them directly to the gateway. Handler order is
- * significant because each stage observes mutations made by all preceding stages.</p>
+ * <p>The gateway normally places routing first, custom handlers in the middle, and fanout
+ * activation last. Custom handlers can validate, persist, or measure messages without changes
+ * to the gateway. Each handler sees the context changes made by earlier handlers.</p>
  *
  * <p>Starting the chain schedules the complete traversal on the configured {@link Executor}.
  * Each handler decides whether to continue by invoking its supplied {@link DispatchChain}. The
  * future returned to the caller completes when traversal finishes or a handler throws.</p>
  *
- * <p>A no-op sentinel head is excluded from iteration. The chain only manages structure and
- * propagation; lifecycle ownership remains with the component that creates a handler. Structural
- * mutation is unsynchronized and should finish before dispatch begins.</p>
+ * <p>Iteration skips the no-op sentinel head. The chain manages links and calls between handlers;
+ * the component that creates a handler manages its lifecycle. Changes to the links are
+ * unsynchronized and should finish before dispatch begins.</p>
  *
  * @author yun
  */

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatcherQueueManager.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/DispatcherQueueManager.java
@@ -3,13 +3,12 @@ package org.traffichunter.titan.dispatch;
 import org.traffichunter.titan.core.util.Destination;
 
 /**
- * Management boundary for dispatcher queues owned by a running transport or
+ * Creates and deletes dispatcher queues owned by a running transport or
  * fanout component.
  *
- * <p>This interface is intentionally narrower than {@link Dispatcher}. It is
- * used by operational surfaces, such as the monitor HTTP API, when they need to
- * create or remove queues without depending on the concrete fanout
- * implementation.</p>
+ * <p>This interface provides a smaller set of operations than {@link Dispatcher}.
+ * Management tools such as the monitor HTTP API use it to create or remove queues
+ * without depending on a specific fanout implementation.</p>
  *
  * @author yungwang-o
  */

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompSendToFanoutHandler.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/StompSendToFanoutHandler.java
@@ -44,11 +44,9 @@ import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 /**
  * Converts inbound STOMP {@code SEND} frames into fanout messages.
  *
- * <p>This handler is deliberately narrow. It validates the required STOMP
- * destination header, maps the frame body into Titan's internal {@link Message}
- * type, and delegates routing to {@link DispatchGateway}. It does not write
- * directly to subscribers; the exporter layer owns that protocol-specific
- * delivery step.</p>
+ * <p>Validates the required destination header, converts the frame body to a
+ * Titan {@link Message}, and passes it to {@link DispatchGateway} for routing.
+ * Exporters handle protocol-specific writes to subscribers.</p>
  */
 public final class StompSendToFanoutHandler implements StompServerCommandHandler {
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/DispatchExporter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/DispatchExporter.java
@@ -31,7 +31,7 @@ import org.traffichunter.titan.core.util.inet.Frame;
 import org.traffichunter.titan.dispatch.AggregationResult;
 
 /**
- * Protocol boundary for writing a fanout payload to subscribed clients.
+ * Writes a fanout payload to subscribed clients using their protocol.
  *
  * <p>The gateway calls exporters after a message has been routed to a
  * destination queue. Implementations should find the currently eligible

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/TcpDispatchExporter.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/TcpDispatchExporter.java
@@ -36,10 +36,9 @@ import java.util.List;
  * Dispatch exporter that writes raw payload buffers to every active TCP child
  * channel owned by an {@link InetServer}.
  *
- * <p>This exporter is intentionally transport-level. It does not inspect
- * protocol subscriptions; all active child channels are considered eligible
- * consumers. Use protocol-aware exporters, such as {@link StompDispatchExporter},
- * when delivery must be scoped by session subscription state.</p>
+ * <p>Every active child channel receives the payload, regardless of protocol subscriptions.
+ * Use a protocol-aware exporter such as {@link StompDispatchExporter} to send only to
+ * channels with matching subscriptions.</p>
  */
 public class TcpDispatchExporter implements DispatchExporter {
 

--- a/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/package-info.java
+++ b/dispatch/src/main/java/org/traffichunter/titan/dispatch/exporter/package-info.java
@@ -1,9 +1,8 @@
 /**
  * Protocol-specific fanout exporters.
  *
- * <p>An exporter is the final delivery boundary of fanout. The gateway has
- * already selected a destination and dequeued a message; the exporter converts
- * that message into the protocol surface required by currently connected
+ * <p>Exporters perform the final step of fanout. After destination selection and
+ * dequeueing, an exporter converts the message to the protocol used by connected
  * consumers.</p>
  *
  * <p>Exporter implementations should copy or retain payload buffers according

--- a/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/MetadataCodec.java
+++ b/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/MetadataCodec.java
@@ -31,7 +31,7 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
 /**
  * Codec for Titan AOF metadata records.
  *
- * <p>The v1 layout is big-endian and intentionally self-delimiting:</p>
+ * <p>The v1 format uses big-endian byte order. Its length fields delimit each record:</p>
  *
  * <pre>
  * int    magic

--- a/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/package-info.java
+++ b/incubator/src/main/java/org/traffichunter/titan/incubator/resilience/backup/package-info.java
@@ -1,9 +1,9 @@
 /**
  * Append-only backup support for Titan durability.
  *
- * <p>The package contains the first backup log foundation: binary record metadata, record codec,
- * append/replay file access, fsync policy, and truncated-tail recovery policy. Queue restore,
- * rewrite, manifest, and snapshot integration are intentionally left to later layers.</p>
+ * <p>Contains binary record metadata, a record codec, file append and replay operations,
+ * fsync policies, and truncated-tail recovery policies. Other layers are responsible for
+ * queue restore, rewrite, manifest, and snapshot integration.</p>
  *
  * @author yun
  */

--- a/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringQueueServlet.java
+++ b/monitor/src/main/java/org/traffichunter/titan/monitor/http/MonitoringQueueServlet.java
@@ -19,11 +19,9 @@ import org.traffichunter.titan.monitor.model.QueueSnapshot;
 /**
  * HTTP endpoint for dispatcher queue inspection and management.
  *
- * <p>Read operations follow the monitor authorization policy. Mutating
- * operations are stricter: they require a configured monitor token and a valid
- * bearer token on the request. This prevents queue deletion from being exposed
- * accidentally when the monitor server is started without authentication for
- * local development.</p>
+ * <p>Read operations follow the monitor authorization policy. Changes require both
+ * a configured monitor token and a valid bearer token in the request. Queue deletion
+ * is therefore unavailable when a local development server runs without authentication.</p>
  *
  * @author yungwang-o
  */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/ClientConfiguration.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/ClientConfiguration.java
@@ -34,12 +34,11 @@ import org.traffichunter.titan.core.transport.option.InetClientOption;
 import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
 
 /**
- * Immutable configuration shared by a {@link TitanClient} facade and its client driver.
+ * Immutable configuration shared by a {@link TitanClient} and its driver.
  *
- * <p>The public {@link TitanClient.Builder} is the preferred configuration entry point. This
- * record is also exposed for driver implementations and integrations that need to assemble a
- * client explicitly. The compact constructor supplies defaults for omitted optional values and
- * validates values that would make a connection attempt invalid.</p>
+ * <p>Use {@link TitanClient.Builder} to configure a client. Drivers and integrations can also
+ * construct this record directly. Its compact constructor supplies defaults for omitted
+ * optional values and checks that the configuration is valid for a connection attempt.</p>
  *
  * @param host remote server host used by the transport
  * @param port remote server port

--- a/titan-client/src/main/java/org/traffichunter/titan/client/ClientDriver.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/ClientDriver.java
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Common lifecycle contract for a client runtime implementation.
  *
- * <p>A driver owns transport-specific resources and supplies the serial {@link Worker} used by
- * the facade to coordinate mutable client state. Protocol-specific drivers extend this contract
- * with their connection operation while keeping native runtime types out of {@link TitanClient}.</p>
+ * <p>A driver owns transport-specific resources and supplies a {@link Worker} that processes
+ * client state changes serially. Protocol-specific drivers add connection operations without
+ * adding native runtime types to {@link TitanClient}.</p>
  *
  * <p>Implementations must only close resources they created. A runtime supplied by the caller
  * remains caller-owned unless the concrete driver explicitly documents otherwise.</p>
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 public interface ClientDriver {
 
     /**
-     * Returns the stable implementation name exposed by the client facade.
+     * Returns the stable implementation name reported by the client.
      *
      * @return implementation name
      */
@@ -57,7 +57,7 @@ public interface ClientDriver {
     void start();
 
     /**
-     * Returns the serial execution context used to coordinate facade state and callbacks.
+     * Returns the worker that processes client state changes and callbacks serially.
      *
      * @return driver-owned worker
      */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/DefaultTitanClient.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/DefaultTitanClient.java
@@ -45,12 +45,12 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * Default stateful implementation of the transport-neutral {@link TitanClient} facade.
+ * Default {@link TitanClient} implementation, responsible for client state.
  *
- * <p>This class owns the logical client lifecycle, delegates each connection attempt to a
- * {@link StompClientDriver}, and exposes the resulting physical connection through one stable
- * public API. It also installs user callbacks on every new connection and starts the configured
- * retry policy after an unexpected close or connection drop.</p>
+ * <p>It manages the client lifecycle and delegates connection attempts to a
+ * {@link StompClientDriver}. The public API stays the same when the physical connection changes.
+ * Each new connection receives the user callbacks. An unexpected close or connection drop
+ * starts retries according to the configured policy.</p>
  *
  * <p>An explicit {@link #disconnect()} changes the lifecycle state before closing the physical
  * connection, so it does not trigger reconnect. {@link #shutdown(long, TimeUnit)} additionally
@@ -78,7 +78,7 @@ public final class DefaultTitanClient implements TitanClient {
     private volatile Handler<Throwable> exceptionHandler = ignored -> {};
 
     /**
-     * Creates a client facade for the supplied transport driver.
+     * Creates a client for the supplied transport driver.
      *
      * <p>The driver is not started by this constructor. Call {@link #start()} before
      * {@link #connect()}.</p>
@@ -97,7 +97,7 @@ public final class DefaultTitanClient implements TitanClient {
     }
 
     /**
-     * Creates a client facade using the worker supplied by the driver.
+     * Creates a client using the worker supplied by the driver.
      *
      * @param driver driver responsible for runtime, worker, and physical connections
      */
@@ -455,8 +455,8 @@ public final class DefaultTitanClient implements TitanClient {
     /**
      * Moves an active client back to connecting and starts one retry sequence.
      *
-     * <p>Both close and connection-drop callbacks may describe the same transport failure. The
-     * status transition ensures only the first callback creates reconnect work.</p>
+     * <p>Close and connection-drop callbacks may report the same failure. Only the first callback
+     * that changes the status starts a reconnect attempt.</p>
      */
     private void handleConnectionLoss() {
         if (!status.compareAndSet(Status.CONNECTED, Status.CONNECTING)) {
@@ -477,10 +477,10 @@ public final class DefaultTitanClient implements TitanClient {
     /**
      * Performs one reconnect attempt on the retry executor.
      *
-     * <p>The replacement connection is bound first, then a snapshot of logical subscriptions is
-     * restored within one shared timeout. The client becomes connected only after every restore
-     * succeeds and the replacement connection is still active. Throwing keeps the retry sequence
-     * alive; a normal return ends the current sequence.</p>
+     * <p>Binds the replacement connection, then restores a snapshot of logical subscriptions
+     * within one shared timeout. The client becomes connected only after every subscription is
+     * restored and the replacement connection is still active. An exception triggers another
+     * retry; a normal return ends the current retry sequence.</p>
      */
     private void reconnect() {
         if (status.get() != Status.CONNECTING) {

--- a/titan-client/src/main/java/org/traffichunter/titan/client/Subscription.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/Subscription.java
@@ -31,9 +31,9 @@ import org.traffichunter.titan.core.util.Handler;
 /**
  * Logical subscription retained independently of one physical STOMP connection.
  *
- * <p>The client stores this metadata after a SUBSCRIBE operation succeeds. When a replacement
- * connection is established, the destination, headers, and frame handler are reused to restore
- * the subscription before the client returns to the connected state.</p>
+ * <p>The client stores this metadata after SUBSCRIBE succeeds. On a replacement connection,
+ * it reuses the destination, headers, and frame handler to restore the subscription before
+ * returning to the connected state.</p>
  *
  * @param id stable subscription identifier used for unsubscribe and reconnect
  * @param destination logical destination to restore

--- a/titan-client/src/main/java/org/traffichunter/titan/client/SubscriptionManager.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/SubscriptionManager.java
@@ -30,11 +30,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Thread-safe registry of logical subscriptions owned by one client facade.
+ * Thread-safe registry of logical subscriptions for one client.
  *
- * <p>The registry is separate from transport-native subscription registries because those belong
- * to one physical connection and disappear when that connection is replaced. Snapshot reads are
- * shallow and never expose the mutable registry itself.</p>
+ * <p>Transport subscription registries belong to one physical connection and disappear when
+ * that connection is replaced. This registry stores logical subscriptions separately.
+ * Snapshots are shallow copies; callers do not receive the mutable registry itself.</p>
  *
  * @author yun
  */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanClient.java
@@ -40,12 +40,12 @@ import org.traffichunter.titan.core.util.Handler;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
 /**
- * Transport-neutral public facade for Titan messaging clients.
+ * Public messaging API shared by Titan client implementations.
  *
- * <p>The nested builder is the preferred configuration surface and hides the selected networking
- * implementation from application code. Advanced integrations may provide a
- * {@link StompClientDriver} directly to {@link DefaultTitanClient}, while normal users interact
- * only with this interface and transport-neutral {@link StompFrames} values.</p>
+ * <p>Use the nested builder to configure a client without depending on its networking
+ * implementation. Integrations that supply their own {@link StompClientDriver} can pass it
+ * directly to {@link DefaultTitanClient}. Application code normally uses this interface and
+ * transport-neutral {@link StompFrames} values.</p>
  *
  * @author yun
  */
@@ -73,7 +73,7 @@ public interface TitanClient {
     /**
      * Opens the configured STOMP connection.
      *
-     * @return a future completed with this facade after STOMP negotiation succeeds
+     * @return a future completed with this client after STOMP negotiation succeeds
      */
     CompletableFuture<TitanClient> connect();
 
@@ -227,7 +227,7 @@ public interface TitanClient {
     TitanClient exceptionHandler(Handler<Throwable> handler);
 
     /**
-     * Returns whether the facade currently owns an active STOMP connection.
+     * Returns whether this client currently owns an active STOMP connection.
      *
      * @return {@code true} when messaging operations can be issued
      */
@@ -378,7 +378,7 @@ public interface TitanClient {
         Builder tls(TlsContext context);
 
         /**
-         * Builds a new client facade without starting its runtime.
+         * Builds a new client without starting its runtime.
          *
          * @return configured Titan client
          */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanWorker.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanWorker.java
@@ -32,8 +32,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * {@link Worker} backed by one Titan {@link EventLoop}.
  *
- * <p>The selected event loop serializes client state callbacks with native scheduled tasks while
- * adapting Titan promises to {@link CompletableFuture} for the facade.</p>
+ * <p>Client state callbacks and native scheduled tasks run on the selected event loop.
+ * This adapter converts Titan promises to {@link CompletableFuture} for the client.</p>
  *
  * @author yun
  */

--- a/titan-client/src/main/java/org/traffichunter/titan/client/VertxStompClientDriver.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/VertxStompClientDriver.java
@@ -57,8 +57,8 @@ import java.util.concurrent.TimeoutException;
  * {@link VertxStompConnection}; lifecycle state and reconnect scheduling remain in
  * {@link DefaultTitanClient}.</p>
  *
- * <p>The no-argument-runtime constructor creates and owns a Vert.x instance. Constructors and
- * factories receiving an existing Vert.x object preserve the caller-owned runtime on close.</p>
+ * <p>A constructor that receives no Vert.x runtime creates and owns one. Constructors and
+ * factories that receive an existing runtime leave it open when the driver closes.</p>
  *
  * @deprecated use Titan's native client through {@link TitanClient#builder()}; this driver is
  * retained only for migration compatibility

--- a/titan-client/src/main/java/org/traffichunter/titan/client/Worker.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/Worker.java
@@ -30,12 +30,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * Transport-neutral serial execution context for client state transitions.
+ * Executes client state changes serially, regardless of the transport implementation.
  *
- * <p>Tasks submitted to one worker execute in order on the same logical context. Native Titan
- * workers delegate to an {@code EventLoop}; Vert.x workers delegate to one fixed
- * {@code Context}. This lets reconnect and subscription state use one concurrency model without
- * exposing either runtime through the public client API.</p>
+ * <p>A worker runs submitted tasks in order on the same execution context: an {@code EventLoop}
+ * for Titan or a fixed {@code Context} for Vert.x. Reconnect and subscription state use this
+ * shared execution contract; neither runtime appears in the public client API.</p>
  *
  * <p>Closing a worker prevents further submissions. Ownership of the underlying runtime remains
  * with the driver that supplied the worker.</p>
@@ -53,7 +52,7 @@ public interface Worker extends Executor, AutoCloseable {
     void execute(@NonNull Runnable task);
 
     /**
-     * Schedules a value-producing task and exposes its result as a JDK future.
+     * Schedules a task and returns its result as a JDK future.
      *
      * @param task task to execute
      * @param <T> result type
@@ -64,8 +63,8 @@ public interface Worker extends Executor, AutoCloseable {
     /**
      * Schedules an asynchronous operation and flattens its nested future.
      *
-     * <p>The callable itself executes on this worker. Completion of the returned operation follows
-     * the executor semantics of the future returned by the callable.</p>
+     * <p>The callable runs on this worker. The future it returns determines where the
+     * asynchronous operation completes.</p>
      *
      * @param task asynchronous operation supplier
      * @param <T> result type

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/autoconfigure/TitanStompClientAutoConfiguration.java
@@ -28,10 +28,9 @@ import org.traffichunter.titan.springframework.stomp.core.TitanTemplate;
 /**
  * Autoconfiguration for Titan's Spring STOMP client integration.
  *
- * <p>Spring properties are translated directly into the transport-neutral
- * {@link TitanClient.Builder}; no low-level STOMP option bean is exposed. Native clients create
- * the configured number of I/O workers, while Vert.x clients keep event-loop ownership
- * inside Vert.x. A user-defined {@link TitanClient} bean replaces this default completely.</p>
+ * <p>Maps Spring properties to {@link TitanClient.Builder} without exposing a low-level STOMP
+ * option bean. Native clients create the configured number of I/O workers; Vert.x manages
+ * its own event loops. A user-defined {@link TitanClient} bean replaces the default client.</p>
  *
  * @author yun
  */

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanClientManager.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanClientManager.java
@@ -14,9 +14,9 @@ import java.util.concurrent.TimeUnit;
  * Starts and stops the underlying client with the application context and
  * resolves active STOMP connections for template and listener use.
  *
- * <p>Lifecycle state is owned entirely by the underlying {@link TitanClient}
+ * <p>The underlying {@link TitanClient} owns lifecycle state
  * ({@link TitanClient#isStarted()} / {@link TitanClient#isShutdown()}); this
- * adapter keeps no parallel status to avoid two sources of truth that can drift.
+ * adapter does not maintain a separate copy of that state.
  *
  * @author yun
  */

--- a/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
+++ b/titan-spring-client/src/main/java/org/traffichunter/titan/springframework/stomp/core/TitanTemplate.java
@@ -16,9 +16,9 @@ import org.traffichunter.titan.core.util.buffer.Buffer;
  * Delegates every operation to the active {@link TitanClient} resolved through
  * {@link TitanClientManager}, connecting on demand when no connection exists yet.
  *
- * <p>The {@link StompOperations} contract is asynchronous and returns {@link CompletableFuture}
- * results. Blocking convenience overloads are provided for the common send and
- * subscribe calls and wait up to {@link TitanClientManager#connectTimeoutMillis()}.
+ * <p>{@link StompOperations} methods return {@link CompletableFuture} results.
+ * The blocking send and subscribe overloads wait up to
+ * {@link TitanClientManager#connectTimeoutMillis()}.
  *
  * @author yun
  */

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompSessionOption.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/transport/stomp/option/StompSessionOption.java
@@ -28,9 +28,9 @@ import org.traffichunter.titan.core.codec.stomp.StompVersion;
 /**
  * Configures STOMP framing and session negotiation independently of a client runtime.
  *
- * <p>The same option can be consumed by outbound client channels and accepted server child
- * channels. It intentionally excludes remote ports, socket options, connection timeouts, and
- * reconnect policies because those values belong to the transport runtime.</p>
+ * <p>Outbound client channels and accepted server child channels can use the same settings.
+ * The transport runtime configures remote ports, socket options, connection timeouts, and
+ * reconnect policies separately.</p>
  *
  * @param login optional CONNECT login header
  * @param passcode optional CONNECT passcode header


### PR DESCRIPTION
## Motivation:

Several comments use long design explanations where a direct description of the behavior would be easier to follow.

## Modification:

Rewrite Javadoc in 43 files across bootstrap, core, dispatch, monitor, titan-client, titan-stomp, titan-spring-client, and incubator. Shorten repetitive explanations while keeping thread constraints, buffer ownership rules, lifecycle behavior, and failure handling details.

Code, licenses, Javadoc links, and examples are unchanged.

## Result:

Comments describe each component more directly without changing runtime behavior.

Validation:
- Javadoc generation passed for all eight modules. Existing missing-description and missing-tag warnings remain.
- Compared source with comments removed to verify that the changes contain no code edits.
- Verified that licenses, Javadoc links, and examples are unchanged.
- `git diff --check` passed.
- Tests were not rerun because this PR changes comments only.