### PR TITLE
Add titan native smoke-test

### DIFF
--- a/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadEventLoop.java
+++ b/core/src/main/java/org/traffichunter/titan/core/channel/SingleThreadEventLoop.java
@@ -274,7 +274,7 @@ public abstract class SingleThreadEventLoop extends AbstractEventLoop {
 
         cancel();
         runAllTasks();
-        if(Time.currentNanos() - shutdownStartNanos > shutdownTimeoutNanos) {
+        if(taskQueue.isEmpty() || Time.currentNanos() - shutdownStartNanos > shutdownTimeoutNanos) {
             return true;
         }
 

--- a/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
+++ b/core/src/main/java/org/traffichunter/titan/core/transport/AbstractTransport.java
@@ -101,10 +101,7 @@ public abstract class AbstractTransport<C extends Channel> {
 
     public void close(long timeout, TimeUnit unit) {
         channelRegistry.forEach(Channel::close);
-
-        if (channelRegistry.isClosed()) {
-            eventLoopGroups.gracefullyShutdown(timeout, unit);
-        }
+        eventLoopGroups.gracefullyShutdown(timeout, unit);
     }
 
     public boolean isClosed() {

--- a/core/src/test/java/org/traffichunter/titan/core/test/implementation/TaskEventLoopTest.java
+++ b/core/src/test/java/org/traffichunter/titan/core/test/implementation/TaskEventLoopTest.java
@@ -257,14 +257,14 @@ class TaskEventLoopTest {
         }
 
         @Test
-        void shouldNotShutdownBeforeGracefulTimeoutTest() {
+        void shutdownWithoutQueuedTasksDoesNotWaitForTimeoutTest() {
             eventLoop.start();
 
             eventLoop.gracefullyShutdown(1, TimeUnit.SECONDS);
 
             Awaitility.await()
                     .atMost(500, TimeUnit.MILLISECONDS)
-                    .untilAsserted(() -> assertFalse(eventLoop.isShutdown()));
+                    .untilAsserted(() -> assertTrue(eventLoop.isShutdown()));
         }
 
         @Test

--- a/smoke-test/smoke-titan/README.md
+++ b/smoke-test/smoke-titan/README.md
@@ -1,0 +1,79 @@
+# Native Client Smoke Tests
+
+These tests build the standalone `titan-server` JAR and run it in a separate JVM
+on a loopback port. This exercises configuration loading, SPI assembly, the
+dispatch runtime, and process shutdown in the same form users run. Tests use
+`TitanClient` for normal traffic and a small TCP peer for incomplete frames and
+a subscriber that stops reading. Docker is not required.
+
+## Run
+
+From the repository root:
+
+```bash
+./gradlew :smoke-test:smoke-titan:test --rerun-tasks
+./gradlew :smoke-test:smoke-spring:test
+```
+
+Run one group with `--tests '*TitanMessagingSmokeTest'`,
+`--tests '*TitanConnectionIsolationSmokeTest'`, or
+`--tests '*TitanLifecycleSmokeTest'`.
+
+The HTML report is in `build/reports/tests/test/index.html` under this module.
+
+## Scenarios
+
+| Group | Checks |
+| --- | --- |
+| Messaging | Concurrent producers and two subscribers; empty, UTF-8, and 48 KiB payloads; line breaks and embedded NUL with explicit content-length; subscription restore after server restart |
+| Connection isolation | Split and coalesced SEND frames; oversized input without a terminator; disconnect during a partial frame; a non-reading subscriber alongside a healthy subscriber |
+| Lifecycle | Explicit disconnect without reconnect; outstanding sends at shutdown; rejection and direct-buffer release after shutdown; packaged process termination |
+
+Messaging and client lifecycle scenarios cover TCP and WebSocket. Socket fault
+injection uses TCP. The slow-consumer scenario runs three times and verifies
+that a non-reading subscriber does not delay a healthy subscriber.
+
+Subscription futures wait for STOMP receipts before tests publish. Tests do not
+retry failed sends to turn a failed delivery into a passing assertion.
+The shutdown scenario permits either success or failure for outstanding sends,
+but requires every future to finish.
+
+Each class runs in a fresh test JVM, and every invocation owns a separate Titan
+process. JUnit timeouts run on a separate thread so a stalled client cannot block
+the runner itself. Thread dumps are enabled on timeout, and failed tests attach
+the standalone process log to the JUnit report.
+
+## Regression Findings
+
+Observed on 2026-09-03, JDK 21.0.11, local checkout based on `a6279425`:
+
+- An oversized unterminated SEND closed the connection without delivering an
+  ERROR frame. The decoder's size exception reached the channel read failure
+  path. STOMP 1.2 recommends ERROR followed by close for size-limit violations.
+- Valid multiline and embedded-NUL payloads were rejected on both TCP and
+  WebSocket. The parser searches for NUL before interpreting content-length and
+  takes the last decoded line as the body. Neither operation preserves an
+  arbitrary message body.
+- Waiting for server event loops to terminate after server shutdown failed.
+  Explicit fixture cleanup must not count as successful transport shutdown.
+- Shutdown stalled during a queued-send run and again during concurrent fanout
+  on a later run. One stack stopped in `FanoutDispatchChainHandler.close()` at
+  `ConcurrentHashMap.clear()`; another waited for the dispatch executor to
+  terminate. The thread
+  dump also showed a dispatch virtual thread waiting for the Trie write lock
+  inside `consumers.computeIfAbsent()`, with other virtual threads waiting for
+  that map entry. A stalled scenario can affect later scenarios in the same
+  class. The exact locking/scheduling cause still needs investigation.
+
+The fixes following that run changed frame parsing to honor content-length,
+send an ERROR before closing an oversized server connection, always request
+shutdown for transport-owned event loops, and register fanout consumers before
+starting their tasks. The complete native smoke suite subsequently passed twice
+in succession.
+
+The regression assertions remain enabled. These tests detect defects; they do
+not establish maximum throughput, absence of all buffer leaks, or long-running
+stability. TLS and cross-machine network failures are outside this set.
+
+Protocol reference: [STOMP 1.2](https://stomp.github.io/stomp-specification-1.2.html),
+especially content-length, frame bodies, and size limits.

--- a/smoke-test/smoke-titan/build.gradle.kts
+++ b/smoke-test/smoke-titan/build.gradle.kts
@@ -1,10 +1,18 @@
 dependencies {
-    testImplementation(project(":core"))
-    testImplementation(project(":titan-stomp"))
     testImplementation(project(":titan-client"))
-    testImplementation(project(":dispatch"))
 }
+
+val titanServerJar = project(":bootstrap").layout.buildDirectory
+    .file("libs/titan-server-${project.version}.jar")
 
 tasks.named("jar") {
     enabled = false
+}
+
+tasks.test {
+    dependsOn(":bootstrap:shadowJar")
+
+    systemProperty("titan.smoke.jar", titanServerJar.get().asFile.absolutePath)
+    forkEvery = 1
+    systemProperty("junit.jupiter.execution.timeout.threaddump.enabled", "true")
 }

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/SmokeStompPeer.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/SmokeStompPeer.java
@@ -1,0 +1,105 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A bounded, text-only STOMP peer for malformed input and stopped-reader scenarios.
+ *
+ * @author yun
+ */
+final class SmokeStompPeer implements AutoCloseable {
+
+    private final Socket socket = new Socket();
+
+    SmokeStompPeer(int port) throws IOException {
+        try {
+            socket.setReceiveBufferSize(1024);
+            socket.setSoTimeout(10_000);
+            socket.setTcpNoDelay(true);
+            socket.connect(new InetSocketAddress("127.0.0.1", port), 10_000);
+            send("CONNECT\naccept-version:1.2\nhost:127.0.0.1\nheart-beat:0,0\n\n\0");
+            String connected = readFrame();
+            if (!connected.startsWith("CONNECTED\n")) {
+                throw new IOException("Expected CONNECTED, received: " + connected);
+            }
+        } catch (IOException error) {
+            try {
+                socket.close();
+            } catch (IOException cleanup) {
+                error.addSuppressed(cleanup);
+            }
+            throw error;
+        }
+    }
+
+    void send(String bytes) throws IOException {
+        socket.getOutputStream().write(bytes.getBytes(StandardCharsets.UTF_8));
+        socket.getOutputStream().flush();
+    }
+
+    String readFrame() throws IOException {
+        ByteArrayOutputStream frame = new ByteArrayOutputStream();
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (frame.size() < 64 * 1024 && System.nanoTime() < deadline) {
+            int value = socket.getInputStream().read();
+            if (value == -1) {
+                throw new EOFException("Connection closed before a complete STOMP frame");
+            }
+            if (value == 0) {
+                return frame.toString(StandardCharsets.UTF_8).replace("\r\n", "\n");
+            }
+            if (frame.size() == 0 && (value == '\n' || value == '\r')) {
+                continue;
+            }
+            frame.write(value);
+        }
+        throw new IOException("STOMP response exceeded the smoke peer byte or time limit");
+    }
+
+    boolean awaitEof() throws IOException {
+        int value;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        do {
+            if (System.nanoTime() >= deadline) {
+                throw new SocketTimeoutException("Connection did not close after ERROR");
+            }
+            value = socket.getInputStream().read();
+        } while (value == '\n' || value == '\r');
+        return value == -1;
+    }
+
+    @Override
+    public void close() throws IOException {
+        socket.close();
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanConnectionIsolationSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanConnectionIsolationSmokeTest.java
@@ -1,0 +1,130 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.traffichunter.titan.client.TitanClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Checks that malformed input and stalled readers remain isolated to their connections.
+ *
+ * @author yun
+ */
+@TitanSmokeTest
+@Timeout(value = 90, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class TitanConnectionIsolationSmokeTest {
+
+    @Test
+    void fragmented_and_coalesced_sends_reach_the_subscriber_once(TitanRuntime runtime) throws Exception {
+        runtime.start(TitanSmokeTransport.TCP);
+        try (SmokeStompPeer producer = new SmokeStompPeer(runtime.port())) {
+            String destination = "/queue/" + UUID.randomUUID();
+            LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+            runtime.client().subscribe(destination, frame ->
+                    messages.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+            producer.send("SEND\ndestination:" + destination + "\n\nfrag");
+            assertThat(messages.poll(200, TimeUnit.MILLISECONDS)).as("incomplete frame").isNull();
+            producer.send("mented\0");
+            assertThat(messages.poll(10, TimeUnit.SECONDS)).isEqualTo("fragmented");
+
+            producer.send("SEND\ndestination:" + destination + "\n\none\0"
+                    + "SEND\ndestination:" + destination + "\n\ntwo\0");
+            String first = messages.poll(10, TimeUnit.SECONDS);
+            String second = messages.poll(10, TimeUnit.SECONDS);
+            assertThat(new String[]{first, second}).containsExactlyInAnyOrder("one", "two");
+            assertThat(messages.poll(200, TimeUnit.MILLISECONDS)).as("duplicate frame").isNull();
+        }
+    }
+
+    @Test
+    void oversized_unterminated_frame_gets_error_and_closes_only_its_connection(TitanRuntime runtime)
+            throws Exception {
+        runtime.start(TitanSmokeTransport.TCP, 512);
+        try (SmokeStompPeer invalid = new SmokeStompPeer(runtime.port())) {
+            String destination = "/queue/" + UUID.randomUUID();
+            TitanClient healthy = runtime.client();
+            LinkedBlockingQueue<String> received = new LinkedBlockingQueue<>();
+            healthy.subscribe(destination, frame ->
+                    received.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+            invalid.send("SEND\ndestination:" + destination + "\n\n" + "x".repeat(1024));
+            assertThat(invalid.readFrame()).startsWith("ERROR\n");
+            assertThat(invalid.awaitEof()).as("oversized sender must be closed").isTrue();
+
+            healthy.send(destination, "still-alive").get(10, TimeUnit.SECONDS);
+            assertThat(received.poll(10, TimeUnit.SECONDS)).isEqualTo("still-alive");
+            assertThat(healthy.isConnected()).isTrue();
+        }
+    }
+
+    @Test
+    void abandoned_partial_frames_do_not_stop_the_shared_event_loop(TitanRuntime runtime) throws Exception {
+        runtime.start(TitanSmokeTransport.TCP);
+        String destination = "/queue/" + UUID.randomUUID();
+        TitanClient healthy = runtime.client();
+        LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        healthy.subscribe(destination, frame ->
+                messages.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+        for (int attempt = 0; attempt < 5; attempt++) {
+            try (SmokeStompPeer abandoned = new SmokeStompPeer(runtime.port())) {
+                abandoned.send("SEND\ndestination:" + destination + "\n\nunfinished");
+            }
+            healthy.send(destination, "marker-" + attempt).get(10, TimeUnit.SECONDS);
+            assertThat(messages.poll(10, TimeUnit.SECONDS)).isEqualTo("marker-" + attempt);
+        }
+    }
+
+    @RepeatedTest(3)
+    void non_reading_subscriber_does_not_prevent_healthy_delivery(TitanRuntime runtime) throws Exception {
+        runtime.start(TitanSmokeTransport.TCP);
+        try (SmokeStompPeer slow = new SmokeStompPeer(runtime.port())) {
+            String destination = "/topic/" + UUID.randomUUID();
+            slow.send("SUBSCRIBE\nid:slow\ndestination:" + destination + "\nack:auto\nreceipt:ready\n\n\0");
+            assertThat(slow.readFrame()).startsWith("RECEIPT\n").contains("receipt-id:ready");
+
+            TitanClient producer = runtime.client();
+            TitanClient healthy = runtime.client();
+            LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+            healthy.subscribe(destination, frame ->
+                    messages.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+            for (int i = 0; i < 512; i++) {
+                String payload = i + ":" + "x".repeat(8 * 1024);
+                producer.send(destination, payload).get(10, TimeUnit.SECONDS);
+                assertThat(messages.poll(10, TimeUnit.SECONDS)).as("healthy delivery %s", i).isEqualTo(payload);
+            }
+            assertThat(healthy.isConnected()).isTrue();
+        }
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanFanoutSmokeTest.java
@@ -23,130 +23,51 @@ THE SOFTWARE.
 */
 package org.traffichunter.titan.smoke.titan;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements.ID;
-
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.traffichunter.titan.core.channel.EventLoopGroups;
+import org.junit.jupiter.api.Timeout;
 import org.traffichunter.titan.client.TitanClient;
-import org.traffichunter.titan.core.transport.stomp.StompServer;
-import org.traffichunter.titan.core.transport.stomp.option.StompServerOption;
-import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
-import org.traffichunter.titan.core.util.buffer.Buffer;
-import org.traffichunter.titan.dispatch.DispatchGateway;
-import org.traffichunter.titan.dispatch.StompSendToFanoutHandler;
-import org.traffichunter.titan.dispatch.exporter.StompDispatchExporter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements.ID;
+
+/**
+ * Verifies that the packaged dispatch runtime fans one message out to every subscriber.
+ *
+ * @author yun
+ */
+@TitanSmokeTest
+@Timeout(value = 30, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
 class TitanFanoutSmokeTest {
 
-    private static final String HOST = "127.0.0.1";
-    private static final String PAYLOAD = "smoke-message";
-    private static final String FANOUT_DESTINATION = "/topic/smoke-titan/fanout";
-    private static final long TIMEOUT_MILLIS = 10_000L;
-
     @Test
-    void producer_send_should_be_received_by_subscribed_consumers() throws Exception {
-        String payload = PAYLOAD + "-fanout";
+    void producer_send_is_received_by_subscribed_consumers(TitanRuntime runtime) throws Exception {
+        runtime.start(TitanSmokeTransport.TCP);
+        String destination = "/topic/smoke-titan/" + UUID.randomUUID();
         CountDownLatch received = new CountDownLatch(2);
         AtomicReference<String> firstPayload = new AtomicReference<>();
         AtomicReference<String> secondPayload = new AtomicReference<>();
 
-        EventLoopGroups serverGroups = EventLoopGroups.group(1, 2);
-        StompServer server = StompServer.open(serverGroups, stompServerOption());
-        DispatchGateway dispatchGateway = DispatchGateway.ofVirtual(new StompDispatchExporter(server.connection()));
-        server.onStomp(handler -> handler.sendHandler(new StompSendToFanoutHandler(dispatchGateway)));
+        TitanClient firstConsumer = runtime.client();
+        TitanClient secondConsumer = runtime.client();
+        firstConsumer.subscribe(destination, Map.of(ID, "smoke-fanout-first"), frame -> {
+            firstPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
+            received.countDown();
+        }).get(10, TimeUnit.SECONDS);
+        secondConsumer.subscribe(destination, Map.of(ID, "smoke-fanout-second"), frame -> {
+            secondPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
+            received.countDown();
+        }).get(10, TimeUnit.SECONDS);
 
-        TitanClient producer = null;
-        TitanClient firstConsumer = null;
-        TitanClient secondConsumer = null;
+        runtime.client().send(destination, "smoke-message").get(10, TimeUnit.SECONDS);
 
-        try {
-            server.start();
-            server.listen(HOST, 0).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-            int port = boundPort(server);
-
-            producer = newStompClient(2, port);
-            firstConsumer = newStompClient(2, port);
-            secondConsumer = newStompClient(2, port);
-
-            producer.start();
-            firstConsumer.start();
-            secondConsumer.start();
-
-            TitanClient producerConnection = connect(producer);
-            TitanClient firstConsumerConnection = connect(firstConsumer);
-            TitanClient secondConsumerConnection = connect(secondConsumer);
-
-            firstConsumerConnection.subscribe(FANOUT_DESTINATION, Map.of(ID, "smoke-fanout-first"), frame -> {
-                firstPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
-                received.countDown();
-            }).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-
-            secondConsumerConnection.subscribe(FANOUT_DESTINATION, Map.of(ID, "smoke-fanout-second"), frame -> {
-                secondPayload.set(new String(frame.body(), StandardCharsets.UTF_8));
-                received.countDown();
-            }).get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-
-            producerConnection.send(FANOUT_DESTINATION, Buffer.heap().alloc(payload))
-                    .get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-
-            assertThat(received.await(10, TimeUnit.SECONDS)).isTrue();
-            assertThat(firstPayload.get()).isEqualTo(payload);
-            assertThat(secondPayload.get()).isEqualTo(payload);
-        } finally {
-            shutdown(secondConsumer);
-            shutdown(firstConsumer);
-            shutdown(producer);
-            dispatchGateway.close();
-            if (server.isStart()) {
-                server.shutdown(10, TimeUnit.SECONDS);
-            }
-        }
-    }
-
-    private static StompServerOption stompServerOption() {
-        return StompServerOption.builder()
-                .heartbeatX(0L)
-                .heartbeatY(0L)
-                .build();
-    }
-
-    private static TitanClient newStompClient(int workers, int port) {
-        return TitanClient.builder()
-                .worker(workers)
-                .host(HOST)
-                .port(port)
-                .session(StompSessionOption.builder()
-                        .heartbeatX(0L)
-                        .heartbeatY(0L)
-                        .build())
-                .build();
-    }
-
-    private static TitanClient connect(TitanClient client) throws Exception {
-        return client.connect()
-                .get(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-    }
-
-    private static int boundPort(StompServer server) {
-        SocketAddress localAddress = server.connection().channel().localAddress();
-        assertThat(localAddress).isInstanceOf(InetSocketAddress.class);
-        Assertions.assertNotNull(localAddress);
-        return ((InetSocketAddress) localAddress).getPort();
-    }
-
-    private static void shutdown(TitanClient client) {
-        if (client != null && client.isStarted()) {
-            client.shutdown(10, TimeUnit.SECONDS);
-        }
+        assertThat(received.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(firstPayload.get()).isEqualTo("smoke-message");
+        assertThat(secondPayload.get()).isEqualTo("smoke-message");
     }
 }

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanLifecycleSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanLifecycleSmokeTest.java
@@ -1,0 +1,119 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.traffichunter.titan.client.TitanClient;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Checks packaged-server and client lifecycle behavior at the process boundary.
+ *
+ * @author yun
+ */
+@TitanSmokeTest
+@Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class TitanLifecycleSmokeTest {
+
+    @Test
+    void packaged_server_process_terminates_on_shutdown(TitanRuntime runtime) throws Exception {
+        runtime.start(TitanSmokeTransport.TCP);
+        runtime.client();
+
+        assertThat(runtime.stop()).as("packaged Titan process must terminate").isTrue();
+        assertThat(runtime.isRunning()).isFalse();
+    }
+
+    @ParameterizedTest(name = "explicit disconnect, transport={0}")
+    @EnumSource(TitanSmokeTransport.class)
+    void explicit_disconnect_does_not_restore_the_connection_after_restart(
+            TitanSmokeTransport transport,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        TitanClient disconnected = runtime.client();
+        disconnected.disconnect().get(10, TimeUnit.SECONDS);
+        assertThat(disconnected.isConnected()).isFalse();
+
+        runtime.restart();
+        TitanClient fresh = runtime.client();
+        String destination = "/queue/" + UUID.randomUUID();
+        LinkedBlockingQueue<String> messages = new LinkedBlockingQueue<>();
+        fresh.subscribe(destination, frame ->
+                messages.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+        fresh.send(destination, "fresh-connection").get(10, TimeUnit.SECONDS);
+
+        assertThat(messages.poll(10, TimeUnit.SECONDS)).isEqualTo("fresh-connection");
+        await().during(600, TimeUnit.MILLISECONDS).atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(disconnected.isConnected()).isFalse());
+    }
+
+    @ParameterizedTest(name = "shutdown with queued sends, transport={0}")
+    @EnumSource(TitanSmokeTransport.class)
+    void shutdown_completes_pending_sends_and_rejects_new_sends(
+            TitanSmokeTransport transport,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        String destination = "/queue/" + UUID.randomUUID();
+        TitanClient producer = runtime.client();
+        TitanClient consumer = runtime.client();
+        LinkedBlockingQueue<String> received = new LinkedBlockingQueue<>();
+        consumer.subscribe(destination, frame ->
+                received.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+        List<CompletableFuture<StompFrames>> sends = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            sends.add(producer.send(destination, "pending-" + i));
+        }
+        producer.shutdown(5, TimeUnit.SECONDS);
+        CompletableFuture.allOf(sends.stream()
+                .map(future -> future.handle((frame, failure) -> null))
+                .toArray(CompletableFuture[]::new)).get(10, TimeUnit.SECONDS);
+        assertThat(producer.isShutdown()).isTrue();
+
+        Buffer rejected = Buffer.direct().alloc("after-shutdown");
+        assertThatThrownBy(() -> producer.send(destination, rejected).get(10, TimeUnit.SECONDS))
+                .isInstanceOf(java.util.concurrent.ExecutionException.class);
+        assertThat(rejected.byteBuf().refCnt()).as("rejected payload reference").isZero();
+
+        runtime.client().send(destination, "healthy-marker").get(10, TimeUnit.SECONDS);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> received.contains("healthy-marker"));
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanMessagingSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanMessagingSmokeTest.java
@@ -1,0 +1,189 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.traffichunter.titan.client.TitanClient;
+import org.traffichunter.titan.core.codec.stomp.StompFrames;
+import org.traffichunter.titan.core.util.buffer.Buffer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements.CONTENT_LENGTH;
+import static org.traffichunter.titan.core.codec.stomp.StompHeaders.Elements.ID;
+
+/**
+ * Exercises packaged Titan messaging through TCP and WebSocket transports.
+ *
+ * @author yun
+ */
+@TitanSmokeTest
+@Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+class TitanMessagingSmokeTest {
+
+    @ParameterizedTest(name = "concurrent fanout, transport={0}")
+    @EnumSource(TitanSmokeTransport.class)
+    void concurrent_producers_deliver_each_message_to_every_subscriber(
+            TitanSmokeTransport transport,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        String destination = "/topic/" + UUID.randomUUID();
+        LinkedBlockingQueue<String> first = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<String> second = new LinkedBlockingQueue<>();
+        runtime.client().subscribe(destination, frame ->
+                first.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+        runtime.client().subscribe(destination, frame ->
+                second.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+
+        List<TitanClient> producers = new ArrayList<>();
+        Set<String> expected = new HashSet<>();
+        for (int producer = 0; producer < 3; producer++) {
+            producers.add(runtime.client());
+            for (int sequence = 0; sequence < 20; sequence++) {
+                expected.add(producer + ":" + sequence);
+            }
+        }
+        try (var executor = java.util.concurrent.Executors.newFixedThreadPool(3)) {
+            List<CompletableFuture<Void>> tasks = new ArrayList<>();
+            for (int producer = 0; producer < producers.size(); producer++) {
+                int id = producer;
+                tasks.add(CompletableFuture.runAsync(() -> {
+                    List<CompletableFuture<StompFrames>> sends = new ArrayList<>();
+                    for (int sequence = 0; sequence < 20; sequence++) {
+                        sends.add(producers.get(id).send(destination, id + ":" + sequence));
+                    }
+                    CompletableFuture.allOf(sends.toArray(CompletableFuture[]::new))
+                            .orTimeout(10, TimeUnit.SECONDS).join();
+                }, executor));
+            }
+            CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new)).get(15, TimeUnit.SECONDS);
+        }
+
+        for (LinkedBlockingQueue<String> messages : List.of(first, second)) {
+            List<String> received = new ArrayList<>();
+            for (int i = 0; i < expected.size(); i++) {
+                String message = messages.poll(10, TimeUnit.SECONDS);
+                assertThat(message).as("fanout message %s", i).isNotNull();
+                received.add(message);
+            }
+            assertThat(received).containsExactlyInAnyOrderElementsOf(expected);
+            assertThat(messages.poll(200, TimeUnit.MILLISECONDS)).as("duplicate delivery").isNull();
+        }
+    }
+
+    @ParameterizedTest(name = "payload boundaries, transport={0}")
+    @EnumSource(TitanSmokeTransport.class)
+    void empty_unicode_and_large_payloads_arrive_unchanged(
+            TitanSmokeTransport transport,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        String destination = "/queue/" + UUID.randomUUID();
+        LinkedBlockingQueue<StompFrames> messages = new LinkedBlockingQueue<>();
+        TitanClient producer = runtime.client();
+        runtime.client().subscribe(destination, messages::add).get(10, TimeUnit.SECONDS);
+
+        for (String payload : List.of("", "\uD55C\uAE00-\uD83D\uDE80", "x".repeat(48 * 1024))) {
+            producer.send(destination, payload).get(10, TimeUnit.SECONDS);
+            StompFrames received = messages.poll(10, TimeUnit.SECONDS);
+            assertThat(received).as("payload bytes=%s", payload.getBytes(StandardCharsets.UTF_8).length)
+                    .isNotNull();
+            assertThat(received.body()).isEqualTo(payload.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @ParameterizedTest(name = "restart and resubscribe, transport={0}")
+    @EnumSource(TitanSmokeTransport.class)
+    void server_restart_restores_only_active_subscriptions(
+            TitanSmokeTransport transport,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        String destination = "/topic/" + UUID.randomUUID();
+        LinkedBlockingQueue<String> active = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<String> removed = new LinkedBlockingQueue<>();
+        TitanClient client = runtime.client();
+        client.subscribe(destination, Map.of(ID, "active"), frame ->
+                active.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+        client.subscribe(destination, Map.of(ID, "removed"), frame ->
+                removed.add(new String(frame.body(), StandardCharsets.UTF_8))).get(10, TimeUnit.SECONDS);
+        client.send(destination, "before").get(10, TimeUnit.SECONDS);
+        assertThat(active.poll(10, TimeUnit.SECONDS)).isEqualTo("before");
+        assertThat(removed.poll(10, TimeUnit.SECONDS)).isEqualTo("before");
+
+        client.unsubscribe("removed").get(10, TimeUnit.SECONDS);
+        runtime.stop();
+        await().atMost(10, TimeUnit.SECONDS).until(() -> !client.isConnected());
+        runtime.restart();
+        await().atMost(15, TimeUnit.SECONDS).until(client::isConnected);
+
+        client.send(destination, "after").get(10, TimeUnit.SECONDS);
+        assertThat(active.poll(10, TimeUnit.SECONDS)).isEqualTo("after");
+        assertThat(removed.poll(300, TimeUnit.MILLISECONDS)).isNull();
+        assertThat(active.poll(200, TimeUnit.MILLISECONDS)).as("duplicate restored subscription").isNull();
+    }
+
+    @ParameterizedTest(name = "content-length payload, transport={0}, embeddedNul={1}")
+    @CsvSource({"TCP, false", "TCP, true", "WEBSOCKET, false", "WEBSOCKET, true"})
+    void content_length_preserves_line_breaks_and_embedded_nul(
+            TitanSmokeTransport transport,
+            boolean embeddedNul,
+            TitanRuntime runtime
+    ) throws Exception {
+        runtime.start(transport);
+        String destination = "/queue/" + UUID.randomUUID();
+        LinkedBlockingQueue<StompFrames> messages = new LinkedBlockingQueue<>();
+        TitanClient producer = runtime.client();
+        runtime.client().subscribe(destination, messages::add).get(10, TimeUnit.SECONDS);
+
+        byte[] payload = embeddedNul
+                ? new byte[]{'a', 0, 'b'}
+                : "first\nsecond\r\nthird\n".getBytes(StandardCharsets.UTF_8);
+        LinkedBlockingQueue<String> errors = new LinkedBlockingQueue<>();
+        producer.errorHandler(frame -> errors.add(new String(frame.body(), StandardCharsets.UTF_8)));
+        producer.connectionDroppedHandler(ignored -> errors.add("Producer connection dropped for valid payload"));
+        producer.send(destination, Buffer.heap().alloc(payload),
+                Map.of(CONTENT_LENGTH, Integer.toString(payload.length))).get(10, TimeUnit.SECONDS);
+        await().alias("content-length payload delivery").atMost(10, TimeUnit.SECONDS)
+                .until(() -> !messages.isEmpty() || !errors.isEmpty());
+        assertThat(errors).as("valid payload must not fail the connection").isEmpty();
+        StompFrames received = messages.poll();
+        assertThat(received).as("content-length payload must be delivered intact").isNotNull();
+        assertThat(received.body()).isEqualTo(payload);
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanRuntime.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanRuntime.java
@@ -1,0 +1,257 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.traffichunter.titan.client.TitanClient;
+import org.traffichunter.titan.core.resilience.retry.RetryPolicy;
+import org.traffichunter.titan.core.transport.stomp.option.StompSessionOption;
+
+/**
+ * Controls the packaged Titan server used by one smoke test.
+ *
+ * <p>The server runs in its own JVM, so startup, configuration loading, SPI wiring, shutdown
+ * hooks, and the assembled distribution are exercised together.</p>
+ *
+ * @author yun
+ */
+final class TitanRuntime implements AutoCloseable {
+
+    private static final String HOST = "127.0.0.1";
+    private static final String CONFIGURATION_RESOURCE = "/titan-smoke.yml";
+    private static final Duration START_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration STOP_TIMEOUT = Duration.ofSeconds(10);
+
+    private final List<TitanClient> clients = new ArrayList<>();
+    private final Path directory;
+    private final Path configuration;
+    private final Path log;
+    private Process process;
+    private TitanSmokeTransport transport;
+    private int maxFrameLength;
+    private int port;
+
+    TitanRuntime() {
+        try {
+            directory = Files.createTempDirectory("titan-smoke-");
+            configuration = directory.resolve("titan-env.yml");
+            log = directory.resolve("titan.log");
+        } catch (IOException error) {
+            throw new IllegalStateException("Failed to create Titan smoke directory", error);
+        }
+    }
+
+    void start(TitanSmokeTransport transport) throws Exception {
+        start(transport, 1_048_576);
+    }
+
+    void start(TitanSmokeTransport transport, int maxFrameLength) throws Exception {
+        if (isRunning()) {
+            throw new IllegalStateException("Titan server is already running");
+        }
+        this.transport = transport;
+        this.maxFrameLength = maxFrameLength;
+        if (port == 0) {
+            port = availablePort();
+        }
+
+        Files.writeString(configuration, configuration(transport, maxFrameLength));
+        Path jar = Path.of(System.getProperty("titan.smoke.jar", ""));
+        if (!Files.isRegularFile(jar)) {
+            throw new IllegalStateException("Packaged Titan server not found: " + jar);
+        }
+
+        Path java = Path.of(System.getProperty("java.home"), "bin", "java");
+        process = new ProcessBuilder(
+                java.toString(),
+                "-Dtitan.environment.path=" + configuration,
+                "-Dtitan.banner.mode=off",
+                "-jar",
+                jar.toString()
+        ).redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.appendTo(log.toFile()))
+                .start();
+
+        awaitReady();
+    }
+
+    void restart() throws Exception {
+        if (transport == null) {
+            throw new IllegalStateException("Titan server has not been configured");
+        }
+        stop();
+        start(transport, maxFrameLength);
+    }
+
+    TitanClient client() throws Exception {
+        if (!isRunning()) {
+            throw new IllegalStateException("Titan server is not running");
+        }
+
+        TitanClient.Builder builder = TitanClient.builder()
+                .host(HOST)
+                .port(port)
+                .worker(1)
+                .connectTimeout(Duration.ofSeconds(5))
+                .reconnect(RetryPolicy.fixed(RetryPolicy.UNLIMITED_ATTEMPTS, Duration.ofMillis(100)))
+                .session(StompSessionOption.builder().heartbeatX(0L).heartbeatY(0L).build());
+        if (transport != null && transport.isWebSocket()) {
+            builder.webSocket("/");
+        }
+
+        TitanClient client = builder.build();
+        clients.add(client);
+        client.start();
+        client.connect().get(10, TimeUnit.SECONDS);
+        return client;
+    }
+
+    int port() {
+        return port;
+    }
+
+    boolean isRunning() {
+        return process != null && process.isAlive();
+    }
+
+    boolean stop() throws InterruptedException {
+        Process current = process;
+        if (current == null || !current.isAlive()) {
+            process = null;
+            return true;
+        }
+
+        current.destroy();
+        boolean stopped = current.waitFor(STOP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        if (!stopped) {
+            current.destroyForcibly();
+            stopped = current.waitFor(STOP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        }
+        process = null;
+        return stopped;
+    }
+
+    String logs() {
+        try {
+            return Files.exists(log) ? Files.readString(log) : "Titan process did not produce a log.";
+        } catch (IOException error) {
+            return "Failed to read Titan process log: " + error.getMessage();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        for (TitanClient client : clients) {
+            try {
+                client.shutdown(5, TimeUnit.SECONDS);
+            } catch (Exception error) {
+                failure = append(failure, error);
+            }
+        }
+        clients.clear();
+
+        try {
+            if (!stop()) {
+                failure = append(failure, new IllegalStateException("Titan process did not terminate"));
+            }
+        } catch (Exception error) {
+            failure = append(failure, error);
+        }
+
+        try (var paths = Files.walk(directory)) {
+            for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(path);
+            }
+        } catch (Exception error) {
+            failure = append(failure, error);
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void awaitReady() throws Exception {
+        long deadline = System.nanoTime() + START_TIMEOUT.toNanos();
+        IOException connectionFailure = null;
+        while (System.nanoTime() < deadline) {
+            Process current = process;
+            if (current == null || !current.isAlive()) {
+                throw new IllegalStateException("Titan process exited during startup:\n" + logs());
+            }
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(HOST, port), 200);
+                return;
+            } catch (IOException error) {
+                connectionFailure = error;
+                Thread.sleep(50);
+            }
+        }
+        throw new IllegalStateException("Titan server did not listen within " + START_TIMEOUT + ":\n" + logs(),
+                connectionFailure);
+    }
+
+    private String configuration(TitanSmokeTransport transport, int maxFrameLength) throws IOException {
+        String template;
+        try (var input = TitanRuntime.class.getResourceAsStream(CONFIGURATION_RESOURCE)) {
+            if (input == null) {
+                throw new IOException("Smoke configuration resource not found: " + CONFIGURATION_RESOURCE);
+            }
+            template = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        return template
+                .replace("${transport}", transport.setting())
+                .replace("${host}", HOST)
+                .replace("${port}", Integer.toString(port))
+                .replace("${maxFrameLength}", Integer.toString(maxFrameLength));
+    }
+
+    private static int availablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 0, InetAddress.getLoopbackAddress())) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static Exception append(Exception failure, Exception error) {
+        if (failure == null) {
+            return error;
+        }
+        failure.addSuppressed(error);
+        return failure;
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeExtension.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeExtension.java
@@ -1,0 +1,72 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * Creates one isolated Titan process controller for each smoke test invocation.
+ *
+ * @author yun
+ */
+final class TitanSmokeExtension implements ParameterResolver, AfterEachCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(TitanSmokeExtension.class);
+    private static final String RUNTIME = "runtime";
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return parameterContext.getParameter().getType() == TitanRuntime.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        return store(extensionContext).computeIfAbsent(
+                RUNTIME,
+                ignored -> new TitanRuntime(),
+                TitanRuntime.class
+        );
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        TitanRuntime runtime = store(context).remove(RUNTIME, TitanRuntime.class);
+        if (runtime == null) {
+            return;
+        }
+
+        if (context.getExecutionException().isPresent()) {
+            context.publishReportEntry("titan-process.log", runtime.logs());
+        }
+        runtime.close();
+    }
+
+    private static ExtensionContext.Store store(ExtensionContext context) {
+        return context.getStore(NAMESPACE);
+    }
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeTest.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeTest.java
@@ -1,0 +1,44 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Runs a smoke test against the packaged Titan server in a separate JVM.
+ *
+ * @author yun
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(TitanSmokeExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public @interface TitanSmokeTest {
+}

--- a/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeTransport.java
+++ b/smoke-test/smoke-titan/src/test/java/org/traffichunter/titan/smoke/titan/TitanSmokeTransport.java
@@ -1,0 +1,48 @@
+/*
+The MIT License
+
+Copyright (c) 2025 traffic-hunter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package org.traffichunter.titan.smoke.titan;
+
+/**
+ * Transport selected for a packaged-server smoke scenario.
+ *
+ * @author yun
+ */
+enum TitanSmokeTransport {
+    TCP("tcp"),
+    WEBSOCKET("websocket");
+
+    private final String setting;
+
+    TitanSmokeTransport(String setting) {
+        this.setting = setting;
+    }
+
+    String setting() {
+        return setting;
+    }
+
+    boolean isWebSocket() {
+        return this == WEBSOCKET;
+    }
+}

--- a/smoke-test/smoke-titan/src/test/resources/titan-smoke.yml
+++ b/smoke-test/smoke-titan/src/test/resources/titan-smoke.yml
@@ -1,0 +1,22 @@
+titan:
+  flow-control:
+    enabled: false
+  servers:
+    - name: smoke-stomp
+      transport: ${transport}
+      protocol: stomp
+      host: ${host}
+      port: ${port}
+      primary-threads: 1
+      secondary-threads: 1
+      transport-options:
+        reuse-address: "true"
+        child-tcp-no-delay: "true"
+        child-send-buffer-size: "1024"
+        path: "/"
+      protocol-options:
+        max-frame-length: "${maxFrameLength}"
+        heartbeat-x: "0"
+        heartbeat-y: "0"
+        supported-versions: "1.2"
+        secured: "false"

--- a/titan-client/src/main/java/org/traffichunter/titan/client/TitanStompClientDriver.java
+++ b/titan-client/src/main/java/org/traffichunter/titan/client/TitanStompClientDriver.java
@@ -136,11 +136,9 @@ public final class TitanStompClientDriver implements StompClientDriver {
 
         long timeout = configuration.connectTimeout().toMillis();
         StompFrame connectFrame = createConnectFrame(remoteAddress.getHostString());
-        return connectTransport(remoteAddress, timeout)
+        return connect0(remoteAddress, timeout)
                 .map(channel -> {
-                    StompClientChannel connection = channel instanceof WebSocketChannel webSocketChannel
-                            ? StompClientChannel.wrap(webSocketChannel, configuration.session())
-                            : StompClientChannel.wrap(channel, configuration.session());
+                    StompClientChannel connection = StompClientChannel.wrap(channel, configuration.session());
                     stompClientHandler.handle(connection.handler());
                     channel.chain().add(new StompChannelDecoder(
                             configuration.maxFrameLength(),
@@ -201,7 +199,7 @@ public final class TitanStompClientDriver implements StompClientDriver {
         return connection;
     }
 
-    private Promise<? extends NetChannel> connectTransport(InetSocketAddress remoteAddress, long timeoutMillis) {
+    private Promise<? extends NetChannel> connect0(InetSocketAddress remoteAddress, long timeoutMillis) {
         String webSocketPath = configuration.webSocketPath();
         if (webSocketPath == null) {
             return inetClient.connect(remoteAddress, timeoutMillis, TimeUnit.MILLISECONDS);

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannel.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/channel/stomp/StompClientChannel.java
@@ -60,6 +60,10 @@ public interface StompClientChannel extends StompChannel {
             NetChannel netChannel,
             StompSessionOption option
     ) {
+        if (netChannel instanceof WebSocketChannel webSocketChannel) {
+            return wrap(webSocketChannel, option, handler -> {});
+        }
+
         return wrap(netChannel, option, handler -> {});
     }
 
@@ -68,22 +72,10 @@ public interface StompClientChannel extends StompChannel {
             StompSessionOption option,
             Handler<StompClientHandler> clientHandlerConfigurer
     ) {
+        if (netChannel instanceof WebSocketChannel webSocketChannel) {
+            return new StompClientWebSocketChannel(webSocketChannel, option, clientHandlerConfigurer);
+        }
         return new StompClientTcpChannel(netChannel, option, clientHandlerConfigurer);
-    }
-
-    static StompClientChannel wrap(
-            WebSocketChannel webSocketChannel,
-            StompSessionOption option
-    ) {
-        return wrap(webSocketChannel, option, handler -> { });
-    }
-
-    static StompClientChannel wrap(
-            WebSocketChannel webSocketChannel,
-            StompSessionOption option,
-            Handler<StompClientHandler> clientHandlerConfigurer
-    ) {
-        return new StompClientWebSocketChannel(webSocketChannel, option, clientHandlerConfigurer);
     }
 
     @Override

--- a/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
+++ b/titan-stomp/src/main/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoder.java
@@ -26,18 +26,19 @@ package org.traffichunter.titan.core.codec.stomp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.jspecify.annotations.Nullable;
+import org.traffichunter.titan.core.channel.ChannelInBoundHandlerChain;
 import org.traffichunter.titan.core.channel.NetChannel;
 import org.traffichunter.titan.core.channel.stomp.StompHandler;
 import org.traffichunter.titan.core.channel.stomp.StompClientChannel;
+import org.traffichunter.titan.core.channel.stomp.StompServerHandler;
 import org.traffichunter.titan.core.codec.ChannelDecoder;
-import org.traffichunter.titan.core.codec.LineFrameChannelDecoder;
 import org.traffichunter.titan.core.codec.TooLongFrameException;
 import org.traffichunter.titan.core.util.buffer.Buffer;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
 
 import static org.traffichunter.titan.core.codec.stomp.StompHeaders.*;
+import static org.traffichunter.titan.core.codec.stomp.StompFrame.errorFrame;
 
 /**
  * @author yun, gkdbssla97
@@ -70,8 +71,27 @@ public class StompChannelDecoder extends ChannelDecoder {
     }
 
     @Override
+    public void sparkChannelRead(NetChannel channel, Buffer buffer, ChannelInBoundHandlerChain chain) {
+        try {
+            super.sparkChannelRead(channel, buffer, chain);
+        } catch (TooLongFrameException error) {
+            if (!(handler instanceof StompServerHandler)) {
+                throw error;
+            }
+            String reason = error.getMessage() == null ? "STOMP frame size limit exceeded" : error.getMessage();
+            log.warn("Rejected oversized STOMP frame. session={}, reason={}", stompChannel.session(), reason);
+            stompChannel.send(errorFrame("Frame size limit exceeded.", reason))
+                    .onSuccess(ignored -> stompChannel.close())
+                    .onFailure(sendError -> {
+                        log.warn("Failed to send STOMP ERROR frame before closing. session={}", stompChannel.session(), sendError);
+                        stompChannel.close();
+                    });
+        }
+    }
+
+    @Override
     protected @Nullable Buffer decode(NetChannel channel, Buffer buffer) {
-        StompFrame frame = stompParser.parse(channel, buffer);
+        StompFrame frame = stompParser.parse(buffer);
         if (frame == null) {
             return null;
         }
@@ -83,19 +103,16 @@ public class StompChannelDecoder extends ChannelDecoder {
 
     static class StompParser {
 
-        private static final String NULL = StompDelimiter.NUL.getString();
         private static final String COLON = StompDelimiter.COLON.getString();
         private static final String CONTENT_LENGTH = "content-length";
 
-        private final LineFrameChannelDecoderWrapper lineFrameDecoder;
         private final int maxFrameLength;
 
         private StompParser(int maxFrameLength) {
-            this.lineFrameDecoder = new LineFrameChannelDecoderWrapper(maxFrameLength);
             this.maxFrameLength = maxFrameLength;
         }
 
-        private @Nullable StompFrame parse(NetChannel channel, Buffer buffer) {
+        private @Nullable StompFrame parse(Buffer buffer) {
             if (!buffer.isReadable()) {
                 return null;
             }
@@ -107,59 +124,78 @@ public class StompChannelDecoder extends ChannelDecoder {
                 return StompFrame.PING;
             }
 
-            int frameEnd = findFrameEnd(buffer);
-            if (frameEnd == -1) {
+            int bodyStart = findBodyStart(buffer, readerIndex);
+            if (bodyStart == -1) {
                 validateFrameLength(buffer.length());
                 return null;
             }
 
-            int length = frameEnd - readerIndex;
-            validateFrameLength(length);
-            Buffer sliceBuffer = buffer.readSlice(length);
-            buffer.skipBytes(1);
+            int headerEnd = headerEnd(buffer, bodyStart);
+            String head = new String(
+                    buffer.getBytes(readerIndex, headerEnd - readerIndex),
+                    StandardCharsets.UTF_8
+            );
+            String[] lines = head.split("\\r?\\n");
+            if (lines.length == 0 || lines[0].isBlank()) {
+                return StompFrame.ERR_STOMP_FRAME;
+            }
 
-            Buffer stompFrame = Buffer.heap().alloc(sliceBuffer.length() + 1);
-            List<Buffer> frames = List.of();
-            try {
-                stompFrame.accumulateBuffer(sliceBuffer)
-                        .accumulateByte(StompDelimiter.LF.getHex());
-                frames = lineFrameDecoder.decodes(channel, stompFrame);
-
-                StompCommand stompCommand = StompCommand.valueOf(frames.getFirst().toString());
-
-                int bodyLength = -1;
-                StompHeaders headers = new StompHeaders(StompVersion.STOMP_1_2);
-                for(int i = 1; i < frames.size(); i++) {
-                    String header = frames.get(i).toString();
-                    if(header.isBlank()) {
-                        break;
-                    } else {
-                        String[] keyValue = header.split(COLON, 2);
-                        if (keyValue.length != 2) {
-                            return StompFrame.ERR_STOMP_FRAME;
-                        }
-
-                        String key = keyValue[0].trim();
-                        String value = keyValue[1].trim();
-                        if(key.equals(CONTENT_LENGTH)) {
-                            bodyLength = Integer.parseInt(value);
-                        }
-
-                        headers.put(Elements.convertToElements(key), value);
-                    }
-                }
-
-                Buffer bodyBuffer = frames.getLast();
-                byte[] body = bodyBuffer.getBytes();
-                if(bodyLength > -1 && bodyLength != body.length) {
+            StompCommand stompCommand = StompCommand.valueOf(lines[0].toUpperCase());
+            int contentLength = -1;
+            StompHeaders headers = new StompHeaders(StompVersion.STOMP_1_2);
+            for (int i = 1; i < lines.length; i++) {
+                String[] keyValue = lines[i].split(COLON, 2);
+                if (keyValue.length != 2) {
                     return StompFrame.ERR_STOMP_FRAME;
                 }
 
-                return StompFrame.create(headers, stompCommand, body);
-            } finally {
-                stompFrame.release();
-                frames.forEach(Buffer::release);
+                String key = keyValue[0].trim();
+                String value = keyValue[1].trim();
+                if (key.equals(CONTENT_LENGTH)) {
+                    contentLength = Integer.parseInt(value);
+                    if (contentLength < 0) {
+                        return StompFrame.ERR_STOMP_FRAME;
+                    }
+                }
+                headers.put(Elements.convertToElements(key), value);
             }
+
+            int frameEnd;
+            int bodyLength;
+            if (contentLength >= 0) {
+                long declaredFrameLength = (long) bodyStart - readerIndex + contentLength;
+                if (declaredFrameLength > maxFrameLength) {
+                    throw new TooLongFrameException(
+                            "STOMP frame exceeds " + maxFrameLength + ": " + declaredFrameLength
+                    );
+                }
+                frameEnd = Math.toIntExact((long) bodyStart + contentLength);
+                if (buffer.byteBuf().writerIndex() <= frameEnd) {
+                    return null;
+                }
+                if (buffer.getByte(frameEnd) != StompDelimiter.NUL.getHex()) {
+                    int terminator = findNul(buffer, bodyStart);
+                    if (terminator >= 0) {
+                        buffer.skipBytes(terminator - readerIndex + 1);
+                    }
+                    return StompFrame.ERR_STOMP_FRAME;
+                }
+                bodyLength = contentLength;
+            } else {
+                frameEnd = findNul(buffer, bodyStart);
+                if (frameEnd == -1) {
+                    validateFrameLength(buffer.length());
+                    return null;
+                }
+                validateFrameLength(frameEnd - readerIndex);
+                bodyLength = frameEnd - bodyStart;
+            }
+
+            byte[] body = bodyLength == 0
+                    ? new byte[0]
+                    : buffer.getBytes(bodyStart, bodyLength);
+            buffer.skipBytes(frameEnd - readerIndex + 1);
+            return StompFrame.create(headers, stompCommand, body);
         }
 
         private void validateFrameLength(int frameLength) {
@@ -170,38 +206,36 @@ public class StompChannelDecoder extends ChannelDecoder {
             }
         }
 
-        private int findFrameEnd(Buffer buffer) {
-            int totalLength = buffer.length();
-            int readIdx = buffer.byteBuf().readerIndex();
-            return buffer.indexOf(readIdx, readIdx + totalLength, NULL.charAt(0));
-        }
-    }
-
-    static class LineFrameChannelDecoderWrapper extends LineFrameChannelDecoder {
-
-        private LineFrameChannelDecoderWrapper(int maxLength) {
-            super(maxLength);
-        }
-
-        List<Buffer> decodes(NetChannel channel, Buffer buffer) {
-            List<Buffer> buffers = new LinkedList<>();
-            try {
-                while (buffer.isReadable()) {
-                    Buffer decode = decode(channel, buffer);
-                    if (decode != null) {
-                        buffers.add(decode);
-                    }
+        private static int findBodyStart(Buffer buffer, int readerIndex) {
+            int writerIndex = buffer.byteBuf().writerIndex();
+            for (int index = readerIndex; index < writerIndex - 1; index++) {
+                if (buffer.getByte(index) == StompDelimiter.LF.getHex()
+                        && buffer.getByte(index + 1) == StompDelimiter.LF.getHex()) {
+                    return index + 2;
                 }
-                return buffers;
-            } catch (RuntimeException e) {
-                buffers.forEach(Buffer::release);
-                throw e;
+                if (index < writerIndex - 3
+                        && buffer.getByte(index) == StompDelimiter.CR.getHex()
+                        && buffer.getByte(index + 1) == StompDelimiter.LF.getHex()
+                        && buffer.getByte(index + 2) == StompDelimiter.CR.getHex()
+                        && buffer.getByte(index + 3) == StompDelimiter.LF.getHex()) {
+                    return index + 4;
+                }
             }
+            return -1;
         }
 
-        @Override
-        protected @Nullable Buffer decode(NetChannel channel, Buffer buffer) {
-            return super.decode(channel, buffer);
+        private static int headerEnd(Buffer buffer, int bodyStart) {
+            return buffer.getByte(bodyStart - 2) == StompDelimiter.LF.getHex()
+                    ? bodyStart - 2
+                    : bodyStart - 4;
+        }
+
+        private static int findNul(Buffer buffer, int fromIndex) {
+            return buffer.indexOf(
+                    fromIndex,
+                    buffer.byteBuf().writerIndex(),
+                    StompDelimiter.NUL.getHex()
+            );
         }
     }
 }

--- a/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
+++ b/titan-stomp/src/test/java/org/traffichunter/titan/core/codec/stomp/StompChannelDecoderTest.java
@@ -75,7 +75,7 @@ class StompChannelDecoderTest {
     @Test
     void when_content_length_mismatch_then_err() {
         StompHeaders headers = StompHeaders.create();
-        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "10");
+        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "4");
 
         StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
@@ -106,6 +106,29 @@ class StompChannelDecoderTest {
             assertThat(result).isEqualTo(frame.toBuffer());
         } finally {
             buf.release();
+        }
+    }
+
+    @Test
+    void content_length_preserves_line_breaks_and_embedded_nul() {
+        byte[] body = "first\nsecond\0third".getBytes(StandardCharsets.UTF_8);
+        StompHeaders headers = StompHeaders.create();
+        headers.put(StompHeaders.Elements.CONTENT_LENGTH, Integer.toString(body.length));
+        StompFrame frame = StompFrame.create(headers, StompCommand.SEND, body);
+        Buffer input = frame.toBuffer();
+        List<StompFrame> handled = new ArrayList<>();
+
+        try {
+            TestStompChannelDecoder decoder = new TestStompChannelDecoder(64, (decoded, channel) ->
+                    handled.add(decoded));
+            Buffer result = decoder.decode(new InMemoryNetChannel(), input);
+
+            assertThat(handled).singleElement().satisfies(decoded ->
+                    assertThat(decoded.body()).isEqualTo(body));
+            assertThat(result).isNotNull();
+            result.release();
+        } finally {
+            input.release();
         }
     }
 
@@ -370,7 +393,7 @@ class StompChannelDecoderTest {
         // Leak 3 regression: stompFrame and frames list inside StompParser.parse()
         // must be released even when ERR_STOMP_FRAME is returned early.
         StompHeaders headers = StompHeaders.create();
-        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "10");
+        headers.put(StompHeaders.Elements.CONTENT_LENGTH, "4");
         StompFrame frame = StompFrame.create(headers, StompCommand.SEND, Buffer.heap().alloc("hello"));
         Buffer buf = frame.toBuffer();
 


### PR DESCRIPTION
## Motivation:

To improve Titan's stability, we needed smoke tests that could verify its core functionality in a realistic environment.

Rather than testing only within the test runtime, it seemed more valuable to run integration tests against the actual standalone JAR, making the test environment closer to how Titan is used in practice.

## Modification:

- Added smoke tests covering various scenarios.

- Added JAR-based integration tests that launch the standalone Titan JAR and run tests against the actual server process.

## Result:

```
./gradlew :smoke-test:smoke-titan --no-configuration-cache
```
